### PR TITLE
add `Checkbox`, `Radio` and `Switch` components

### DIFF
--- a/apps/test-app/app/routes/tests/checkbox/index.spec.ts
+++ b/apps/test-app/app/routes/tests/checkbox/index.spec.ts
@@ -16,7 +16,7 @@ test("default", async ({ page }) => {
 	await page.keyboard.press("Tab");
 	await expect(checkbox).toBeFocused();
 
-	await page.keyboard.press(" ");
+	await page.keyboard.press("Space");
 	await expect(checkbox).toBeChecked();
 
 	await label.click();
@@ -49,8 +49,7 @@ test("indeterminate/mixed", async ({ page }) => {
 test("disabled", async ({ page }) => {
 	await page.goto("/tests/checkbox?disabled=true");
 
-	const checkbox = page.getByRole("checkbox");
-	await expect(checkbox).toHaveAccessibleName("Toggle me");
+	const checkbox = page.getByRole("checkbox", { name: "Toggle me" });
 	await expect(checkbox).toBeDisabled();
 	await expect(checkbox).not.toBeChecked();
 
@@ -58,6 +57,6 @@ test("disabled", async ({ page }) => {
 	await expect(checkbox).toBeFocused();
 
 	// should not be able to toggle the disabled checkbox
-	await page.keyboard.press(" ");
+	await page.keyboard.press("Space");
 	await expect(checkbox).not.toBeChecked();
 });

--- a/apps/test-app/app/routes/tests/checkbox/index.spec.ts
+++ b/apps/test-app/app/routes/tests/checkbox/index.spec.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { test, expect } from "@playwright/test";
+
+test("default", async ({ page }) => {
+	await page.goto("/tests/checkbox");
+
+	const checkbox = page.getByRole("checkbox");
+	const label = page.getByText("Toggle me");
+
+	await expect(checkbox).toHaveAccessibleName("Toggle me");
+	await expect(checkbox).not.toBeChecked();
+
+	await page.keyboard.press("Tab");
+	await expect(checkbox).toBeFocused();
+
+	await page.keyboard.press(" ");
+	await expect(checkbox).toBeChecked();
+
+	await label.click();
+	await expect(checkbox).not.toBeChecked();
+});
+
+test("checked", async ({ page }) => {
+	await page.goto("/tests/checkbox?checked=true");
+
+	const checkbox = page.getByRole("checkbox");
+	await expect(checkbox).toBeChecked();
+
+	await checkbox.click();
+	await expect(checkbox).not.toBeChecked();
+});
+
+test("indeterminate/mixed", async ({ page }) => {
+	await page.goto("/tests/checkbox?indeterminate=true");
+
+	const checkbox = page.getByRole("checkbox");
+	await expect(checkbox).toHaveAttribute("aria-checked", "mixed");
+
+	await checkbox.click();
+	await expect(checkbox).toBeChecked();
+
+	await checkbox.click();
+	await expect(checkbox).not.toBeChecked();
+});
+
+test("disabled", async ({ page }) => {
+	await page.goto("/tests/checkbox?disabled=true");
+
+	const checkbox = page.getByRole("checkbox");
+	await expect(checkbox).toHaveAccessibleName("Toggle me");
+	await expect(checkbox).toBeDisabled();
+	await expect(checkbox).not.toBeChecked();
+
+	await page.keyboard.press("Tab");
+	await expect(checkbox).toBeFocused();
+
+	// should not be able to toggle the disabled checkbox
+	await page.keyboard.press(" ");
+	await expect(checkbox).not.toBeChecked();
+});

--- a/apps/test-app/app/routes/tests/checkbox/index.tsx
+++ b/apps/test-app/app/routes/tests/checkbox/index.tsx
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { Checkbox, Label } from "@itwin/kiwi-react/bricks";
+import { useSearchParams } from "@remix-run/react";
+import { useId } from "react";
+
+export default function Page() {
+	const [searchParams] = useSearchParams();
+	const checked = searchParams.get("checked") === "true";
+	const indeterminate = searchParams.get("indeterminate") === "true";
+	const disabled = searchParams.get("disabled") === "true";
+
+	const id = useId();
+
+	return (
+		<>
+			<h1>Checkbox</h1>
+
+			<Checkbox
+				id={id}
+				defaultChecked={indeterminate ? "mixed" : checked}
+				disabled={disabled}
+			/>
+			<Label htmlFor={id}>Toggle me</Label>
+		</>
+	);
+}

--- a/apps/test-app/app/routes/tests/radio/index.spec.ts
+++ b/apps/test-app/app/routes/tests/radio/index.spec.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { test, expect } from "@playwright/test";
+
+test("default", async ({ page }) => {
+	await page.goto("/tests/radio");
+
+	const radioA = page.getByRole("radio", { name: "A" });
+	const radioB = page.getByRole("radio", { name: "B" });
+	await expect(radioA).not.toBeChecked();
+	await expect(radioB).not.toBeChecked();
+
+	await page.keyboard.press("Tab");
+	await expect(radioA).toBeFocused();
+	await expect(radioA).not.toBeChecked();
+
+	await page.keyboard.press("ArrowDown");
+	await expect(radioB).toBeFocused();
+	await expect(radioB).toBeChecked();
+
+	await page.keyboard.press("ArrowUp");
+	await expect(radioA).toBeFocused();
+	await expect(radioA).toBeChecked();
+	await expect(radioB).not.toBeChecked();
+});
+
+test("default value", async ({ page }) => {
+	await page.goto("/tests/radio?defaultValue=A");
+
+	const radioA = page.getByRole("radio", { name: "A" });
+	const radioB = page.getByRole("radio", { name: "B" });
+	await expect(radioA).toBeChecked();
+	await expect(radioB).not.toBeChecked();
+
+	await radioB.click();
+	await expect(radioA).not.toBeChecked();
+	await expect(radioB).toBeChecked();
+});
+
+test("disabled", async ({ page }) => {
+	await page.goto("/tests/radio?disabled=true&defaultValue=B");
+
+	const radioA = page.getByRole("radio", { name: "A" });
+	const radioB = page.getByRole("radio", { name: "B" });
+
+	await page.keyboard.press("Tab");
+	await expect(radioB).toBeChecked();
+	await expect(radioB).toBeChecked();
+
+	// should not be able to toggle the disabled radio
+	await page.keyboard.press("ArrowUp");
+	await expect(radioA).toBeFocused();
+	await expect(radioA).not.toBeChecked();
+	await expect(radioB).toBeChecked();
+	await radioA.click({ force: true });
+	await expect(radioA).not.toBeChecked();
+});

--- a/apps/test-app/app/routes/tests/radio/index.tsx
+++ b/apps/test-app/app/routes/tests/radio/index.tsx
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { Radio, Label } from "@itwin/kiwi-react/bricks";
+import { useSearchParams } from "@remix-run/react";
+import { useId } from "react";
+
+export default function Page() {
+	const [searchParams] = useSearchParams();
+	const defaultValue = searchParams.get("defaultValue");
+	const disabled = searchParams.get("disabled") === "true";
+
+	const idA = useId();
+	const idB = useId();
+
+	return (
+		<>
+			<h1>Radio</h1>
+
+			<Radio
+				name="test"
+				value="A"
+				id={idA}
+				defaultChecked={defaultValue === "A"}
+				disabled={disabled}
+			/>
+			<Label htmlFor={idA}>A</Label>
+
+			<Radio
+				name="test"
+				value="B"
+				id={idB}
+				defaultChecked={defaultValue === "B"}
+				disabled={disabled}
+			/>
+			<Label htmlFor={idB}>B</Label>
+		</>
+	);
+}

--- a/apps/test-app/app/routes/tests/switch/index.spec.ts
+++ b/apps/test-app/app/routes/tests/switch/index.spec.ts
@@ -16,7 +16,7 @@ test("default", async ({ page }) => {
 	await page.keyboard.press("Tab");
 	await expect(toggleSwitch).toBeFocused();
 
-	await page.keyboard.press(" ");
+	await page.keyboard.press("Space");
 	await expect(toggleSwitch).toBeChecked();
 
 	await label.click();
@@ -36,8 +36,7 @@ test("checked", async ({ page }) => {
 test("disabled", async ({ page }) => {
 	await page.goto("/tests/switch?disabled=true");
 
-	const toggleSwitch = page.getByRole("switch");
-	await expect(toggleSwitch).toHaveAccessibleName("Toggle me");
+	const toggleSwitch = page.getByRole("switch", { name: "Toggle me" });
 	await expect(toggleSwitch).toBeDisabled();
 	await expect(toggleSwitch).not.toBeChecked();
 
@@ -45,6 +44,6 @@ test("disabled", async ({ page }) => {
 	await expect(toggleSwitch).toBeFocused();
 
 	// should not be able to toggle the disabled switch
-	await page.keyboard.press(" ");
+	await page.keyboard.press("Space");
 	await expect(toggleSwitch).not.toBeChecked();
 });

--- a/apps/test-app/app/routes/tests/switch/index.spec.ts
+++ b/apps/test-app/app/routes/tests/switch/index.spec.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { test, expect } from "@playwright/test";
+
+test("default", async ({ page }) => {
+	await page.goto("/tests/switch");
+
+	const toggleSwitch = page.getByRole("switch");
+	const label = page.getByText("Toggle me");
+
+	await expect(toggleSwitch).toHaveAccessibleName("Toggle me");
+	await expect(toggleSwitch).not.toBeChecked();
+
+	await page.keyboard.press("Tab");
+	await expect(toggleSwitch).toBeFocused();
+
+	await page.keyboard.press(" ");
+	await expect(toggleSwitch).toBeChecked();
+
+	await label.click();
+	await expect(toggleSwitch).not.toBeChecked();
+});
+
+test("checked", async ({ page }) => {
+	await page.goto("/tests/switch?checked=true");
+
+	const toggleSwitch = page.getByRole("switch");
+	await expect(toggleSwitch).toBeChecked();
+
+	await toggleSwitch.click();
+	await expect(toggleSwitch).not.toBeChecked();
+});
+
+test("disabled", async ({ page }) => {
+	await page.goto("/tests/switch?disabled=true");
+
+	const toggleSwitch = page.getByRole("switch");
+	await expect(toggleSwitch).toHaveAccessibleName("Toggle me");
+	await expect(toggleSwitch).toBeDisabled();
+	await expect(toggleSwitch).not.toBeChecked();
+
+	await page.keyboard.press("Tab");
+	await expect(toggleSwitch).toBeFocused();
+
+	// should not be able to toggle the disabled switch
+	await page.keyboard.press(" ");
+	await expect(toggleSwitch).not.toBeChecked();
+});

--- a/apps/test-app/app/routes/tests/switch/index.tsx
+++ b/apps/test-app/app/routes/tests/switch/index.tsx
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { Switch, Label } from "@itwin/kiwi-react/bricks";
+import { useSearchParams } from "@remix-run/react";
+import { useId } from "react";
+
+export default function Page() {
+	const [searchParams] = useSearchParams();
+	const checked = searchParams.get("checked") === "true";
+	const disabled = searchParams.get("disabled") === "true";
+
+	const id = useId();
+
+	return (
+		<>
+			<h1>Switch</h1>
+
+			<Switch id={id} defaultChecked={checked} disabled={disabled} />
+			<Label htmlFor={id}>Toggle me</Label>
+		</>
+	);
+}

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import * as Ariakit from "@ariakit/react";
+
+interface CheckboxProps extends Ariakit.CheckboxProps {}
+
+export const Checkbox = React.forwardRef<
+	React.ElementRef<typeof Ariakit.Checkbox>,
+	CheckboxProps
+>((props, forwardedRef) => {
+	return (
+		<Ariakit.Checkbox accessibleWhenDisabled {...props} ref={forwardedRef} />
+	);
+});

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import * as Ariakit from "@ariakit/react";
+
+interface RadioProps extends Ariakit.RadioProps {}
+
+export const Radio = React.forwardRef<
+	React.ElementRef<typeof Ariakit.Radio>,
+	RadioProps
+>((props, forwardedRef) => {
+	return <Ariakit.Radio accessibleWhenDisabled {...props} ref={forwardedRef} />;
+});

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import * as Ariakit from "@ariakit/react";
+
+interface SwitchProps extends Ariakit.CheckboxProps {
+	/** The default checked state of the toggle switch. */
+	defaultChecked?: boolean;
+	/** The checked state of the toggle switch. */
+	checked?: boolean;
+}
+
+export const Switch = React.forwardRef<
+	React.ElementRef<typeof Ariakit.Checkbox>,
+	SwitchProps
+>((props, forwardedRef) => {
+	return (
+		<Ariakit.Checkbox
+			accessibleWhenDisabled
+			{...props}
+			role="switch"
+			ref={forwardedRef}
+		/>
+	);
+});

--- a/packages/kiwi-react/src/bricks/index.ts
+++ b/packages/kiwi-react/src/bricks/index.ts
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 export { Root } from "./Root.js";
 export { Button } from "./Button.js";
+export { Checkbox } from "./Checkbox.js";
 export { Input } from "./Input.js";
 export { Label } from "./Label.js";
+export { Radio } from "./Radio.js";
+export { Switch } from "./Switch.js";
 export { Textarea } from "./Textarea.js";
 export { VisuallyHidden } from "./VisuallyHidden.js";


### PR DESCRIPTION
Based on Ariakit [`Checkbox`](https://ariakit.org/components/checkbox) and [`Radio`](https://ariakit.org/components/radio) components.

Note that `Ariakit.Checkbox` does not support the [`indeterminate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) property. They support a third `"mixed"` value for `defaultChecked`/`checked`, which maps to [`aria-checked="mixed"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked#mixed).

`Switch` is just a checkbox with [`role="switch"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role). For now I've excluded the `"mixed"` state from it because we do not have it in the Figma file (and even iTwinUI doesn't support it). I would like the `Switch` to be based on a `<button>` rather than `<input type=checkbox>`, but we can do that in the future.