### PR TITLE
add `Divider` component

### DIFF
--- a/apps/test-app/app/routes/tests/divider/index.spec.ts
+++ b/apps/test-app/app/routes/tests/divider/index.spec.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { test, expect } from "@playwright/test";
+
+test("default", async ({ page }) => {
+	await page.goto("/tests/divider");
+	const divider = page.getByRole("separator");
+	expect(divider).toHaveAttribute("aria-orientation", "horizontal");
+});
+
+test("vertical", async ({ page }) => {
+	await page.goto("/tests/divider?orientation=vertical");
+	const divider = page.getByRole("separator");
+	expect(divider).toHaveAttribute("aria-orientation", "vertical");
+});

--- a/apps/test-app/app/routes/tests/divider/index.spec.ts
+++ b/apps/test-app/app/routes/tests/divider/index.spec.ts
@@ -7,6 +7,12 @@ import { test, expect } from "@playwright/test";
 test("default", async ({ page }) => {
 	await page.goto("/tests/divider");
 	const divider = page.getByRole("separator");
+	await expect(divider).not.toHaveAttribute("aria-orientation");
+});
+
+test("horizontal", async ({ page }) => {
+	await page.goto("/tests/divider?orientation=horizontal");
+	const divider = page.getByRole("separator");
 	await expect(divider).toHaveAttribute("aria-orientation", "horizontal");
 });
 

--- a/apps/test-app/app/routes/tests/divider/index.spec.ts
+++ b/apps/test-app/app/routes/tests/divider/index.spec.ts
@@ -7,11 +7,11 @@ import { test, expect } from "@playwright/test";
 test("default", async ({ page }) => {
 	await page.goto("/tests/divider");
 	const divider = page.getByRole("separator");
-	expect(divider).toHaveAttribute("aria-orientation", "horizontal");
+	await expect(divider).toHaveAttribute("aria-orientation", "horizontal");
 });
 
 test("vertical", async ({ page }) => {
 	await page.goto("/tests/divider?orientation=vertical");
 	const divider = page.getByRole("separator");
-	expect(divider).toHaveAttribute("aria-orientation", "vertical");
+	await expect(divider).toHaveAttribute("aria-orientation", "vertical");
 });

--- a/apps/test-app/app/routes/tests/divider/index.tsx
+++ b/apps/test-app/app/routes/tests/divider/index.tsx
@@ -12,7 +12,7 @@ export default function Page() {
 		<>
 			<h1>Divider</h1>
 
-			<Divider orientation={orientation} />
+			<Divider orientation={orientation as "horizontal" | "vertical"} />
 		</>
 	);
 }

--- a/apps/test-app/app/routes/tests/divider/index.tsx
+++ b/apps/test-app/app/routes/tests/divider/index.tsx
@@ -2,10 +2,17 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export { Root } from "./Root.js";
-export { Button } from "./Button.js";
-export { Divider } from "./Divider.js";
-export { Input } from "./Input.js";
-export { Label } from "./Label.js";
-export { Textarea } from "./Textarea.js";
-export { VisuallyHidden } from "./VisuallyHidden.js";
+import { Divider } from "@itwin/kiwi-react/bricks";
+import { useSearchParams } from "@remix-run/react";
+
+export default function Page() {
+	const orientation = useSearchParams()[0].get("orientation") || "horizontal";
+
+	return (
+		<>
+			<h1>Divider</h1>
+
+			<Divider orientation={orientation} />
+		</>
+	);
+}

--- a/apps/test-app/app/routes/tests/divider/index.tsx
+++ b/apps/test-app/app/routes/tests/divider/index.tsx
@@ -6,13 +6,16 @@ import { Divider } from "@itwin/kiwi-react/bricks";
 import { useSearchParams } from "@remix-run/react";
 
 export default function Page() {
-	const orientation = useSearchParams()[0].get("orientation") || "horizontal";
+	const orientation = useSearchParams()[0].get("orientation") as
+		| "horizontal"
+		| "vertical"
+		| undefined;
 
 	return (
 		<>
 			<h1>Divider</h1>
 
-			<Divider orientation={orientation as "horizontal" | "vertical"} />
+			<Divider orientation={orientation} />
 		</>
 	);
 }

--- a/packages/kiwi-react/src/bricks/Divider.tsx
+++ b/packages/kiwi-react/src/bricks/Divider.tsx
@@ -2,10 +2,13 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export { Root } from "./Root.js";
-export { Button } from "./Button.js";
-export { Divider } from "./Divider.js";
-export { Input } from "./Input.js";
-export { Label } from "./Label.js";
-export { Textarea } from "./Textarea.js";
-export { VisuallyHidden } from "./VisuallyHidden.js";
+import * as React from "react";
+import * as Ariakit from "@ariakit/react";
+
+interface DividerProps extends Ariakit.SeparatorProps<"hr"> {}
+
+export const Divider = React.forwardRef<React.ElementRef<"hr">, DividerProps>(
+	(props, forwardedRef) => {
+		return <Ariakit.Separator {...props} ref={forwardedRef} />;
+	},
+);

--- a/packages/kiwi-react/src/bricks/Divider.tsx
+++ b/packages/kiwi-react/src/bricks/Divider.tsx
@@ -7,8 +7,9 @@ import * as Ariakit from "@ariakit/react";
 
 interface DividerProps extends Ariakit.SeparatorProps<"hr"> {}
 
-export const Divider = React.forwardRef<React.ElementRef<"hr">, DividerProps>(
-	(props, forwardedRef) => {
-		return <Ariakit.Separator {...props} ref={forwardedRef} />;
-	},
-);
+export const Divider = React.forwardRef<
+	React.ElementRef<typeof Ariakit.Separator>,
+	DividerProps
+>((props, forwardedRef) => {
+	return <Ariakit.Separator {...props} ref={forwardedRef} />;
+});

--- a/packages/kiwi-react/src/bricks/index.ts
+++ b/packages/kiwi-react/src/bricks/index.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 export { Root } from "./Root.js";
 export { Button } from "./Button.js";
-export { Divider } from "./Divider.js";
 export { Checkbox } from "./Checkbox.js";
+export { Divider } from "./Divider.js";
 export { Input } from "./Input.js";
 export { Label } from "./Label.js";
 export { Radio } from "./Radio.js";


### PR DESCRIPTION
Based on [`Ariakit.Separator`](https://ariakit.org/components/separator).

Name is debatable (Divider vs Separator). I prefer "Separator" because it matches the ARIA role, but the current Figma file (and iTwinUI) calls it "Divider".

**Note**: The `orientation` prop currently only handles the semantics. Visually it still uses the default `<hr />` styling, which appears horizontally.