### PR TITLE
run `tsc` during dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
 	"description": "Monorepo for the kiwi design system",
 	"scripts": {
 		"build": "pnpm --filter=\"./packages/**\" --filter=\"./apps/**\" build",
-		"dev": "pnpm --filter=@itwin/test-app dev",
+		"dev": "npm run dev:app & npm run dev:ts &",
+		"dev:app": "pnpm --filter=@itwin/test-app dev",
+		"dev:ts": "pnpm --filter=@itwin/kiwi-react dev",
 		"format": "pnpm --recursive --no-bail format",
 		"lint": "pnpm --recursive --no-bail lint",
 		"lint:copyright": "tsx scripts/copyright-linter.ts",

--- a/packages/kiwi-react/package.json
+++ b/packages/kiwi-react/package.json
@@ -38,6 +38,7 @@
 	],
 	"scripts": {
 		"build": "rm -rf dist && node scripts/build.js && tsc --outDir dist",
+		"dev": "tsc --watch --outDir dist",
 		"format": "biome format ./src",
 		"lint": "biome lint ./src"
 	},

--- a/packages/kiwi-react/tsconfig.json
+++ b/packages/kiwi-react/tsconfig.json
@@ -24,7 +24,8 @@
 		"verbatimModuleSyntax": true,
 		"baseUrl": ".",
 		"emitDeclarationOnly": true,
-		"types": ["./types.d.ts"]
+		"types": ["./types.d.ts"],
+		"preserveWatchOutput": true
 	},
 	"include": ["src", "types.d.ts"],
 	"exclude": ["node_modules", "dist/**/*"]


### PR DESCRIPTION
This updates the main `pnpm dev` script to also run `tsc` in watch mode (alongside remix/vite). This is mainly needed to generate declaration files for IDE autocomplete and typechecking, not for the actual dev server.

