### PR TITLE
add `Tabs` component

### DIFF
--- a/apps/test-app/app/routes/tests/tabs/index.spec.ts
+++ b/apps/test-app/app/routes/tests/tabs/index.spec.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { test, expect } from "@playwright/test";
+
+test("default", async ({ page }) => {
+	await page.goto("/tests/tabs");
+
+	const tab1 = page.getByRole("tab", { name: "Tab 1" });
+	const tab2 = page.getByRole("tab", { name: "Tab 2" });
+	const tab3 = page.getByRole("tab", { name: "Tab 3" });
+
+	const tab1Panel = page.getByRole("tabpanel", { name: "Tab 1" });
+	const tab2Panel = page.getByRole("tabpanel", { name: "Tab 2" });
+	const tab3Panel = page.getByRole("tabpanel", { name: "Tab 3" });
+
+	await expect(tab1).toHaveAttribute("aria-selected", "true");
+	await expect(tab2).toHaveAttribute("aria-selected", "false");
+	await expect(tab3).toHaveAttribute("aria-selected", "false");
+
+	await expect(tab1Panel).toBeVisible();
+	await expect(tab2Panel).not.toBeVisible();
+	await expect(tab3Panel).not.toBeVisible();
+
+	await tab2.click();
+	await expect(tab1).toHaveAttribute("aria-selected", "false");
+	await expect(tab2).toHaveAttribute("aria-selected", "true");
+	await expect(tab3).toHaveAttribute("aria-selected", "false");
+
+	await expect(tab1Panel).not.toBeVisible();
+	await expect(tab2Panel).toBeVisible();
+	await expect(tab3Panel).not.toBeVisible();
+
+	await page.keyboard.press("ArrowRight");
+	await expect(tab1).toHaveAttribute("aria-selected", "false");
+	await expect(tab2).toHaveAttribute("aria-selected", "false");
+	await expect(tab3).toHaveAttribute("aria-selected", "true");
+
+	await expect(tab1Panel).not.toBeVisible();
+	await expect(tab2Panel).not.toBeVisible();
+	await expect(tab3Panel).toBeVisible();
+});
+
+test("disabled", async ({ page }) => {
+	await page.goto("/tests/tabs?disabled=true");
+
+	const tab1 = page.getByRole("tab", { name: "Tab 1" });
+	const tab2 = page.getByRole("tab", { name: "Tab 2" });
+	const tab3 = page.getByRole("tab", { name: "Tab 3" });
+
+	const tab1Panel = page.getByRole("tabpanel", { name: "Tab 1" });
+	const tab2Panel = page.getByRole("tabpanel", { name: "Tab 2" });
+	const tab3Panel = page.getByRole("tabpanel", { name: "Tab 3" });
+
+	await expect(tab1).toHaveAttribute("aria-selected", "true");
+	await expect(tab1Panel).toBeVisible();
+
+	await expect(tab1).not.toBeDisabled();
+	await expect(tab2).toBeDisabled();
+	await expect(tab3).not.toBeDisabled();
+
+	// should not select disabled tab
+	await tab2.click({ force: true });
+	await expect(tab2).toHaveAttribute("aria-selected", "false");
+	await expect(tab1Panel).toBeVisible();
+	await expect(tab2Panel).not.toBeVisible();
+
+	await tab3.click();
+	await expect(tab3).toHaveAttribute("aria-selected", "true");
+	await expect(tab3Panel).toBeVisible();
+
+	// should still focus disabled tab
+	await page.keyboard.press("ArrowLeft");
+	await expect(tab2).toBeFocused();
+	await expect(tab2Panel).not.toBeVisible();
+	await expect(tab3Panel).toBeVisible();
+});
+
+test("defaultSelectedId", async ({ page }) => {
+	await page.goto("/tests/tabs?defaultSelectedId=tab2");
+
+	const tab1 = page.getByRole("tab", { name: "Tab 1" });
+	const tab2 = page.getByRole("tab", { name: "Tab 2" });
+	const tab3 = page.getByRole("tab", { name: "Tab 3" });
+
+	const tab1Panel = page.getByRole("tabpanel", { name: "Tab 1" });
+	const tab2Panel = page.getByRole("tabpanel", { name: "Tab 2" });
+	const tab3Panel = page.getByRole("tabpanel", { name: "Tab 3" });
+
+	await expect(tab1).toHaveAttribute("aria-selected", "false");
+	await expect(tab2).toHaveAttribute("aria-selected", "true");
+	await expect(tab3).toHaveAttribute("aria-selected", "false");
+
+	await expect(tab1Panel).not.toBeVisible();
+	await expect(tab2Panel).toBeVisible();
+	await expect(tab3Panel).not.toBeVisible();
+
+	await tab1.click();
+	await expect(tab1).toHaveAttribute("aria-selected", "true");
+	await expect(tab2).toHaveAttribute("aria-selected", "false");
+	await expect(tab1Panel).toBeVisible();
+	await expect(tab2Panel).not.toBeVisible();
+});

--- a/apps/test-app/app/routes/tests/tabs/index.tsx
+++ b/apps/test-app/app/routes/tests/tabs/index.tsx
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { Tabs } from "@itwin/kiwi-react/bricks";
+import { useSearchParams } from "@remix-run/react";
+
+export default function Page() {
+	const [searchParams] = useSearchParams();
+	const defaultSelectedId = searchParams.get("defaultSelectedId") || undefined;
+	const disabled = searchParams.get("disabled") === "true";
+
+	return (
+		<>
+			<h1>Tabs</h1>
+
+			<Tabs.Root defaultSelectedId={defaultSelectedId}>
+				<Tabs.TabList>
+					<Tabs.Tab id="tab1">Tab 1</Tabs.Tab>
+					<Tabs.Tab id="tab2" disabled={disabled}>
+						Tab 2
+					</Tabs.Tab>
+					<Tabs.Tab id="tab3">Tab 3</Tabs.Tab>
+				</Tabs.TabList>
+
+				<Tabs.TabPanel tabId="tab1">Tab 1 content</Tabs.TabPanel>
+				<Tabs.TabPanel tabId="tab2">Tab 2 content</Tabs.TabPanel>
+				<Tabs.TabPanel tabId="tab3">Tab 3 content</Tabs.TabPanel>
+			</Tabs.Root>
+		</>
+	);
+}

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import * as Ariakit from "@ariakit/react";
 
-interface CheckboxProps extends Ariakit.CheckboxProps {}
+interface CheckboxProps extends Omit<Ariakit.CheckboxProps, "store"> {}
 
 export const Checkbox = React.forwardRef<
 	React.ElementRef<typeof Ariakit.Checkbox>,

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import * as Ariakit from "@ariakit/react";
 
-interface RadioProps extends Ariakit.RadioProps {}
+interface RadioProps extends Omit<Ariakit.RadioProps, "store"> {}
 
 export const Radio = React.forwardRef<
 	React.ElementRef<typeof Ariakit.Radio>,

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import * as Ariakit from "@ariakit/react";
 
-interface SwitchProps extends Ariakit.CheckboxProps {
+interface SwitchProps extends Omit<Ariakit.CheckboxProps, "store"> {
 	/** The default checked state of the toggle switch. */
 	defaultChecked?: boolean;
 	/** The checked state of the toggle switch. */

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as Ariakit from "@ariakit/react";
+import * as React from "react";
+
+// ----------------------------------------------------------------------------
+
+interface TabsProps
+	extends Pick<
+		Ariakit.TabProviderProps,
+		| "defaultSelectedId"
+		| "selectedId"
+		| "setSelectedId"
+		| "selectOnMove"
+		| "children"
+	> {}
+
+function Tabs(props: TabsProps) {
+	const {
+		defaultSelectedId,
+		selectedId,
+		setSelectedId,
+		selectOnMove,
+		children,
+	} = props;
+	return (
+		<Ariakit.TabProvider
+			defaultSelectedId={defaultSelectedId}
+			selectedId={selectedId}
+			setSelectedId={setSelectedId}
+			selectOnMove={selectOnMove}
+		>
+			{children}
+		</Ariakit.TabProvider>
+	);
+}
+
+// ----------------------------------------------------------------------------
+
+interface TabListProps extends Ariakit.RoleProps<"div"> {}
+
+const TabList = React.forwardRef<
+	React.ElementRef<typeof Ariakit.TabList>,
+	TabListProps
+>((props, forwardedRef) => {
+	return <Ariakit.TabList {...props} ref={forwardedRef} />;
+});
+
+// ----------------------------------------------------------------------------
+
+interface TabProps
+	extends Ariakit.FocusableProps<"button">,
+		Pick<Ariakit.TabProps, "id"> {}
+
+const Tab = React.forwardRef<React.ElementRef<typeof Ariakit.Tab>, TabProps>(
+	(props, forwardedRef) => {
+		return <Ariakit.Tab accessibleWhenDisabled {...props} ref={forwardedRef} />;
+	},
+);
+
+// ----------------------------------------------------------------------------
+
+interface TabPanelProps
+	extends Ariakit.RoleProps<"div">,
+		Pick<Ariakit.TabPanelProps, "tabId" | "unmountOnHide"> {}
+
+const TabPanel = React.forwardRef<
+	React.ElementRef<typeof Ariakit.TabPanel>,
+	TabPanelProps
+>((props, forwardedRef) => {
+	return <Ariakit.TabPanel {...props} ref={forwardedRef} />;
+});
+
+// ----------------------------------------------------------------------------
+
+export { Tabs as Root, TabList, Tab, TabPanel };

--- a/packages/kiwi-react/src/bricks/index.ts
+++ b/packages/kiwi-react/src/bricks/index.ts
@@ -9,5 +9,6 @@ export { Input } from "./Input.js";
 export { Label } from "./Label.js";
 export { Radio } from "./Radio.js";
 export { Switch } from "./Switch.js";
+export * as Tabs from "./Tabs.js";
 export { Textarea } from "./Textarea.js";
 export { VisuallyHidden } from "./VisuallyHidden.js";


### PR DESCRIPTION
Based on [`Ariakit.Tab`](https://ariakit.org/components/tab) (and related components).

This is a compound component exposed as four subcomponents:

```tsx
<Tabs.Root>
  <Tabs.TabList>
    <Tabs.Tab>Tab 1</Tab>
    <Tabs.Tab>Tab 2</Tab>
  </Tabs.TabList>
  <Tabs.TabPanel>Panel 1</TabPanel>
  <Tabs.TabPanel>Panel 2</TabPanel>
</Tabs.Root>
```

**Notes**:
- `Tabs.Root` currently only renders `TabProvider`, but I've written it in such a way that we can easily add a wrapper `<div>` inside it if we need it in the future (for styling purposes).
- Most props have been excluded, because there are a lot of [optional props](https://ariakit.org/reference/tab#optional-props) that probably should not be part of the public API; users should not have so much control over the internals of Ariakit.
  - After doing this, I also went through other props and tried to exclude any unnecessary props. Specifically, I excluded the [`store`](https://ariakit.org/reference/checkbox#store) prop from `Checkbox`, `Switch` and `Radio`.