### PR TITLE
reintroduce `tsc` during `dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
 	"description": "Monorepo for the kiwi design system",
 	"scripts": {
 		"build": "pnpm --filter=\"./packages/**\" --filter=\"./apps/**\" build",
-		"dev": "pnpm --filter=@itwin/test-app dev",
+		"dev": "npm run dev:app & npm run dev:ts &",
+		"dev:app": "pnpm --filter=@itwin/test-app dev",
+		"dev:ts": "pnpm --filter=@itwin/kiwi-react dev",
 		"format": "biome format .",
 		"lint": "biome lint .",
 		"lint:copyright": "tsx scripts/copyright-linter.ts",

--- a/packages/kiwi-react/package.json
+++ b/packages/kiwi-react/package.json
@@ -33,7 +33,8 @@
 		"ui"
 	],
 	"scripts": {
-		"build": "rm -rf dist && node scripts/build.js && tsc --outDir dist"
+		"build": "rm -rf dist && node scripts/build.js && tsc --outDir dist",
+		"dev": "tsc --watch --outDir dist"
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.8",


### PR DESCRIPTION
#18 was accidentally reverted by #16 because of a bad merge. This PR re-adds it.

I've also updated the ruleset for `main` branch so that PRs are required to be up-to-date before merging.