### PR TITLE
deploy previews for `main`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -132,7 +132,7 @@ jobs:
     name: Deploy test app to github pages
     needs: install
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:
@@ -169,7 +169,6 @@ jobs:
             })).data.map(pr => pr.number))].join('\n')
 
       - name: Deploy build output to gh-pages branch
-        if: github.ref != 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages


### PR DESCRIPTION
Follow-up to #25. In addition to PRs, `main` branch will now also deploy test-app to gh-pages after every push. The main reason for this is to run cleanup of PRs that have already merged.