### PR TITLE
fix remnants of #24

### DIFF
--- a/packages/kiwi-react/src/bricks/Button.css
+++ b/packages/kiwi-react/src/bricks/Button.css
@@ -23,18 +23,17 @@
 		--_kiwi-button-padding-inline: 12px;
 	}
 
-	font: inherit;
 	text-decoration: none;
 	line-height: 1;
 	white-space: nowrap;
 	user-select: none;
 	cursor: pointer;
 	font-weight: 500;
+	border: 1px solid transparent;
 
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	vertical-align: middle;
 	flex-shrink: 0;
 	gap: var(--_kiwi-button-gap);
 
@@ -47,7 +46,7 @@
 		var(--__kiwi-button-state--active, var(--_kiwi-button-color-background-active))
 		var(--__kiwi-button-state--disabled, var(--_kiwi-button-color-background-disabled));
 	background-image: linear-gradient(hsl(0 0% 0% / 0), hsl(0 0% 0% / 0.1));
-	border: 1px solid var(--_kiwi-button-color-border);
+	border-color: var(--_kiwi-button-color-border);
 	box-shadow: 0px 0px 0px 1px var(--_kiwi-button-color-shadow-inner) inset;
 	color: var(--_kiwi-button-color-text);
 	transition: background-color 150ms ease-out;
@@ -57,10 +56,10 @@
 		&:where(:hover) {
 			--__kiwi-button-state: var(--__kiwi-button-state--hover);
 		}
+	}
 
-		&:where(:active) {
-			--__kiwi-button-state: var(--__kiwi-button-state--active);
-		}
+	&:where(:active) {
+		--__kiwi-button-state: var(--__kiwi-button-state--active);
 	}
 
 	&:where([disabled], :disabled, [aria-disabled="true"]) {


### PR DESCRIPTION
- `font: inherit` is already covered by reset
- `:active` shouldn't be guarded under `@media (any-hover)` because pressing a button doesn't require hover capabilities
- `vertical-align` does nothing when using flex centering
- `border` shorthand should not contain variables because of https://github.com/iTwin/appui/issues/893