### PR TITLE
reorganize component CSS into sublayers

### DIFF
--- a/packages/kiwi-react/src/bricks/Anchor.css
+++ b/packages/kiwi-react/src/bricks/Anchor.css
@@ -3,35 +3,37 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .\🥝-anchor {
-	@layer settings {
+	@layer base {
 		--_kiwi-anchor-color-text: #edeff0;
-	}
 
-	cursor: pointer;
-	font-weight: 500;
-	text-underline-offset: 0.25ex;
+		cursor: pointer;
+		font-weight: 500;
+		text-underline-offset: 0.25ex;
 
-	border-radius: 4px;
+		border-radius: 4px;
 
-	color: var(--_kiwi-anchor-color-text);
+		color: var(--_kiwi-anchor-color-text);
 
-	&:where(button) {
-		border: none;
-		background: transparent;
-	}
-
-	@media (any-hover: hover) {
-		&:where(:hover) {
-			text-decoration: none;
+		&:where(button) {
+			border: none;
+			background: transparent;
 		}
 	}
 
-	&:where(:active) {
-		text-decoration: none;
-	}
+	@layer states {
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				text-decoration: none;
+			}
+		}
 
-	&:where([disabled], :disabled, [aria-disabled="true"]) {
-		cursor: not-allowed;
-		opacity: 0.5;
+		&:where(:active) {
+			text-decoration: none;
+		}
+
+		&:where([disabled], :disabled, [aria-disabled="true"]) {
+			cursor: not-allowed;
+			opacity: 0.5;
+		}
 	}
 }

--- a/packages/kiwi-react/src/bricks/Button.css
+++ b/packages/kiwi-react/src/bricks/Button.css
@@ -3,68 +3,73 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .\🥝-button {
-	/* Cyclic toggles for default/hover/active/disabled states. See https://kizu.dev/cyclic-toggles/ */
-	--__kiwi-button-state: var(--__kiwi-button-state--default);
-	--__kiwi-button-state--default: var(--__kiwi-button-state,);
-	--__kiwi-button-state--hover: var(--__kiwi-button-state,);
-	--__kiwi-button-state--active: var(--__kiwi-button-state,);
-	--__kiwi-button-state--disabled: var(--__kiwi-button-state,);
-
-	@layer settings {
+	@layer base {
 		--_kiwi-button-color-background: #43494e;
 		--_kiwi-button-color-background-active: #697177;
 		--_kiwi-button-color-background-disabled: #43494e;
 		--_kiwi-button-color-background-hover: #5a6369;
 		--_kiwi-button-color-border: #181a1b;
 		--_kiwi-button-color-shadow-inner: #ffffff1a;
+
 		--_kiwi-button-color-text: #edeff0;
 		--_kiwi-button-gap: 4px;
 		--_kiwi-button-height: 1.5rem;
 		--_kiwi-button-padding-inline: 12px;
+
+		text-decoration: none;
+		line-height: 1;
+		white-space: nowrap;
+		user-select: none;
+		cursor: pointer;
+		font-weight: 500;
+		border: 1px solid transparent;
+
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		gap: var(--_kiwi-button-gap);
+
+		block-size: var(--_kiwi-button-height);
+		border-radius: 4px;
+		padding-inline: var(--_kiwi-button-padding-inline);
+
+		background-image: linear-gradient(hsl(0 0% 0% / 0), hsl(0 0% 0% / 0.1));
+		border-color: var(--_kiwi-button-color-border);
+		box-shadow: 0px 0px 0px 1px var(--_kiwi-button-color-shadow-inner) inset;
+
+		color: var(--_kiwi-button-color-text);
+		transition: background-color 150ms ease-out;
+		-webkit-tap-highlight-color: var(--_kiwi-button-color-background-active);
 	}
 
-	text-decoration: none;
-	line-height: 1;
-	white-space: nowrap;
-	user-select: none;
-	cursor: pointer;
-	font-weight: 500;
-	border: 1px solid transparent;
+	@layer states {
+		/* Cyclic toggles for default/hover/active/disabled states. See https://kizu.dev/cyclic-toggles/ */
+		--__kiwi-button-state: var(--__kiwi-button-state--default);
+		--__kiwi-button-state--default: var(--__kiwi-button-state,);
+		--__kiwi-button-state--hover: var(--__kiwi-button-state,);
+		--__kiwi-button-state--active: var(--__kiwi-button-state,);
+		--__kiwi-button-state--disabled: var(--__kiwi-button-state,);
 
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	flex-shrink: 0;
-	gap: var(--_kiwi-button-gap);
+		background-color: var(--__kiwi-button-state--default, var(--_kiwi-button-color-background))
+			var(--__kiwi-button-state--hover, var(--_kiwi-button-color-background-hover))
+			var(--__kiwi-button-state--active, var(--_kiwi-button-color-background-active))
+			var(--__kiwi-button-state--disabled, var(--_kiwi-button-color-background-disabled));
 
-	block-size: var(--_kiwi-button-height);
-	border-radius: 4px;
-	padding-inline: var(--_kiwi-button-padding-inline);
-
-	background-color: var(--__kiwi-button-state--default, var(--_kiwi-button-color-background))
-		var(--__kiwi-button-state--hover, var(--_kiwi-button-color-background-hover))
-		var(--__kiwi-button-state--active, var(--_kiwi-button-color-background-active))
-		var(--__kiwi-button-state--disabled, var(--_kiwi-button-color-background-disabled));
-	background-image: linear-gradient(hsl(0 0% 0% / 0), hsl(0 0% 0% / 0.1));
-	border-color: var(--_kiwi-button-color-border);
-	box-shadow: 0px 0px 0px 1px var(--_kiwi-button-color-shadow-inner) inset;
-	color: var(--_kiwi-button-color-text);
-	transition: background-color 150ms ease-out;
-	-webkit-tap-highlight-color: var(--_kiwi-button-color-background-active);
-
-	@media (any-hover: hover) {
-		&:where(:hover) {
-			--__kiwi-button-state: var(--__kiwi-button-state--hover);
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				--__kiwi-button-state: var(--__kiwi-button-state--hover);
+			}
 		}
-	}
 
-	&:where(:active) {
-		--__kiwi-button-state: var(--__kiwi-button-state--active);
-	}
+		&:where(:active) {
+			--__kiwi-button-state: var(--__kiwi-button-state--active);
+		}
 
-	&:where([disabled], :disabled, [aria-disabled="true"]) {
-		--__kiwi-button-state: var(--__kiwi-button-state--disabled);
-		cursor: not-allowed;
-		opacity: 0.5;
+		&:where([disabled], :disabled, [aria-disabled="true"]) {
+			--__kiwi-button-state: var(--__kiwi-button-state--disabled);
+			cursor: not-allowed;
+			opacity: 0.5;
+		}
 	}
 }

--- a/packages/kiwi-react/src/bricks/Input.css
+++ b/packages/kiwi-react/src/bricks/Input.css
@@ -3,70 +3,74 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .\🥝-input {
-	/* Cyclic toggles for default/hover/active/disabled states. See https://kizu.dev/cyclic-toggles/ */
-	--__kiwi-input-state: var(--__kiwi-input-state--default);
-	--__kiwi-input-state--default: var(--__kiwi-input-state,);
-	--__kiwi-input-state--hover: var(--__kiwi-input-state,);
-	--__kiwi-input-state--disabled: var(--__kiwi-input-state,);
-
-	@layer settings {
+	@layer base {
 		--_kiwi-input-color-background: #181a1b;
 		--_kiwi-input-color-background-hover: #212325;
 		--_kiwi-input-color-background-disabled: #181a1b;
 		--_kiwi-input-color-border: #43494e;
 		--_kiwi-input-color-border-hover: #5a6369;
 		--_kiwi-input-color-border-disabled: #43494e;
+
 		--_kiwi-input-color-text: #edeff0;
 		--_kiwi-input-color-placeholder: #777e84;
 		--_kiwi-input-height: 1.5rem;
 		--_kiwi-input-padding-inline: 8px;
 		--_kiwi-input-padding-block: 4px;
-	}
 
-	appearance: none;
-	border: 1px solid transparent;
+		appearance: none;
+		border: 1px solid transparent;
 
-	display: inline-flex;
-	align-items: center;
-	justify-content: flex-start;
+		display: inline-flex;
+		align-items: center;
+		justify-content: flex-start;
 
-	min-block-size: var(--_kiwi-input-height);
-	padding-inline: var(--_kiwi-input-padding-inline);
-	padding-block: var(--_kiwi-input-padding-block);
-	border-radius: 4px;
+		min-block-size: var(--_kiwi-input-height);
+		padding-inline: var(--_kiwi-input-padding-inline);
+		padding-block: var(--_kiwi-input-padding-block);
+		border-radius: 4px;
 
-	background-color: var(--__kiwi-input-state--default, var(--_kiwi-input-color-background))
-		var(--__kiwi-input-state--hover, var(--_kiwi-input-color-background-hover))
-		var(--__kiwi-input-state--disabled, var(--_kiwi-input-color-background-disabled));
-	border-color: var(--__kiwi-input-state--default, var(--_kiwi-input-color-border))
-		var(--__kiwi-input-state--hover, var(--_kiwi-input-color-border-hover))
-		var(--__kiwi-input-state--disabled, var(--_kiwi-input-color-border-disabled));
-	box-shadow:
-		0px 2px 0px 0px hsl(0 0% 0% / 0.4) inset,
-		0px 2px 4px 0px hsl(0 0% 0% / 0.2) inset;
-	color: var(--_kiwi-input-color-text);
-	transition: all 150ms ease-out;
-	transition-property: background-color, border-color;
+		box-shadow:
+			0px 2px 0px 0px hsl(0 0% 0% / 0.4) inset,
+			0px 2px 4px 0px hsl(0 0% 0% / 0.2) inset;
+		color: var(--_kiwi-input-color-text);
+		transition: all 150ms ease-out;
+		transition-property: background-color, border-color;
 
-	&::placeholder {
-		color: var(--_kiwi-input-color-placeholder);
-		opacity: 1;
-	}
+		&::placeholder {
+			color: var(--_kiwi-input-color-placeholder);
+			opacity: 1;
+		}
 
-	&:where(textarea) {
-		resize: vertical;
-		resize: block;
-	}
-
-	@media (any-hover: hover) {
-		&:where(:hover) {
-			--__kiwi-input-state: var(--__kiwi-input-state--hover);
+		&:where(textarea) {
+			resize: vertical;
+			resize: block;
 		}
 	}
 
-	&:where(:disabled) {
-		--__kiwi-input-state: var(--__kiwi-input-state--disabled);
-		cursor: pointer;
-		opacity: 0.5;
+	@layer states {
+		/* Cyclic toggles for default/hover/active/disabled states. See https://kizu.dev/cyclic-toggles/ */
+		--__kiwi-input-state: var(--__kiwi-input-state--default);
+		--__kiwi-input-state--default: var(--__kiwi-input-state,);
+		--__kiwi-input-state--hover: var(--__kiwi-input-state,);
+		--__kiwi-input-state--disabled: var(--__kiwi-input-state,);
+
+		background-color: var(--__kiwi-input-state--default, var(--_kiwi-input-color-background))
+			var(--__kiwi-input-state--hover, var(--_kiwi-input-color-background-hover))
+			var(--__kiwi-input-state--disabled, var(--_kiwi-input-color-background-disabled));
+		border-color: var(--__kiwi-input-state--default, var(--_kiwi-input-color-border))
+			var(--__kiwi-input-state--hover, var(--_kiwi-input-color-border-hover))
+			var(--__kiwi-input-state--disabled, var(--_kiwi-input-color-border-disabled));
+
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				--__kiwi-input-state: var(--__kiwi-input-state--hover);
+			}
+		}
+
+		&:where(:disabled) {
+			--__kiwi-input-state: var(--__kiwi-input-state--disabled);
+			cursor: pointer;
+			opacity: 0.5;
+		}
 	}
 }

--- a/packages/kiwi-react/src/bricks/Label.css
+++ b/packages/kiwi-react/src/bricks/Label.css
@@ -3,18 +3,22 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .\🥝-label {
-	color: #afb5ba;
-	cursor: default;
+	@layer base {
+		color: #afb5ba;
+		cursor: default;
 
-	&:is(label) {
-		cursor: pointer;
-
-		&:has(+ :where(:disabled, [disabled], [aria-disabled="true"])) {
-			cursor: not-allowed;
+		&:is(label) {
+			cursor: pointer;
 		}
 	}
 
-	&:has(+ :where(:disabled, [disabled], [aria-disabled="true"])) {
-		opacity: 0.5;
+	@layer states {
+		&:has(+ :where(:disabled, [disabled], [aria-disabled="true"])) {
+			opacity: 0.5;
+
+			&:is(label) {
+				cursor: not-allowed;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Pulled out of #39.

All component CSS now includes `@layer base` and `@layer states`. The latter is where the `:hover`/`:active`/`:disabled` states live, along with cyclic toggles and the declarations which _use_ the cyclic toggles.

(It's not in this PR, but in #39 I've added another `@layer modifiers` which lives between the two)

For reviewing, make sure to [turn off whitespace diff](https://github.com/iTwin/kiwi/pull/40/files?w=1).