### PR TITLE
Fix playwright tests on the CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -116,7 +116,6 @@ jobs:
           version: 9
 
       - run: pnpm install
-      - run: pnpm dlx playwright install --with-deps
       - run: pnpm run build
       - run: pnpm --filter=@itwin/test-app exec playwright test
         env:


### PR DESCRIPTION
Remove `playwright install` from CI workflow since playwright is already installed via the Docker image.