### PR TITLE
bump `express` and related deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2388,10 +2388,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  express@4.20.0:
+  express@4.21.0:
     resolution:
       {
-        integrity: sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==,
+        integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==,
       }
     engines: { node: ">= 0.10.0" }
 
@@ -2427,10 +2427,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  finalhandler@1.2.0:
+  finalhandler@1.3.1:
     resolution:
       {
-        integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==,
+        integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==,
       }
     engines: { node: ">= 0.8" }
 
@@ -4053,13 +4053,6 @@ packages:
         integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==,
       }
 
-  qs@6.11.0:
-    resolution:
-      {
-        integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==,
-      }
-    engines: { node: ">=0.6" }
-
   qs@6.13.0:
     resolution:
       {
@@ -4285,13 +4278,6 @@ packages:
     engines: { node: ">=10" }
     hasBin: true
 
-  send@0.18.0:
-    resolution:
-      {
-        integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==,
-      }
-    engines: { node: ">= 0.8.0" }
-
   send@0.19.0:
     resolution:
       {
@@ -4299,10 +4285,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  serve-static@1.16.0:
+  serve-static@1.16.2:
     resolution:
       {
-        integrity: sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==,
+        integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==,
       }
     engines: { node: ">= 0.8.0" }
 
@@ -5602,7 +5588,7 @@ snapshots:
       esbuild-plugins-node-modules-polyfill: 1.6.4(esbuild@0.17.6)
       execa: 5.1.1
       exit-hook: 2.2.1
-      express: 4.20.0
+      express: 4.21.0
       fs-extra: 10.1.0
       get-port: 5.1.1
       gunzip-maybe: 1.4.2
@@ -5648,10 +5634,10 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  "@remix-run/express@2.11.0(express@4.20.0)(typescript@5.5.4)":
+  "@remix-run/express@2.11.0(express@4.21.0)(typescript@5.5.4)":
     dependencies:
       "@remix-run/node": 2.11.0(typescript@5.5.4)
-      express: 4.20.0
+      express: 4.21.0
     optionalDependencies:
       typescript: 5.5.4
 
@@ -5683,11 +5669,11 @@ snapshots:
 
   "@remix-run/serve@2.11.0(typescript@5.5.4)":
     dependencies:
-      "@remix-run/express": 2.11.0(express@4.20.0)(typescript@5.5.4)
+      "@remix-run/express": 2.11.0(express@4.21.0)(typescript@5.5.4)
       "@remix-run/node": 2.11.0(typescript@5.5.4)
       chokidar: 3.6.0
       compression: 1.7.4
-      express: 4.20.0
+      express: 4.21.0
       get-port: 5.1.1
       morgan: 1.10.0
       source-map-support: 0.5.21
@@ -6362,7 +6348,7 @@ snapshots:
 
   exit-hook@2.2.1: {}
 
-  express@4.20.0:
+  express@4.21.0:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -6376,7 +6362,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.2.0
+      finalhandler: 1.3.1
       fresh: 0.5.2
       http-errors: 2.0.0
       merge-descriptors: 1.0.3
@@ -6385,11 +6371,11 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.10
       proxy-addr: 2.0.7
-      qs: 6.11.0
+      qs: 6.13.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
-      serve-static: 1.16.0
+      serve-static: 1.16.2
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -6420,10 +6406,10 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.2.0:
+  finalhandler@1.3.1:
     dependencies:
       debug: 2.6.9
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
@@ -7450,10 +7436,6 @@ snapshots:
       inherits: 2.0.4
       pump: 2.0.1
 
-  qs@6.11.0:
-    dependencies:
-      side-channel: 1.0.6
-
   qs@6.13.0:
     dependencies:
       side-channel: 1.0.6
@@ -7610,24 +7592,6 @@ snapshots:
 
   semver@7.6.3: {}
 
-  send@0.18.0:
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -7646,12 +7610,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.0:
+  serve-static@1.16.2:
     dependencies:
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.18.0
+      send: 0.19.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
This PR fixes the [recent `npm audit` failures](https://github.com/iTwin/kiwi/actions/runs/10812403737/job/29993981751) by updating `express` to `4.21.0`.