### PR TITLE
force bump `cookie`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,18 @@
 		"@biomejs/biome": "1.9.1",
 		"@types/node": "*",
 		"fast-glob": "^3.3.2",
+		"internal": "workspace:*",
 		"lefthook": "^1.7.11",
 		"prettier": "3.3.3",
-		"internal": "workspace:*",
 		"tsx": "^4.16.5"
 	},
 	"engines": {
 		"node": ">=20.16.0"
 	},
-	"packageManager": "pnpm@9.6.0"
+	"packageManager": "pnpm@9.6.0",
+	"pnpm": {
+		"overrides": {
+			"cookie@<0.7.0": ">=0.7.0"
+		}
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  cookie@<0.7.0: ">=0.7.0"
+
 importers:
   .:
     devDependencies:
@@ -2035,10 +2038,10 @@ packages:
       }
     engines: { node: ">=6.6.0" }
 
-  cookie@0.6.0:
+  cookie@0.7.2:
     resolution:
       {
-        integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==,
+        integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
       }
     engines: { node: ">= 0.6" }
 
@@ -5810,7 +5813,7 @@ snapshots:
       "@remix-run/router": 1.19.2
       "@types/cookie": 0.6.0
       "@web3-storage/multipart-parser": 1.0.0
-      cookie: 0.6.0
+      cookie: 0.7.2
       set-cookie-parser: 2.7.0
       source-map: 0.7.4
       turbo-stream: 2.4.0
@@ -6235,7 +6238,7 @@ snapshots:
 
   cookie-signature@1.2.1: {}
 
-  cookie@0.6.0: {}
+  cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
 
@@ -6482,7 +6485,7 @@ snapshots:
       body-parser: 1.20.3
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.6.0
+      cookie: 0.7.2
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-pxg6-pf52-xh8x

I had to use `overrides`, because `cookies` is coming from `express` and `@remix-run/server-runtime`, neither of which have updated to use the latest version of `cookies` (yet).