### PR TITLE
fix typo in layer name

### DIFF
--- a/packages/kiwi-react/src/bricks/sublayers.css
+++ b/packages/kiwi-react/src/bricks/sublayers.css
@@ -2,4 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@layer base, modifiers, state;
+@layer base, modifiers, states;


### PR DESCRIPTION
The `sublayers.css` was referencing a nonexistent layer name. `state` → `states`.