### PR TITLE
Implement field wrapper component

### DIFF
--- a/apps/test-app/app/routes/index.tsx
+++ b/apps/test-app/app/routes/index.tsx
@@ -13,6 +13,7 @@ const components = [
 	"Checkbox",
 	"Divider",
 	"DropdownMenu",
+	"Field",
 	"Icon",
 	"Input",
 	"List",

--- a/apps/test-app/app/routes/tests/field/index.spec.ts
+++ b/apps/test-app/app/routes/tests/field/index.spec.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { test, expect } from "@playwright/test";
+
+test.describe("default", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/tests/field");
+	});
+
+	test("wrapping input and label", async ({ page }) => {
+		await expect(page.locator("input:not([type])")).toHaveAccessibleName(
+			"Text example",
+		);
+	});
+
+	test("wrapping textarea and label", async ({ page }) => {
+		await expect(page.locator("textarea")).toHaveAccessibleName(
+			"Textarea example",
+		);
+	});
+
+	test("wrapping checkbox and label", async ({ page }) => {
+		await expect(page.getByRole("checkbox")).toHaveAccessibleName(
+			"Checkbox example",
+		);
+	});
+
+	test("wrapping radio and label", async ({ page }) => {
+		await expect(page.getByRole("radio")).toHaveAccessibleName("Radio example");
+	});
+});

--- a/apps/test-app/app/routes/tests/field/index.spec.ts
+++ b/apps/test-app/app/routes/tests/field/index.spec.ts
@@ -21,13 +21,23 @@ test.describe("default", () => {
 		);
 	});
 
+	test("wrapping radio and label", async ({ page }) => {
+		await expect(page.getByRole("radio")).toHaveAccessibleName("Radio example");
+	});
+
 	test("wrapping checkbox and label", async ({ page }) => {
 		await expect(page.getByRole("checkbox")).toHaveAccessibleName(
 			"Checkbox example",
 		);
 	});
 
-	test("wrapping radio and label", async ({ page }) => {
-		await expect(page.getByRole("radio")).toHaveAccessibleName("Radio example");
+	test("wrapping switch and label", async ({ page }) => {
+		await expect(page.getByRole("switch")).toHaveAccessibleName(
+			"Switch example",
+		);
+	});
+
+	test("rendering as a label", async ({ page }) => {
+		await expect(page.locator(".🥝-label.🥝-field")).toBeVisible();
 	});
 });

--- a/apps/test-app/app/routes/tests/field/index.tsx
+++ b/apps/test-app/app/routes/tests/field/index.tsx
@@ -8,6 +8,7 @@ import {
 	Input,
 	Label,
 	Radio,
+	Switch,
 	Textarea,
 } from "@itwin/kiwi-react/bricks";
 
@@ -22,12 +23,15 @@ export default function Page() {
 			</Field>
 			<Field>
 				<Label>
-					<Checkbox /> Checkbox example
+					<Radio name="radio" value="radio" /> Radio example
 				</Label>
+			</Field>
+			<Field render={<Label />}>
+				<Checkbox /> Checkbox example
 			</Field>
 			<Field>
 				<Label>
-					<Radio name="radio" value="radio" /> Radio example
+					<Switch /> Switch example
 				</Label>
 			</Field>
 		</form>

--- a/apps/test-app/app/routes/tests/field/index.tsx
+++ b/apps/test-app/app/routes/tests/field/index.tsx
@@ -2,20 +2,33 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Field, Input, Label } from "@itwin/kiwi-react/bricks";
+import {
+	Checkbox,
+	Field,
+	Input,
+	Label,
+	Radio,
+	Textarea,
+} from "@itwin/kiwi-react/bricks";
 
 export default function Page() {
 	return (
 		<form>
-			{/* These should be synced */}
 			<Field>
-				<Label>Name</Label>
-				<Input />
+				<Label>Text example</Label> <Input />
 			</Field>
-			{/* These aren’t synced and right now that’s intentional */}
 			<Field>
-				<Label>Fruit</Label>
-				<Input id="fruit" />
+				<Label>Textarea example</Label> <Textarea />
+			</Field>
+			<Field>
+				<Label>
+					<Checkbox /> Checkbox example
+				</Label>
+			</Field>
+			<Field>
+				<Label>
+					<Radio name="radio" value="radio" /> Radio example
+				</Label>
 			</Field>
 		</form>
 	);

--- a/apps/test-app/app/routes/tests/field/index.tsx
+++ b/apps/test-app/app/routes/tests/field/index.tsx
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { Field, Input, Label } from "@itwin/kiwi-react/bricks";
+
+export default function Page() {
+	return (
+		<form>
+			{/* These should be synced */}
+			<Field>
+				<Label>Name</Label>
+				<Input />
+			</Field>
+			{/* These aren’t synced and right now that’s intentional */}
+			<Field>
+				<Label>Fruit</Label>
+				<Input id="fruit" />
+			</Field>
+		</form>
+	);
+}

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -18,8 +18,8 @@ export const Checkbox = React.forwardRef<
 	return (
 		<Ariakit.Checkbox
 			accessibleWhenDisabled
+			id={fieldId}
 			{...props}
-			id={props.id ?? fieldId}
 			className={cx("🥝-checkbox", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
+import { useFieldId } from "./Field.js";
 
 interface CheckboxProps extends Omit<Ariakit.CheckboxProps, "store"> {}
 
@@ -12,10 +13,13 @@ export const Checkbox = React.forwardRef<
 	React.ElementRef<typeof Ariakit.Checkbox>,
 	CheckboxProps
 >((props, forwardedRef) => {
+	const fieldId = useFieldId();
+
 	return (
 		<Ariakit.Checkbox
 			accessibleWhenDisabled
 			{...props}
+			id={props.id ?? fieldId}
 			className={cx("🥝-checkbox", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import type * as Ariakit from "@ariakit/react";
+import cx from "classnames";
+
+interface FieldProps extends Ariakit.RoleProps<"div"> {}
+
+const FieldIdContext = React.createContext<string | undefined>(undefined);
+
+export function useFieldId() {
+	return React.useContext(FieldIdContext);
+}
+
+export const Field = React.forwardRef<React.ElementRef<"div">, FieldProps>(
+	(props, forwardedRef) => {
+		const fieldId = React.useId();
+
+		return (
+			<FieldIdContext.Provider value={fieldId}>
+				<div
+					{...props}
+					className={cx("🥝-field", props.className)}
+					ref={forwardedRef}
+				/>
+			</FieldIdContext.Provider>
+		);
+	},
+);

--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -3,10 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
-import type * as Ariakit from "@ariakit/react";
+import * as Ariakit from "@ariakit/react";
 import cx from "classnames";
 
-interface FieldProps extends Ariakit.RoleProps<"div"> {}
+interface FieldProps extends Ariakit.RoleProps {}
 
 const FieldIdContext = React.createContext<string | undefined>(undefined);
 
@@ -20,7 +20,7 @@ export const Field = React.forwardRef<React.ElementRef<"div">, FieldProps>(
 
 		return (
 			<FieldIdContext.Provider value={fieldId}>
-				<div
+				<Ariakit.Role
 					{...props}
 					className={cx("🥝-field", props.className)}
 					ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/Input.tsx
+++ b/packages/kiwi-react/src/bricks/Input.tsx
@@ -5,14 +5,18 @@
 import * as React from "react";
 import * as Ariakit from "@ariakit/react";
 import cx from "classnames";
+import { useFieldId } from "./Field.js";
 
 interface InputProps extends Ariakit.FocusableProps<"input"> {}
 
 export const Input = React.forwardRef<React.ElementRef<"input">, InputProps>(
 	(props, forwardedRef) => {
+		const fieldId = useFieldId();
+
 		return (
 			<Ariakit.Role.input
 				{...props}
+				id={props.id ?? fieldId}
 				className={cx("🥝-input", props.className)}
 				render={
 					<Ariakit.Focusable

--- a/packages/kiwi-react/src/bricks/Input.tsx
+++ b/packages/kiwi-react/src/bricks/Input.tsx
@@ -15,8 +15,8 @@ export const Input = React.forwardRef<React.ElementRef<"input">, InputProps>(
 
 		return (
 			<Ariakit.Role.input
+				id={fieldId}
 				{...props}
-				id={props.id ?? fieldId}
 				className={cx("🥝-input", props.className)}
 				render={
 					<Ariakit.Focusable

--- a/packages/kiwi-react/src/bricks/Label.tsx
+++ b/packages/kiwi-react/src/bricks/Label.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
+import { useFieldId } from "./Field.js";
 
 interface LabelProps extends Ariakit.RoleProps<"label"> {}
 
@@ -12,9 +13,12 @@ export const Label = React.forwardRef<
 	React.ElementRef<typeof Ariakit.Role.label>,
 	LabelProps
 >((props, forwardedRef) => {
+	const fieldId = useFieldId();
+
 	return (
 		<Ariakit.Role.label
 			{...props}
+			htmlFor={props.htmlFor ?? fieldId}
 			className={cx("🥝-label", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Label.tsx
+++ b/packages/kiwi-react/src/bricks/Label.tsx
@@ -17,8 +17,8 @@ export const Label = React.forwardRef<
 
 	return (
 		<Ariakit.Role.label
+			htmlFor={fieldId}
 			{...props}
-			htmlFor={props.htmlFor ?? fieldId}
 			className={cx("🥝-label", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
+import { useFieldId } from "./Field.js";
 
 interface RadioProps extends Omit<Ariakit.RadioProps, "store"> {}
 
@@ -12,10 +13,13 @@ export const Radio = React.forwardRef<
 	React.ElementRef<typeof Ariakit.Radio>,
 	RadioProps
 >((props, forwardedRef) => {
+	const fieldId = useFieldId();
+
 	return (
 		<Ariakit.Radio
 			accessibleWhenDisabled
 			{...props}
+			id={props.id ?? fieldId}
 			className={cx("🥝-checkbox", "🥝-radio", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -18,8 +18,8 @@ export const Radio = React.forwardRef<
 	return (
 		<Ariakit.Radio
 			accessibleWhenDisabled
+			id={fieldId}
 			{...props}
-			id={props.id ?? fieldId}
 			className={cx("🥝-checkbox", "🥝-radio", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
+import { useFieldId } from "./Field.js";
 
 interface SwitchProps extends Omit<Ariakit.CheckboxProps, "store"> {
 	/** The default checked state of the toggle switch. */
@@ -17,9 +18,12 @@ export const Switch = React.forwardRef<
 	React.ElementRef<typeof Ariakit.Checkbox>,
 	SwitchProps
 >((props, forwardedRef) => {
+	const fieldId = useFieldId();
+
 	return (
 		<Ariakit.Checkbox
 			accessibleWhenDisabled
+			id={fieldId}
 			{...props}
 			className={cx("🥝-switch", props.className)}
 			role="switch"

--- a/packages/kiwi-react/src/bricks/Textarea.tsx
+++ b/packages/kiwi-react/src/bricks/Textarea.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 import * as Ariakit from "@ariakit/react";
 import cx from "classnames";
+import { useFieldId } from "./Field.js";
 
 interface TextareaProps extends Ariakit.FocusableProps<"textarea"> {}
 
@@ -12,9 +13,11 @@ export const Textarea = React.forwardRef<
 	React.ElementRef<"textarea">,
 	TextareaProps
 >((props, forwardedRef) => {
+	const fieldId = useFieldId();
 	return (
 		<Ariakit.Role.textarea
 			{...props}
+			id={props.id ?? fieldId}
 			className={cx("🥝-input", props.className)}
 			render={
 				<Ariakit.Focusable

--- a/packages/kiwi-react/src/bricks/Textarea.tsx
+++ b/packages/kiwi-react/src/bricks/Textarea.tsx
@@ -14,10 +14,11 @@ export const Textarea = React.forwardRef<
 	TextareaProps
 >((props, forwardedRef) => {
 	const fieldId = useFieldId();
+
 	return (
 		<Ariakit.Role.textarea
+			id={fieldId}
 			{...props}
-			id={props.id ?? fieldId}
 			className={cx("🥝-input", props.className)}
 			render={
 				<Ariakit.Focusable

--- a/packages/kiwi-react/src/bricks/index.ts
+++ b/packages/kiwi-react/src/bricks/index.ts
@@ -10,6 +10,7 @@ export * as DropdownMenu from "./DropdownMenu.js";
 export { Divider } from "./Divider.js";
 export { Icon } from "./Icon.js";
 export { Input } from "./Input.js";
+export { Field } from "./Field.js";
 export { Label } from "./Label.js";
 export { Radio } from "./Radio.js";
 export { Switch } from "./Switch.js";


### PR DESCRIPTION
This introduces a field wrapper component called `<Field>` and modifies existing form controls to work with it (i.e. `<Input>`, `<Textarea>`, `<Checkbox>`, and `<Radio>`). The current implementation prioritizes simplicity and avoids breaking uses of the form controls outside of `<Field>` (since it uses context).

Here’s how to use it:

```jsx
<Field>
    <Label>Artist</Label>
    <Input name="artist" value="Unprocessed" />
</Field>
```

We can also use the `render` prop to render the container as the `<Label>` (or whatever element you pass it):


```jsx
<Field render={<Label />}>
    Artist <Input name="artist" value="Unprocessed" />
</Field>
```

All the form controls use an internal `useFieldId()` hook exported from the same file as `<Field>`. I figured colocation is fine for now, though we might want to explore a home for these sorts of things in the future.

## Limitations

The following currently **does not work** (i.e. it will break since the `<Label>` doesn’t know `<Input>` has a custom `id`):

```jsx
<Field>
    <Label>Artist</Label>
    <Input id="artist" name="artist" value="Unprocessed" />
</Field>
```

The workaround is to manually set `htmlFor` on the `<Label>` as well:

```jsx
<Field>
    <Label htmlFor="artist">Artist</Label>
    <Input id="artist" name="artist" value="Unprocessed" />
</Field>
```

This happens because currently the component only associates a control to a label using a generated ID and will not sync a user-provided `id` prop for the control with the label. That likely is desirable, however, due to the added complexity, I decided to prioritize a simpler implementation to start. _I am happy to make it work for this PR though._