### PR TITLE
update global CSS to use semantic tokens

### DIFF
--- a/packages/kiwi-react/src/foundations/global.css
+++ b/packages/kiwi-react/src/foundations/global.css
@@ -9,11 +9,11 @@ html {
 body {
 	font-family: var(--kiwi-font-family-sans);
 	font-size: var(--kiwi-font-size-m);
-	color: #fbfcfd; /* text/neutral/primary */
+	color: var(--kiwi-color-text-neutral-primary);
 }
 
 *:focus-visible {
-	--💥focus-color: #0bfac2 /* border/accent/strong */;
+	--💥focus-color: var(--kiwi-color-border-accent-strong);
 	outline: 2px solid var(--💥focus-color);
 	outline-offset: 1px;
 }


### PR DESCRIPTION
This is a small follow-up to #71 (which only handled component CSS). There were two spots in `global.css` which were still hardcoding hex values.