### PR TITLE
decrease playwright screenshot `threshold`

### DIFF
--- a/apps/test-app/playwright.config.ts
+++ b/apps/test-app/playwright.config.ts
@@ -50,4 +50,10 @@ export default defineConfig({
 		url: "http://localhost:1800",
 		reuseExistingServer: !process.env.CI,
 	},
+
+	expect: {
+		toHaveScreenshot: {
+			threshold: 0.1,
+		},
+	},
 });


### PR DESCRIPTION
See https://github.com/iTwin/kiwi/pull/83#issuecomment-2413864780

`0.2` ([default](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1-option-threshold)) → `0.1`. This should hopefully help us catch smaller visual differences.