### PR TITLE
change sorting of files in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,6 @@
 	},
 	"[jsonc]": {
 		"editor.defaultFormatter": "biomejs.biome"
-	}
+	},
+	"explorer.sortOrderLexicographicOptions": "lower"
 }


### PR DESCRIPTION
Since we rely on VSCode's explorer nesting, this sometimes leads to lowercase and uppercase files being present in the same directory.

This PR changes `sortOrderLexicographicOptions` so that lowercase file names are grouped together.

| Before | After |
| --- | --- |
| <img width="287" alt="" src="https://github.com/user-attachments/assets/68bbcd28-d5ca-4f83-8a2a-ca9a92c87b76"> | <img width="261" alt="" src="https://github.com/user-attachments/assets/20684c48-0d62-4c07-aa97-af004e89b871"> |