### PR TITLE
fix edge cases in `staticVariablesTransform`

### DIFF
--- a/internal/visitors.js
+++ b/internal/visitors.js
@@ -176,7 +176,7 @@ export function staticVariablesTransform() {
 			if (rule.value.selectors.some((s) => s?.[0]?.type === "nesting")) return;
 			lastNonNestedSelector = rule.value.selectors;
 		},
-		Declaration({ property, value: { name, value } }) {
+		DeclarationExit({ property, value: { name, value } }) {
 			if (property !== "custom") return;
 			if (!name.startsWith("--✨")) return;
 
@@ -187,9 +187,12 @@ export function staticVariablesTransform() {
 
 			return []; // Remove the declaration
 		},
-		VariableExit({ name }) {
+		Variable({ name }) {
 			if (name.ident.startsWith("--✨")) {
-				return savedValues.get(lastNonNestedSelector)?.[name.ident];
+				return [
+					...(savedValues.get(lastNonNestedSelector)?.[name.ident] ?? []),
+					{ type: "token", value: { type: "white-space", value: " " } },
+				];
 			}
 		},
 	};


### PR DESCRIPTION
This is a small update to `staticVariablesTransform` to fix some edge-cases.

1. Changed `Declaration` to `DeclarationExit`. This allows the contents of the static variable declarations to be processed before saving the value of the variable (important for things like nested variables). See [docs](https://lightningcss.dev/transforms.html#entry-and-exit-visitors).
2. Changed `VariableExit` to just `Variable`. This ensures that the variable is not transformed too late (important when the variable is used inside a function like `color-mix`).
3. Added a white-space token to the substituted variable value. This was necessary for cases where a variable is used in a larger list of tokens (e.g. `box-shadow`). Not having the white-space would result in an invalid value.

I noticed these issues when trying to update component CSS to use static variables.

---

For testing, try using this code and compare the results of `main` branch with this branch:

<details><summary>Button.css</summary>

```css
.🥝-button {
	--✨color: var(--kiwi-color-text-neutral-primary);
	--✨gap: 4px;
	--✨height: 1.5rem;
	--✨padding-inline: 12px;

	--✨hover-glow: var(--kiwi-color-glow-hue) var(--kiwi-color-bg-glow-base-hover-\%);
	--✨press-glow: var(--kiwi-color-glow-hue) var(--kiwi-color-bg-glow-base-press-\%);

	--✨bg--solid-default: var(--kiwi-color-bg-neutral-base);
	--✨bg--solid-hover: color-mix(in oklch, var(--✨bg--solid-default) 100%, var(--✨hover-glow));
	--✨bg--solid-pressed: color-mix(in oklch, var(--✨bg--solid-default) 100%, var(--✨press-glow));
	--✨border--solid: #ffffff14;

	--✨bg--ghost-default: transparent;
	--✨bg--ghost-hover: color-mix(in oklch, var(--✨bg--ghost-default) 100%, var(--✨hover-glow));
	--✨bg--ghost-pressed: color-mix(in oklch, var(--✨bg--ghost-default) 100%, var(--✨press-glow));

	@layer base {
		text-decoration: none;
		line-height: 1;
		white-space: nowrap;
		user-select: none;
		cursor: pointer;
		font-size: 0.75rem;
		font-weight: 500;
		border: none;

		display: inline-flex;
		align-items: center;
		justify-content: center;
		flex-shrink: 0;
		gap: var(--✨gap);

		block-size: var(--✨height);
		border-radius: 4px;
		padding-inline: var(--✨padding-inline);

		color: var(--✨color);
		transition: background-color 150ms ease-out;
		-webkit-tap-highlight-color: var(--✨bg--solid-pressed);
		--_kiwi-icon-color: var(--_kiwi-button-color-icon);

		@media (forced-colors: active) {
			border: 1px solid;
		}
	}

	@layer modifiers {
		&[data-kiwi-variant="solid"] {
			--_kiwi-button-color-background: var(--✨bg--solid-default);
			--_kiwi-button-color-background-hover: var(--✨bg--solid-hover);
			--_kiwi-button-color-background-pressed: var(--✨bg--solid-pressed);
			--_kiwi-button-color-background-disabled: var(--✨bg--solid-default);
			box-shadow:
				0px 3px 3px -1.5px #00000029,
				0px 1px 1px -0.5px #00000029,
				0px 0px 0px 1px var(--✨border--solid) inset,
				0px -1px 0px 0px #00000014 inset;
		}

		&[data-kiwi-variant="ghost"] {
			--_kiwi-button-color-background: var(--✨bg--ghost-default);
			--_kiwi-button-color-background-hover: var(--✨bg--ghost-hover);
			--_kiwi-button-color-background-pressed: var(--✨bg--ghost-pressed);
			--_kiwi-button-color-background-disabled: var(--✨bg--ghost-default);
		}
	}

	@layer states {
		/* Cyclic toggles for default/hover/pressed/disabled states. See https://kizu.dev/cyclic-toggles/ */
		--__kiwi-button-state: var(--__kiwi-button-state--default);
		--__kiwi-button-state--default: var(--__kiwi-button-state,);
		--__kiwi-button-state--hover: var(--__kiwi-button-state,);
		--__kiwi-button-state--pressed: var(--__kiwi-button-state,);
		--__kiwi-button-state--disabled: var(--__kiwi-button-state,);

		background-color: var(--__kiwi-button-state--default, var(--_kiwi-button-color-background))
			var(--__kiwi-button-state--hover, var(--_kiwi-button-color-background-hover))
			var(--__kiwi-button-state--pressed, var(--_kiwi-button-color-background-pressed))
			var(--__kiwi-button-state--disabled, var(--_kiwi-button-color-background-disabled));

		--_kiwi-button-color-icon: var(
				--__kiwi-button-state--default,
				var(--kiwi-color-icon-neutral-base)
			)
			var(--__kiwi-button-state--hover, var(--kiwi-color-icon-neutral-hover))
			var(--__kiwi-button-state--pressed, var(--kiwi-color-icon-neutral-hover))
			var(--__kiwi-button-state--disabled, var(--kiwi-color-icon-neutral-disabled));

		@media (any-hover: hover) {
			&:where(:hover) {
				--__kiwi-button-state: var(--__kiwi-button-state--hover);
			}
		}

		&:where(:active) {
			--__kiwi-button-state: var(--__kiwi-button-state--pressed);
		}

		&:where([disabled], :disabled, [aria-disabled="true"]) {
			--__kiwi-button-state: var(--__kiwi-button-state--disabled);
			color: var(--kiwi-color-text-neutral-disabled);
			cursor: not-allowed;
		}
	}
}
```

</details> 