### PR TITLE
use `IconButton` in sandbox

### DIFF
--- a/apps/test-app/app/routes/sandbox.tsx
+++ b/apps/test-app/app/routes/sandbox.tsx
@@ -57,7 +57,12 @@ export default function Page() {
 								style={{ color: "var(--kiwi-color-text-accent-strong)" }}
 								href={searchIcon}
 							/>
-							<Icon href={panelLeftIcon} />
+							<IconButton
+								icon={panelLeftIcon}
+								label="Dock panel"
+								variant="ghost"
+								disabled
+							/>
 						</div>
 					</div>
 					<div className={styles.searchWrapper}>


### PR DESCRIPTION
Now that we have an `IconButton` component, we can use start using it in our sandbox.

This PR replaces a couple instances of `Icon` with ghost `IconButton`s. Specifically, "Dock" and "Filter" are now buttons.

| Before | After |
| --- | --- |
| ![](https://github.com/user-attachments/assets/2828915a-251a-4038-8d79-f0437b77c89a) | ![](https://github.com/user-attachments/assets/172f76bd-5ca0-412e-ab56-057e680d69b1) |
