### PR TITLE
fix nested selectors in `staticVariablesTransform`

### DIFF
--- a/internal/visitors.js
+++ b/internal/visitors.js
@@ -184,7 +184,7 @@ export function staticVariablesTransform() {
 	return {
 		Rule(rule) {
 			if (rule.type !== "style") return;
-			if (rule.value.selectors.some((s) => s?.[0]?.type === "nesting")) return;
+			if (rule.value.selectors?.[0]?.some((s) => s?.type === "nesting")) return;
 			lastNonNestedSelector = rule.value.selectors;
 		},
 		DeclarationExit({ property, value: { name, value } }) {


### PR DESCRIPTION
This fixes a typo in `staticVariablesTransform` in the handling of nested selectors.

We want to access the first item (which is an array) in `rule.value.selectors` and see if any items inside that have a `type` of `"nesting"`. The `[0]` was in the wrong place.

This issue was found in https://github.com/iTwin/kiwi/pull/122#discussion_r1830073181, where we want to use `&` at the end of a selector (rather than at the beginning).