### PR TITLE
Move `Textarea` under `TextBox`

### DIFF
--- a/apps/test-app/app/routes/tests/field/index.tsx
+++ b/apps/test-app/app/routes/tests/field/index.tsx
@@ -9,7 +9,6 @@ import {
 	Label,
 	Radio,
 	Switch,
-	Textarea,
 } from "@itwin/kiwi-react/bricks";
 import { useSearchParams } from "@remix-run/react";
 
@@ -20,7 +19,7 @@ const controls: Record<string, React.ElementType> = {
 	input: TextBox.Input,
 	radio: Radio,
 	switch: Switch,
-	textarea: Textarea,
+	textarea: TextBox.Textarea,
 };
 
 export default function Page() {
@@ -75,7 +74,7 @@ function VisualTestForTextControls() {
 			{/* Default layout for text controls (block) with wrapper rendered as a `<Label>` */}
 			<Field render={<Label />}>
 				<span>Textarea control</span>
-				<Textarea />
+				<TextBox.Textarea />
 			</Field>
 
 			{/* Inline layout for text controls */}
@@ -87,7 +86,7 @@ function VisualTestForTextControls() {
 			{/* Inline layout for text controls with wrapper rendered as a `<Label>` */}
 			<Field render={<Label />} layout="inline">
 				<span>Textarea control</span>
-				<Textarea />
+				<TextBox.Textarea />
 			</Field>
 		</div>
 	);

--- a/apps/test-app/app/routes/tests/textarea/index.tsx
+++ b/apps/test-app/app/routes/tests/textarea/index.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Label, Textarea } from "@itwin/kiwi-react/bricks";
+import { Label, TextBox } from "@itwin/kiwi-react/bricks";
 import { useSearchParams } from "@remix-run/react";
 import { useId } from "react";
 
@@ -15,7 +15,7 @@ export default function Page() {
 	return (
 		<>
 			<Label htmlFor={id}>Fruit</Label>
-			<Textarea id={id} rows={3} disabled={disabled} />
+			<TextBox.Textarea id={id} rows={3} disabled={disabled} />
 		</>
 	);
 }

--- a/packages/kiwi-react/src/bricks/TextBox.tsx
+++ b/packages/kiwi-react/src/bricks/TextBox.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import * as Ariakit from "@ariakit/react";
 import cx from "classnames";
 import { useFieldId } from "./Field.js";
+import { Textarea } from "./Textarea.js";
 
 // ----------------------------------------------------------------------------
 
@@ -93,4 +94,4 @@ const TextBoxRootContext = React.createContext(false);
 
 // ----------------------------------------------------------------------------
 
-export { TextBoxInput as Input, TextBoxRoot as Root };
+export { TextBoxInput as Input, TextBoxRoot as Root, Textarea };

--- a/packages/kiwi-react/src/bricks/Textarea.tsx
+++ b/packages/kiwi-react/src/bricks/Textarea.tsx
@@ -9,6 +9,14 @@ import { useFieldId } from "./Field.js";
 
 interface TextareaProps extends Ariakit.FocusableProps<"textarea"> {}
 
+/**
+ * Textarea component that allows users to enter multiline text values.
+ *
+ * Example usage:
+ * ```tsx
+ * <TextBox.Textarea defaultValue="Hello" />
+ * ```
+ */
 export const Textarea = React.forwardRef<
 	React.ElementRef<"textarea">,
 	TextareaProps

--- a/packages/kiwi-react/src/bricks/index.ts
+++ b/packages/kiwi-react/src/bricks/index.ts
@@ -17,7 +17,6 @@ export { Label } from "./Label.js";
 export { Radio } from "./Radio.js";
 export { Switch } from "./Switch.js";
 export * as Tabs from "./Tabs.js";
-export { Textarea } from "./Textarea.js";
 export * as TextBox from "./TextBox.js";
 export { Tooltip } from "./Tooltip.js";
 export { VisuallyHidden } from "./VisuallyHidden.js";


### PR DESCRIPTION
_Stacked against #130_

This PR moves the `Textarea` component under the `TextBox` module. This is mainly done to consistently group text-based inputs and to enable decoration support in the future if needed.

API usage is changed from `<Textarea />` to `<TextBox.Textarea />`.

Added docs to `Textarea` as well.

`textarea` route and `Textarea.tsx` module are left as is, we can merge with `TextBox` if needed with follow-up PRs to keep the codebase consistent.