### PR TITLE
typecheck test files

### DIFF
--- a/apps/test-app/app/routes/tests/field/index.tsx
+++ b/apps/test-app/app/routes/tests/field/index.tsx
@@ -103,7 +103,7 @@ function VisualTestForCheckableControls() {
 			</Field>
 			<Field>
 				<Label>Radio control</Label>
-				<Radio />
+				<Radio value="A" />
 			</Field>
 			<Field>
 				<Label>Switch control</Label>
@@ -116,7 +116,7 @@ function VisualTestForCheckableControls() {
 				<Label>Checkbox control</Label>
 			</Field>
 			<Field>
-				<Radio />
+				<Radio value="A" />
 				<Label>Radio control</Label>
 			</Field>
 			<Field>
@@ -131,7 +131,7 @@ function VisualTestForCheckableControls() {
 			</Field>
 			<Field render={<Label />}>
 				<span>Radio control</span>
-				<Radio />
+				<Radio value="A" />
 			</Field>
 			<Field render={<Label />}>
 				<span>Switch control</span>
@@ -144,7 +144,7 @@ function VisualTestForCheckableControls() {
 				<span>Checkbox control</span>
 			</Field>
 			<Field render={<Label />}>
-				<Radio />
+				<Radio value="A" />
 				<span>Radio control</span>
 			</Field>
 			<Field render={<Label />}>

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -4,7 +4,7 @@
 	"sideEffects": false,
 	"type": "module",
 	"scripts": {
-		"build": "remix vite:build",
+		"build": "remix vite:build && tsc",
 		"dev": "remix vite:dev",
 		"preview": "vite preview",
 		"test": "tsx ./scripts/run-tests.cts pnpm exec playwright test",


### PR DESCRIPTION
`pnpm run build` in test-app will now also type-check all routes, so that there are no type errors. This fixes the issue found in https://github.com/iTwin/kiwi/pull/106#discussion_r1836530117

When adding this, I noticed that `Radio` was missing the [required `value` prop](https://ariakit.org/reference/radio#required-props) in `field` tests, so I fixed that.