### PR TITLE
fix `IconButton` types

### DIFF
--- a/apps/test-app/app/routes/tests/icon-button/index.tsx
+++ b/apps/test-app/app/routes/tests/icon-button/index.tsx
@@ -39,7 +39,7 @@ function VisualTest() {
 	return (
 		<div style={{ display: "flex", gap: 4 }}>
 			<IconButton label="Click me" icon={placeholderIcon} />
-			<IconButton variant="solid" label="Click me" icon={placeholderIcon} />
+			<IconButton variant="outline" label="Click me" icon={placeholderIcon} />
 			<IconButton variant="ghost" label="Click me" icon={placeholderIcon} />
 			<IconButton
 				variant="ghost"

--- a/packages/kiwi-react/src/bricks/IconButton.tsx
+++ b/packages/kiwi-react/src/bricks/IconButton.tsx
@@ -46,7 +46,7 @@ type IconButtonExtraProps =
 			isActive?: boolean;
 	  }
 	| {
-			variant?: "solid";
+			variant?: Omit<React.ComponentProps<typeof Button>["variant"], "ghost">;
 			isActive?: never;
 	  };
 


### PR DESCRIPTION
~~_Stacked upon #135_~~

This fixes the `variant` type to allow `"outline"`, and undoes the erroneous test file change from #106. See https://github.com/iTwin/kiwi/pull/106#discussion_r1838600754 for more context.

As a result, the rendered output of the `icon-button?visual` route now matches the test snapshot.