### PR TITLE
reset default `overflow` to fix `Tooltip` box-shadow

### DIFF
--- a/packages/kiwi-react/src/foundations/reset.css
+++ b/packages/kiwi-react/src/foundations/reset.css
@@ -44,6 +44,7 @@
 	inset: unset;
 	max-width: unset;
 	max-height: unset;
+	overflow: unset;
 }
 
 :where(dialog:not([open], [popover]), [popover]:not(:popover-open)) {


### PR DESCRIPTION
After #106, the Tooltip box-shadow was getting clipped. This is because the [user-agent styles](https://html.spec.whatwg.org/#flow-content-3) for `popover` attribute include `overflow: auto`. 

This PR unsets the `overflow` property, thus fixing the `box-shadow` appearance.

| Before | After |
| --- | --- |
| ![tooltip without any box-shadow](https://github.com/user-attachments/assets/cce2eda4-718e-433c-ab51-76c575267d77) | ![tooltip with a prominent box-shadow](https://github.com/user-attachments/assets/705f1905-a38b-4452-b8e3-581db26d79ad) |