### PR TITLE
Use view transition to animate tabs

### DIFF
--- a/packages/kiwi-react/src/bricks/Tabs.css
+++ b/packages/kiwi-react/src/bricks/Tabs.css
@@ -65,14 +65,6 @@
 			inset-inline: 0;
 			inset-block: 0 calc(var(--🥝tab-active-stripe-gap) * -1);
 		}
-
-		&::after {
-			content: "";
-			position: absolute;
-			block-size: var(--✨active-tab-stripe-size);
-			inset-inline: var(--✨padding-inline);
-			inset-block: auto calc(var(--🥝tab-active-stripe-gap) * -1);
-		}
 	}
 
 	@layer modifiers {
@@ -109,6 +101,11 @@
 
 			/* This pseudo-element adds the active stripe */
 			&::after {
+				content: "";
+				position: absolute;
+				block-size: var(--✨active-tab-stripe-size);
+				inset-inline: var(--✨padding-inline);
+				inset-block: auto calc(var(--🥝tab-active-stripe-gap) * -1);
 				background-color: var(--🥝tab-active-stripe-color);
 
 				@media (prefers-reduced-motion: no-preference) {

--- a/packages/kiwi-react/src/bricks/Tabs.css
+++ b/packages/kiwi-react/src/bricks/Tabs.css
@@ -153,5 +153,12 @@
 }
 
 .🥝-tab-panel {
-	outline-offset: -2px;
+	@layer base {
+		outline-offset: -2px;
+
+		/* Prevents stacking when multiple panels are mounted (during animation) */
+		&:not([data-open]) {
+			display: none !important;
+		}
+	}
 }

--- a/packages/kiwi-react/src/bricks/Tabs.css
+++ b/packages/kiwi-react/src/bricks/Tabs.css
@@ -112,7 +112,7 @@
 				background-color: var(--🥝tab-active-stripe-color);
 
 				@media (prefers-reduced-motion: no-preference) {
-					view-transition-name: var(--kiwi-tabs-active-tab-view-transition-name);
+					view-transition-name: var(--🥝tab-active-stripe-view-transition-name);
 				}
 
 				@media (forced-colors: active) {

--- a/packages/kiwi-react/src/bricks/Tabs.css
+++ b/packages/kiwi-react/src/bricks/Tabs.css
@@ -103,10 +103,10 @@
 			&::after {
 				content: "";
 				position: absolute;
+				background-color: var(--🥝tab-active-stripe-color);
 				block-size: var(--✨active-tab-stripe-size);
 				inset-inline: var(--✨padding-inline);
 				inset-block: auto calc(var(--🥝tab-active-stripe-gap) * -1);
-				background-color: var(--🥝tab-active-stripe-color);
 
 				@media (prefers-reduced-motion: no-preference) {
 					view-transition-name: var(--🥝tab-active-stripe-view-transition-name);

--- a/packages/kiwi-react/src/bricks/Tabs.css
+++ b/packages/kiwi-react/src/bricks/Tabs.css
@@ -65,6 +65,14 @@
 			inset-inline: 0;
 			inset-block: 0 calc(var(--🥝tab-active-stripe-gap) * -1);
 		}
+
+		&::after {
+			content: "";
+			position: absolute;
+			block-size: var(--✨active-tab-stripe-size);
+			inset-inline: var(--✨padding-inline);
+			inset-block: auto calc(var(--🥝tab-active-stripe-gap) * -1);
+		}
 	}
 
 	@layer modifiers {
@@ -101,12 +109,8 @@
 
 			/* This pseudo-element adds the active stripe */
 			&::after {
-				content: "";
-				position: absolute;
 				background-color: var(--🥝tab-active-stripe-color);
-				block-size: var(--✨active-tab-stripe-size);
-				inset-inline: var(--✨padding-inline);
-				inset-block: auto calc(var(--🥝tab-active-stripe-gap) * -1);
+				view-transition-name: var(--kiwi-tabs-active-tab-view-transition-name);
 
 				@media (forced-colors: active) {
 					background-color: SelectedItem;

--- a/packages/kiwi-react/src/bricks/Tabs.css
+++ b/packages/kiwi-react/src/bricks/Tabs.css
@@ -110,7 +110,10 @@
 			/* This pseudo-element adds the active stripe */
 			&::after {
 				background-color: var(--🥝tab-active-stripe-color);
-				view-transition-name: var(--kiwi-tabs-active-tab-view-transition-name);
+
+				@media (prefers-reduced-motion: no-preference) {
+					view-transition-name: var(--kiwi-tabs-active-tab-view-transition-name);
+				}
 
 				@media (forced-colors: active) {
 					background-color: SelectedItem;

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -80,7 +80,7 @@ const TabList = React.forwardRef<
 			className={cx("🥝-tab-list", props.className)}
 			style={
 				{
-					"--kiwi-tabs-active-tab-view-transition-name": viewTransitionName,
+					"--🥝tab-active-stripe-view-transition-name": viewTransitionName,
 				} as React.CSSProperties
 			}
 			ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -39,17 +39,20 @@ function Tabs(props: TabsProps) {
 		<Ariakit.TabProvider
 			defaultSelectedId={defaultSelectedId}
 			selectedId={selectedId}
-			setSelectedId={(id) => {
-				if (document.startViewTransition) {
-					document.startViewTransition(() => {
-						ReactDOM.flushSync(() => {
-							setSelectedId(id);
+			setSelectedId={React.useCallback(
+				(id: Ariakit.TabStoreState["selectedId"]) => {
+					if (document.startViewTransition) {
+						document.startViewTransition(() => {
+							ReactDOM.flushSync(() => {
+								setSelectedId(id);
+							});
 						});
-					});
-				} else {
-					setSelectedId(id);
-				}
-			}}
+					} else {
+						setSelectedId(id);
+					}
+				},
+				[setSelectedId],
+			)}
 			selectOnMove={selectOnMove}
 		>
 			{children}

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -37,7 +37,6 @@ function Tabs(props: TabsProps) {
 
 	return (
 		<Ariakit.TabProvider
-			defaultSelectedId={defaultSelectedId}
 			selectedId={selectedId}
 			setSelectedId={React.useCallback(
 				(id: Ariakit.TabStoreState["selectedId"]) => {

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -118,14 +118,14 @@ const TabPanel = React.forwardRef<
 		tab,
 		() => props.tabId ?? tab?.panels.item(id)?.tabId,
 	);
-	const activeId = Ariakit.useStoreState(tab, "activeId");
+	const selectedId = Ariakit.useStoreState(tab, "selectedId");
 
 	return (
 		<Ariakit.TabPanel
 			{...props}
 			id={id}
 			tabId={tabId}
-			hidden={activeId !== tabId}
+			hidden={selectedId !== tabId}
 			alwaysVisible
 			className={cx("🥝-tab-panel", props.className)}
 			ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -111,9 +111,22 @@ const TabPanel = React.forwardRef<
 	React.ElementRef<typeof Ariakit.TabPanel>,
 	TabPanelProps
 >((props, forwardedRef) => {
+	const tab = Ariakit.useTabContext();
+	const defaultId = React.useId();
+	const id = props.id ?? defaultId;
+	const tabId = Ariakit.useStoreState(
+		tab,
+		() => props.tabId ?? tab?.panels.item(id)?.tabId,
+	);
+	const activeId = Ariakit.useStoreState(tab, "activeId");
+
 	return (
 		<Ariakit.TabPanel
 			{...props}
+			id={id}
+			tabId={tabId}
+			hidden={activeId !== tabId}
+			alwaysVisible
 			className={cx("🥝-tab-panel", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -71,9 +71,7 @@ const TabList = React.forwardRef<
 	TabListProps
 >((props, forwardedRef) => {
 	const { tone = "neutral", ...rest } = props;
-
-	const id = React.useId().replaceAll(":", "_");
-	const viewTransitionName = `kiwi-tabs-active-tab-${id}`;
+	const viewTransitionName = `🥝${React.useId().replaceAll(":", "_")}`;
 
 	return (
 		<Ariakit.TabList

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -23,10 +23,10 @@ interface TabsProps
 function Tabs(props: TabsProps) {
 	const {
 		defaultSelectedId,
-		selectOnMove,
-		children,
 		selectedId: selectedIdProp,
 		setSelectedId: setSelectedIdProp,
+		selectOnMove,
+		children,
 	} = props;
 
 	const [selectedId, setSelectedId] = useControlledState(

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -71,7 +71,7 @@ const TabList = React.forwardRef<
 	TabListProps
 >((props, forwardedRef) => {
 	const { tone = "neutral", ...rest } = props;
-	const viewTransitionName = `🥝${React.useId().replaceAll(":", "_")}`;
+	const viewTransitionName = `🥝active-stripe-${React.useId().replaceAll(":", "_")}`;
 
 	return (
 		<Ariakit.TabList

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -111,22 +111,9 @@ const TabPanel = React.forwardRef<
 	React.ElementRef<typeof Ariakit.TabPanel>,
 	TabPanelProps
 >((props, forwardedRef) => {
-	const tab = Ariakit.useTabContext();
-	const defaultId = React.useId();
-	const id = props.id ?? defaultId;
-	const tabId = Ariakit.useStoreState(
-		tab,
-		() => props.tabId ?? tab?.panels.item(id)?.tabId,
-	);
-	const selectedId = Ariakit.useStoreState(tab, "selectedId");
-
 	return (
 		<Ariakit.TabPanel
 			{...props}
-			id={id}
-			tabId={tabId}
-			hidden={selectedId !== tabId}
-			alwaysVisible
 			className={cx("🥝-tab-panel", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -21,12 +21,18 @@ interface TabsProps
 	> {}
 
 function Tabs(props: TabsProps) {
-	const { defaultSelectedId, selectOnMove, children } = props;
+	const {
+		defaultSelectedId,
+		selectOnMove,
+		children,
+		selectedId: selectedIdProp,
+		setSelectedId: setSelectedIdProp,
+	} = props;
 
 	const [selectedId, setSelectedId] = useControlledState(
 		defaultSelectedId,
-		props.selectedId,
-		props.setSelectedId,
+		selectedIdProp,
+		setSelectedIdProp,
 	);
 
 	return (


### PR DESCRIPTION
This implements view transitions to animate the line underneath the active tab. This is a progressive enhancement, so the animation — which isn’t vital — does not apply for [browsers that do not support view transitions](https://caniuse.com/?search=document.startViewTransition). For reduced motion, the view transition name is not set, but the view transition still occurs which animates the opacity — which isn’t motion.

**Animated:**

https://github.com/user-attachments/assets/59a9a983-27ad-4b09-a7c9-0f5f0ad8dd69

<details><summary>Animated video description</summary>
<p>The user clicks between the tabs and the underline slides over the selected tab. The tab panel content crossfades as its associated tab becomes selected.</p>
</details> 

**Animated (reduced motion):**

https://github.com/user-attachments/assets/a1843d9a-34e1-4611-9d9d-71a1a92db7fc

<details><summary>Animated reduced motion video description</summary>
<p>The user clicks between the tabs and the underline fades in under the selected tab and fade out under the previously selected tab. The tab panel content crossfades as its associated tab becomes selected.</p>
</details> 


**Fallback:**

https://github.com/user-attachments/assets/9c04ee9f-7403-4b40-9e2c-a52169631fde

<details><summary>Fallback video description</summary>
<p>The user clicks between the tabs and the underline immediately appears under the selected tab. The tab panel content cuts as its associated tab becomes selected.</p>
</details> 

## Implementation notes

- We need to generate a unique view transition name to be used by the tabs which we propagate to them using inheritance. Since the name is dynamic, we use a custom property on the `<Tabs.TabList>` element which the tabs use when they’re selected.
- View transitions need to call all of their relevant DOM updates synchronously. We use `ReactDOM.flushSync()` within the `document.startViewTransition()` call. We noticed that DOM updates to the tab panels were sometimes taking place asychronously which was causing layout shift that affected the tab underline animate (i.e. it would cause it to bump down and slide up in the transition). In order to get around this, we need to force `display: none` for tab panels that don’t have the `data-open` attribute set on them.

## Relevant tests

- For a simple test: `/tests/tabs`
- To observe that no layout shift is affecting the animation (and that disabled don’t animate): `/tests/tabs?visual=true`