### PR TITLE
set up custom `exports` conditions

### DIFF
--- a/apps/test-app/tsconfig.dev.json
+++ b/apps/test-app/tsconfig.dev.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"customConditions": ["@kiwi/source"]
+	}
+}

--- a/apps/test-app/vite.config.ts
+++ b/apps/test-app/vite.config.ts
@@ -13,6 +13,8 @@ import {
 	staticVariablesTransform,
 } from "internal/visitors.js";
 
+const isDev = process.env.NODE_ENV === "development";
+
 const basename = process.env.BASE_FOLDER
 	? `/${process.env.BASE_FOLDER}/`
 	: undefined;
@@ -51,6 +53,9 @@ export default defineConfig({
 	},
 	preview: {
 		port: 1800, // prod server port
+	},
+	resolve: {
+		conditions: isDev ? ["@kiwi/source"] : undefined,
 	},
 });
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
 	"scripts": {
 		"build": "pnpm --filter=\"./packages/**\" --filter=\"./apps/**\" build",
 		"build:icons": "pnpm --filter=@itwin/kiwi-icons build",
-		"dev": "npm run build:icons && npm run dev:app & npm run dev:ts &",
+		"dev": "npm run build:icons && npm run dev:app &",
 		"dev:app": "pnpm --filter=@itwin/test-app dev",
-		"dev:ts": "pnpm --filter=@itwin/kiwi-react dev",
 		"format": "biome format .",
 		"lint": "biome lint .",
 		"lint:copyright": "tsx internal/copyright-linter.ts",

--- a/packages/kiwi-react/package.json
+++ b/packages/kiwi-react/package.json
@@ -7,7 +7,7 @@
 	"sideEffects": false,
 	"exports": {
 		"./bricks": {
-			"development": "./src/bricks/index.ts",
+			"@kiwi/source": "./src/bricks/index.ts",
 			"default": "./dist/bricks/index.js"
 		},
 		"./package.json": "./package.json"


### PR DESCRIPTION
**Main change**: `kiwi-react/package.json` now exposes the uncompiled TS source to `test-app` using a custom `"@kiwi/source"` condition instead of the commonly used `"development"` condition. See [Node docs](https://nodejs.org/api/packages.html#resolving-user-conditions).

---

Previously we were (intentionally) misusing the `"development"` condition which allowed us to easily reference the uncompiled TS source without any extra configuration. This was a temporary measure and we cannot publish the package with this condition in place. Additionally, it required us to run `tsc` during `dev` to keep the types up-to-date (#18).

With a unique `"@kiwi/source"` condition:
- We will be able to publish to npm (Consuming applications will just ignore it).
- It frees up the `"development"` condition for proper use, i.e. adding development-only checks and warnings.
- The IDE experience is now improved so that type changes in the package source are instantly reflected in the test-app without even needing to save the file.
  - We do not need to run `tsc` during `dev` anymore. It just works automatically.

<details><summary>Screen recording of IDE experience</summary>

https://github.com/user-attachments/assets/0a3a39a6-c5ca-4d53-84a4-f8f8a8c95919

</details> 

---

To make this work, I had to configure two things:

1. Set up `resolve.conditions` in `test-app/vite.config.ts`. See [Vite docs](https://vite.dev/config/shared-options.html#resolve-conditions).
   - Detecting dev-only using `process.env.NODE_ENV`.
2. Set up `customConditions` in `test-app/tsconfig.dev.json`. See [TS docs](https://www.typescriptlang.org/tsconfig/#customConditions).
   - Faking dev-only using a new `tsconfig.dev.json` file (gets used by VSCode but ignored by `tsc` CLI, which looks for `tsconfig.json` when type-checking).