### PR TITLE
sandbox: add search icon to input

### DIFF
--- a/apps/test-app/app/routes/sandbox.tsx
+++ b/apps/test-app/app/routes/sandbox.tsx
@@ -465,11 +465,10 @@ function Subheader() {
 			</Ariakit.Role.h3>
 
 			{isSearching ? (
-				<TextBox.Input
-					className={styles.searchInput}
-					placeholder="Search"
-					ref={searchInputRef}
-				/>
+				<TextBox.Root className={styles.searchInput}>
+					<TextBox.Icon href={searchIcon} />
+					<TextBox.Input placeholder="Search" ref={searchInputRef} />
+				</TextBox.Root>
 			) : null}
 
 			<div className={styles.subheaderActions}>{actions}</div>

--- a/packages/kiwi-react/src/bricks/TextBox.css
+++ b/packages/kiwi-react/src/bricks/TextBox.css
@@ -31,6 +31,7 @@
 	@layer base {
 		cursor: var(--🥝text-box-cursor);
 		font-size: 0.75rem;
+		min-inline-size: 0;
 
 		min-block-size: var(--✨height);
 		padding-inline: var(--✨padding-inline);
@@ -74,6 +75,7 @@
 		:where(input, textarea) {
 			appearance: none;
 			line-height: 1.3; /* This is a safe value for Inter — lower values will be ignored. */
+			min-inline-size: 0;
 			border: 1px solid var(--🥝text-box-border-color);
 			cursor: var(--🥝text-box-cursor);
 			padding-block: var(--✨padding-block);


### PR DESCRIPTION
This PR adds the search icon decoration to the search field in sandbox (made possible by #110).

![](https://github.com/user-attachments/assets/f7f7c34c-b0cd-4c28-b473-439fe7ef2e45)

I noticed that when resizing the panel, the input was overflowing the left panel, so I needed to add `min-inline-size: 0` to the `<input>` (in order to reset the default min-width) and to the wrapper (see [below](https://github.com/iTwin/kiwi/pull/149#discussion_r1851354460)).