### PR TITLE
add Geist Mono font

### DIFF
--- a/apps/test-app/app/root.css
+++ b/apps/test-app/app/root.css
@@ -2,13 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-:root,
-:host {
-	--kiwi-font-family-sans: "InterVariable", "Inter", "Noto Sans", "Open Sans", sans-serif;
-	--kiwi-font-family-mono: "Geist Mono", "Noto Sans Mono", ui-monospace, "Segoe UI Mono", Consolas,
-		monospace;
-
-	--kiwi-font-size-s: 0.75rem; /* 12px */
-	--kiwi-font-size-m: 0.875rem; /* 14px */
-	--kiwi-font-size-l: 1rem; /* 16px */
+@font-face {
+	font-family: "Geist Mono";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 400;
+	src: url(https://cdn.jsdelivr.net/fontsource/fonts/geist-mono@latest/latin-400-normal.woff2)
+		format("woff2");
 }

--- a/apps/test-app/app/root.tsx
+++ b/apps/test-app/app/root.tsx
@@ -11,12 +11,14 @@ import {
 } from "@remix-run/react";
 import type { LinksFunction } from "@remix-run/node";
 import { Root } from "@itwin/kiwi-react/bricks";
+import globalStyles from "./root.css?url";
 
 export const links: LinksFunction = () => {
 	return [
 		{ rel: "icon", href: "/favicon.svg", sizes: "any", type: "image/svg+xml" },
 		{ rel: "preconnect", href: "https://rsms.me/" },
 		{ rel: "stylesheet", href: "https://rsms.me/inter/inter.css" },
+		{ rel: "stylesheet", href: globalStyles },
 	];
 };
 


### PR DESCRIPTION
It looks like the monospace font was updated in the Figma library (first noticed in #139).

- Changed `--kiwi-font-family-mono` variable to prefer "Geist Mono" font.
- Added Geist Mono font to test-app (linking to [FontSource package on CDN](https://fontsource.org/fonts/geist-mono/cdn))
  - I could have installed the package instead, but we can always do that in the future. We are currently also hotlinking Inter from the CDN.