### PR TITLE
migrate `test-app` to `react-router` v7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 # Build outputs
 dist
 build
+.react-router
 
 packages/kiwi-icons/icons-list.json
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,8 @@
 		"*.css": "${capture}.css.ts",
 		".gitignore": ".gitattributes",
 		"Dockerfile": ".dockerignore",
-		"lefthook.yml": "biome.jsonc, .prettierrc"
+		"lefthook.yml": "biome.jsonc, .prettierrc",
+		"vite.config.ts": "react-router.config.ts"
 	},
 	"javascript.preferences.importModuleSpecifierEnding": "js",
 	"typescript.preferences.importModuleSpecifierEnding": "js",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Packages:
 
 Apps:
 
-- [`test-app`](./apps/test-app): A [Remix](https://remix.run/) app for automated and manual testing.
+- [`test-app`](./apps/test-app): A [React Router](https://reactrouter.com/) app for automated and manual testing.
 
 Also, there’s [an internal package](./internal) which is used for configuration files and common variables for the workspace at large.
 

--- a/apps/test-app/README.md
+++ b/apps/test-app/README.md
@@ -1,6 +1,6 @@
 # test-app
 
-Test app built using [Remix](https://remix.run/).
+Test app built using [React Router](https://reactrouter.com/).
 
 ## Running the tests
 

--- a/apps/test-app/app/root.tsx
+++ b/apps/test-app/app/root.tsx
@@ -8,8 +8,8 @@ import {
 	Outlet,
 	Scripts,
 	ScrollRestoration,
-} from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/node";
+	type LinksFunction,
+} from "react-router";
 import { Root } from "@itwin/kiwi-react/bricks";
 import globalStyles from "./root.css?url";
 

--- a/apps/test-app/app/routes.ts
+++ b/apps/test-app/app/routes.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { RouteConfig } from "@react-router/dev/routes";
+import { createRoutesFromFolders } from "@remix-run/v1-route-convention";
+import { remixRoutesOptionAdapter } from "@react-router/remix-routes-option-adapter";
+
+export default remixRoutesOptionAdapter((defineRoutes) => {
+	// `createRoutesFromFolders` will follow the Remix v1 route convention.
+	// See https://remix.run/docs/en/v1/file-conventions/routes-files
+	return createRoutesFromFolders(defineRoutes, {
+		ignoredFilePatterns: ["**/*.spec.*", "**/*.css", "**/.DS_Store"],
+	});
+}) satisfies RouteConfig;

--- a/apps/test-app/app/routes/icons.tsx
+++ b/apps/test-app/app/routes/icons.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Icon, VisuallyHidden } from "@itwin/kiwi-react/bricks";
-import type { MetaFunction } from "@remix-run/react";
+import type { MetaFunction } from "react-router";
 import iconsListJson from "@itwin/kiwi-icons/icons-list.json";
 
 const title = "Kiwi icons";

--- a/apps/test-app/app/routes/index.tsx
+++ b/apps/test-app/app/routes/index.tsx
@@ -3,10 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import globalStyles from "./index.css?url";
-import { Link, type MetaFunction } from "@remix-run/react";
+import { Link, type MetaFunction, type LinksFunction } from "react-router";
 import { Anchor, Divider } from "@itwin/kiwi-react/bricks";
 import styles from "./index.module.css";
-import type { LinksFunction } from "@remix-run/node";
 
 const components = [
 	"Root",

--- a/apps/test-app/app/routes/sandbox.tsx
+++ b/apps/test-app/app/routes/sandbox.tsx
@@ -16,7 +16,7 @@ import {
 	VisuallyHidden,
 } from "@itwin/kiwi-react/bricks";
 import * as ListItem from "@itwin/kiwi-react-internal/src/bricks/ListItem.js";
-import type { MetaFunction } from "@remix-run/react";
+import type { MetaFunction } from "react-router";
 
 const title = "Kiwi sandbox";
 export const meta: MetaFunction = () => {

--- a/apps/test-app/app/routes/tests.tsx
+++ b/apps/test-app/app/routes/tests.tsx
@@ -4,8 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import globalStyles from "./tests.css?url";
 import { VisuallyHidden } from "@itwin/kiwi-react/bricks";
-import type { LinksFunction } from "@remix-run/node";
-import { Outlet, useMatches, type MetaFunction } from "@remix-run/react";
+import {
+	Outlet,
+	useMatches,
+	type MetaFunction,
+	type LinksFunction,
+} from "react-router";
 
 export const meta: MetaFunction = () => {
 	return [{ title: "Kiwi tests" }, { name: "color-scheme", content: "dark" }];

--- a/apps/test-app/app/routes/tests/anchor/index.tsx
+++ b/apps/test-app/app/routes/tests/anchor/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Anchor } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 export const handle = { title: "Anchor" };
 

--- a/apps/test-app/app/routes/tests/button/index.tsx
+++ b/apps/test-app/app/routes/tests/button/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Button, Icon } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 const placeholderIconHref = new URL(
 	"@itwin/kiwi-icons/placeholder.svg",

--- a/apps/test-app/app/routes/tests/checkbox/index.tsx
+++ b/apps/test-app/app/routes/tests/checkbox/index.tsx
@@ -8,7 +8,7 @@ import {
 	Label,
 	VisuallyHidden,
 } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 import { useId } from "react";
 
 export const handle = { title: "Checkbox" };

--- a/apps/test-app/app/routes/tests/divider/index.tsx
+++ b/apps/test-app/app/routes/tests/divider/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Divider } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 export const handle = { title: "Divider" };
 

--- a/apps/test-app/app/routes/tests/dropdown-menu/index.tsx
+++ b/apps/test-app/app/routes/tests/dropdown-menu/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { DropdownMenu } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 export const handle = { title: "DropdownMenu" };
 

--- a/apps/test-app/app/routes/tests/field/index.tsx
+++ b/apps/test-app/app/routes/tests/field/index.tsx
@@ -10,7 +10,7 @@ import {
 	Radio,
 	Switch,
 } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 export const handle = { title: "Field" };
 

--- a/apps/test-app/app/routes/tests/icon-button/index.tsx
+++ b/apps/test-app/app/routes/tests/icon-button/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { IconButton, Icon } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 const placeholderIcon = new URL(
 	"@itwin/kiwi-icons/placeholder.svg",

--- a/apps/test-app/app/routes/tests/icon/index.tsx
+++ b/apps/test-app/app/routes/tests/icon/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Icon } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 export const handle = { title: "Icon" };
 

--- a/apps/test-app/app/routes/tests/list/index.tsx
+++ b/apps/test-app/app/routes/tests/list/index.tsx
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as ListItem from "@itwin/kiwi-react-internal/src/bricks/ListItem";
 import { Icon } from "@itwin/kiwi-react-internal/src/bricks/Icon";
-import { useSearchParams } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/node";
+import { useSearchParams, type LinksFunction } from "react-router";
 import testStyles from "./index.css?url";
 
 export const handle = { title: "List" };

--- a/apps/test-app/app/routes/tests/radio/index.tsx
+++ b/apps/test-app/app/routes/tests/radio/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Radio, Label, VisuallyHidden, Field } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 import { useId } from "react";
 
 export const handle = { title: "Radio" };

--- a/apps/test-app/app/routes/tests/switch/index.tsx
+++ b/apps/test-app/app/routes/tests/switch/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Switch, Label, VisuallyHidden, Field } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 import { useId } from "react";
 
 export const handle = { title: "Switch" };

--- a/apps/test-app/app/routes/tests/tabs/index.tsx
+++ b/apps/test-app/app/routes/tests/tabs/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Tabs } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 export const handle = { title: "Tabs" };
 

--- a/apps/test-app/app/routes/tests/text-box/index.tsx
+++ b/apps/test-app/app/routes/tests/text-box/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { TextBox, Label, Field } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 import { useId } from "react";
 
 export const handle = { title: "TextBox" };

--- a/apps/test-app/app/routes/tests/textarea/index.tsx
+++ b/apps/test-app/app/routes/tests/textarea/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Field, Label, TextBox } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 import { useId } from "react";
 
 export const handle = { title: "Textarea" };

--- a/apps/test-app/app/routes/tests/tooltip/index.tsx
+++ b/apps/test-app/app/routes/tests/tooltip/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Tooltip, Button, VisuallyHidden } from "@itwin/kiwi-react/bricks";
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 
 export const handle = { title: "Tooltip" };
 

--- a/apps/test-app/app/routes/tests/tree/index.tsx
+++ b/apps/test-app/app/routes/tests/tree/index.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { useSearchParams } from "@remix-run/react";
+import { useSearchParams } from "react-router";
 import { Icon, IconButton, Tree } from "@itwin/kiwi-react/bricks";
 import React from "react";
 

--- a/apps/test-app/app/routes/tokens.tsx
+++ b/apps/test-app/app/routes/tokens.tsx
@@ -5,12 +5,11 @@
 import globalStyles from "./tokens.css?url";
 import * as Ariakit from "@ariakit/react";
 import type * as React from "react";
-import type { MetaFunction } from "@remix-run/react";
+import type { MetaFunction, LinksFunction } from "react-router";
 import { Button, Divider, Icon } from "@itwin/kiwi-react/bricks";
 import { parseTokens } from "internal/visitors.js";
 import rawTokens from "internal/theme-dark.json";
 import styles from "./tokens.module.css";
-import type { LinksFunction } from "@remix-run/node";
 
 const colorTokens = parseTokens(rawTokens.color);
 const shadowTokens = parseTokens(rawTokens.shadow);

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -4,27 +4,27 @@
 	"sideEffects": false,
 	"type": "module",
 	"scripts": {
-		"build": "remix vite:build && tsc",
-		"dev": "remix vite:dev",
+		"build": "react-router typegen && react-router build && tsc",
+		"dev": "react-router dev",
 		"preview": "vite preview",
 		"test": "tsx ./scripts/run-tests.cts pnpm exec playwright test",
-		"typecheck": "tsc"
+		"typecheck": "react-router typegen && tsc"
 	},
 	"dependencies": {
 		"@ariakit/react": "*",
 		"@itwin/kiwi-icons": "*",
 		"@itwin/kiwi-react": "*",
-		"@remix-run/node": "^2.14.0",
-		"@remix-run/react": "^2.14.0",
-		"@remix-run/serve": "^2.14.0",
+		"@react-router/node": "^7.0.1",
 		"isbot": "^5.1.17",
 		"react": "18",
-		"react-dom": "18"
+		"react-dom": "18",
+		"react-router": "^7.0.1"
 	},
 	"devDependencies": {
 		"@axe-core/playwright": "^4.10.1",
 		"@playwright/test": "~1.49.0",
-		"@remix-run/dev": "^2.14.0",
+		"@react-router/dev": "^7.0.1",
+		"@react-router/remix-routes-option-adapter": "^7.0.1",
 		"@remix-run/v1-route-convention": "^0.1.4",
 		"@types/node": "*",
 		"@types/react": "*",

--- a/apps/test-app/react-router.config.ts
+++ b/apps/test-app/react-router.config.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { reactRouterConfig } from "./vite.config.js";
+
+export default reactRouterConfig;

--- a/apps/test-app/tsconfig.json
+++ b/apps/test-app/tsconfig.json
@@ -5,11 +5,12 @@
 		"**/.server/**/*.ts",
 		"**/.server/**/*.tsx",
 		"**/.client/**/*.ts",
-		"**/.client/**/*.tsx"
+		"**/.client/**/*.tsx",
+		".react-router/types/**/*"
 	],
 	"compilerOptions": {
 		"lib": ["DOM", "DOM.Iterable", "ES2022"],
-		"types": ["@remix-run/node", "vite/client"],
+		"types": ["@react-router/node", "vite/client"],
 		"isolatedModules": true,
 		"esModuleInterop": true,
 		"jsx": "react-jsx",
@@ -26,6 +27,7 @@
 			"~/*": ["./app/*"],
 			"@itwin/kiwi-react-internal/*": ["./node_modules/@itwin/kiwi-react/*"]
 		},
+		"rootDirs": [".", "./.react-router/types"],
 
 		// Vite takes care of building everything, not tsc.
 		"noEmit": true

--- a/apps/test-app/vite.config.ts
+++ b/apps/test-app/vite.config.ts
@@ -2,11 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { vitePlugin as remix } from "@remix-run/dev";
+import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig, type Plugin } from "vite";
+import type { Config as ReactRouterConfig } from "@react-router/dev/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 import * as lightningcss from "lightningcss";
-import { createRoutesFromFolders } from "@remix-run/v1-route-convention";
 import {
 	primitivesTransform,
 	themeTransform,
@@ -19,31 +19,16 @@ const basename = process.env.BASE_FOLDER
 	? `/${process.env.BASE_FOLDER}/`
 	: undefined;
 
+// https://reactrouter.com/explanation/special-files#react-routerconfigts
+export const reactRouterConfig = {
+	...(basename && { basename }),
+	ssr: false, // SPA mode for github-pages
+} satisfies ReactRouterConfig;
+
+// https://vite.dev/config/
 export default defineConfig({
 	...(basename && { base: basename }),
-	plugins: [
-		remix({
-			...(basename && { basename }),
-			future: {
-				v3_fetcherPersist: true,
-				v3_relativeSplatPath: true,
-				v3_throwAbortReason: true,
-				v3_lazyRouteDiscovery: true,
-				v3_singleFetch: true,
-			},
-			ignoredRouteFiles: ["**/*"], // Ignore default Remix v2 file conventions.
-			routes: (defineRoutes) => {
-				// `createRoutesFromFolders` will follow the Remix v1 route convention.
-				// See https://remix.run/docs/en/v1/file-conventions/routes-files
-				return createRoutesFromFolders(defineRoutes, {
-					ignoredFilePatterns: ["**/*.spec.*", "**/*.css", "**/.DS_Store"],
-				});
-			},
-			ssr: false, // SPA mode for github-pages
-		}),
-		tsconfigPaths(),
-		bundleCssPlugin(),
-	],
+	plugins: [reactRouter(), tsconfigPaths(), bundleCssPlugin()],
 	build: {
 		assetsInlineLimit: (filePath) => {
 			if (filePath.includes("kiwi-icons/icons")) return false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,15 +43,9 @@ importers:
       "@itwin/kiwi-react":
         specifier: "*"
         version: link:../../packages/kiwi-react
-      "@remix-run/node":
-        specifier: ^2.14.0
-        version: 2.14.0(typescript@5.6.3)
-      "@remix-run/react":
-        specifier: ^2.14.0
-        version: 2.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      "@remix-run/serve":
-        specifier: ^2.14.0
-        version: 2.14.0(typescript@5.6.3)
+      "@react-router/node":
+        specifier: ^7.0.1
+        version: 7.0.1(react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       isbot:
         specifier: ^5.1.17
         version: 5.1.17
@@ -61,6 +55,9 @@ importers:
       react-dom:
         specifier: "18"
         version: 18.3.1(react@18.3.1)
+      react-router:
+        specifier: ^7.0.1
+        version: 7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       "@axe-core/playwright":
         specifier: ^4.10.1
@@ -68,9 +65,12 @@ importers:
       "@playwright/test":
         specifier: ~1.49.0
         version: 1.49.0
-      "@remix-run/dev":
-        specifier: ^2.14.0
-        version: 2.14.0(@remix-run/react@2.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@remix-run/serve@2.14.0(typescript@5.6.3))(@types/node@22.9.1)(lightningcss@1.28.1)(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(lightningcss@1.28.1))
+      "@react-router/dev":
+        specifier: ^7.0.1
+        version: 7.0.1(@types/node@22.9.1)(lightningcss@1.28.1)(react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(lightningcss@1.28.1))
+      "@react-router/remix-routes-option-adapter":
+        specifier: ^7.0.1
+        version: 7.0.1(@react-router/dev@7.0.1(@types/node@22.9.1)(lightningcss@1.28.1)(react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(lightningcss@1.28.1)))(typescript@5.6.3)
       "@remix-run/v1-route-convention":
         specifier: ^0.1.4
         version: 0.1.4(@remix-run/dev@2.14.0(@remix-run/react@2.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@remix-run/serve@2.14.0(typescript@5.6.3))(@types/node@22.9.1)(lightningcss@1.28.1)(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(lightningcss@1.28.1)))
@@ -1403,6 +1403,12 @@ packages:
         integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==,
       }
 
+  "@mjackson/node-fetch-server@0.2.0":
+    resolution:
+      {
+        integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==,
+      }
+
   "@nodelib/fs.scandir@2.1.5":
     resolution:
       {
@@ -1466,6 +1472,53 @@ packages:
       }
     engines: { node: ">=18" }
     hasBin: true
+
+  "@react-router/dev@7.0.1":
+    resolution:
+      {
+        integrity: sha512-7B9xUb/5um3Pe/zqpObQP/Yhypw49q6CFxn7NWWS78DJnuO7axXuH4IerrMLIiqv+8Ft0uo3UQVj+ztTr0T2+w==,
+      }
+    engines: { node: ">=20.0.0" }
+    hasBin: true
+    peerDependencies:
+      "@react-router/serve": ^7.0.1
+      react-router: ^7.0.1
+      typescript: ^5.1.0
+      vite: ^5.1.0
+      wrangler: ^3.28.2
+    peerDependenciesMeta:
+      "@react-router/serve":
+        optional: true
+      typescript:
+        optional: true
+      wrangler:
+        optional: true
+
+  "@react-router/node@7.0.1":
+    resolution:
+      {
+        integrity: sha512-09AkG1jobbMApTx4Wx8lf1u+nZeYG2ZOBAhxTLz7dgnr7sQpUVD3ewe9gizedXpJrCfP4Sx272aGywX1gEqoSQ==,
+      }
+    engines: { node: ">=20.0.0" }
+    peerDependencies:
+      react-router: 7.0.1
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  "@react-router/remix-routes-option-adapter@7.0.1":
+    resolution:
+      {
+        integrity: sha512-qdKyO+Xp4Me05rs1lz+F1LuyOTSeTQoVBrQoRSsHh5c48mlMBoUVERT1HCzLYwGUKQ2sbyBreL+gUCMtCfmerw==,
+      }
+    engines: { node: ">=20.0.0" }
+    peerDependencies:
+      "@react-router/dev": ^7.0.1
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   "@remix-run/dev@2.14.0":
     resolution:
@@ -1970,6 +2023,12 @@ packages:
       }
     engines: { node: ">=4" }
 
+  babel-dead-code-elimination@1.0.6:
+    resolution:
+      {
+        integrity: sha512-JxFi9qyRJpN0LjEbbjbN8g0ux71Qppn9R8Qe3k6QzHg2CaKsbUQtbn307LQGiDLGjV6JCtEFqfxzVig9MyDCHQ==,
+      }
+
   bail@2.0.2:
     resolution:
       {
@@ -2132,6 +2191,13 @@ packages:
       }
     engines: { node: ">= 8.10.0" }
 
+  chokidar@4.0.1:
+    resolution:
+      {
+        integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==,
+      }
+    engines: { node: ">= 14.16.0" }
+
   chownr@1.1.4:
     resolution:
       {
@@ -2257,6 +2323,13 @@ packages:
         integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==,
       }
     engines: { node: ">= 0.6" }
+
+  cookie@1.0.2:
+    resolution:
+      {
+        integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==,
+      }
+    engines: { node: ">=18" }
 
   core-util-is@1.0.3:
     resolution:
@@ -4453,6 +4526,19 @@ packages:
     peerDependencies:
       react: ">=16.8"
 
+  react-router@7.0.1:
+    resolution:
+      {
+        integrity: sha512-WVAhv9oWCNsja5AkK6KLpXJDSJCQizOIyOd4vvB/+eHGbYx5vkhcmcmwWjQ9yqkRClogi+xjEg9fNEOd5EX/tw==,
+      }
+    engines: { node: ">=20.0.0" }
+    peerDependencies:
+      react: ">=18"
+      react-dom: ">=18"
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@18.3.1:
     resolution:
       {
@@ -4479,6 +4565,13 @@ packages:
         integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
       }
     engines: { node: ">=8.10.0" }
+
+  readdirp@4.0.2:
+    resolution:
+      {
+        integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==,
+      }
+    engines: { node: ">= 14.16.0" }
 
   regenerator-runtime@0.14.1:
     resolution:
@@ -5916,6 +6009,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@mjackson/node-fetch-server@0.2.0": {}
+
   "@nodelib/fs.scandir@2.1.5":
     dependencies:
       "@nodelib/fs.stat": 2.0.5
@@ -5967,6 +6062,70 @@ snapshots:
   "@playwright/test@1.49.0":
     dependencies:
       playwright: 1.49.0
+
+  "@react-router/dev@7.0.1(@types/node@22.9.1)(lightningcss@1.28.1)(react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(lightningcss@1.28.1))":
+    dependencies:
+      "@babel/core": 7.26.0
+      "@babel/generator": 7.26.2
+      "@babel/parser": 7.26.2
+      "@babel/plugin-syntax-decorators": 7.25.9(@babel/core@7.26.0)
+      "@babel/plugin-syntax-jsx": 7.25.9(@babel/core@7.26.0)
+      "@babel/preset-typescript": 7.26.0(@babel/core@7.26.0)
+      "@babel/traverse": 7.25.9
+      "@babel/types": 7.26.0
+      "@npmcli/package-json": 4.0.1
+      "@react-router/node": 7.0.1(react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      arg: 5.0.2
+      babel-dead-code-elimination: 1.0.6
+      chokidar: 4.0.1
+      dedent: 1.5.3
+      es-module-lexer: 1.5.4
+      exit-hook: 2.2.1
+      fs-extra: 10.1.0
+      gunzip-maybe: 1.4.2
+      jsesc: 3.0.2
+      lodash: 4.17.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      picomatch: 2.3.1
+      prettier: 2.8.8
+      react-refresh: 0.14.2
+      react-router: 7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      semver: 7.6.3
+      set-cookie-parser: 2.7.1
+      valibot: 0.41.0(typescript@5.6.3)
+      vite: 5.4.11(@types/node@22.9.1)(lightningcss@1.28.1)
+      vite-node: 1.6.0(@types/node@22.9.1)(lightningcss@1.28.1)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - "@types/node"
+      - babel-plugin-macros
+      - bluebird
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  "@react-router/node@7.0.1(react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)":
+    dependencies:
+      "@mjackson/node-fetch-server": 0.2.0
+      react-router: 7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      source-map-support: 0.5.21
+      stream-slice: 0.1.2
+      undici: 6.21.0
+    optionalDependencies:
+      typescript: 5.6.3
+
+  "@react-router/remix-routes-option-adapter@7.0.1(@react-router/dev@7.0.1(@types/node@22.9.1)(lightningcss@1.28.1)(react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(lightningcss@1.28.1)))(typescript@5.6.3)":
+    dependencies:
+      "@react-router/dev": 7.0.1(@types/node@22.9.1)(lightningcss@1.28.1)(react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(lightningcss@1.28.1))
+    optionalDependencies:
+      typescript: 5.6.3
 
   "@remix-run/dev@2.14.0(@remix-run/react@2.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@remix-run/serve@2.14.0(typescript@5.6.3))(@types/node@22.9.1)(lightningcss@1.28.1)(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(lightningcss@1.28.1))":
     dependencies:
@@ -6052,6 +6211,7 @@ snapshots:
       express: 4.21.1
     optionalDependencies:
       typescript: 5.6.3
+    optional: true
 
   "@remix-run/node@2.14.0(typescript@5.6.3)":
     dependencies:
@@ -6092,13 +6252,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    optional: true
 
   "@remix-run/server-runtime@2.14.0(typescript@5.6.3)":
     dependencies:
       "@remix-run/router": 1.21.0
       "@types/cookie": 0.6.0
       "@web3-storage/multipart-parser": 1.0.0
-      cookie: 0.7.1
+      cookie: 1.0.2
       set-cookie-parser: 2.7.1
       source-map: 0.7.4
       turbo-stream: 2.4.0
@@ -6343,6 +6504,15 @@ snapshots:
 
   axe-core@4.10.2: {}
 
+  babel-dead-code-elimination@1.0.6:
+    dependencies:
+      "@babel/core": 7.26.0
+      "@babel/parser": 7.26.2
+      "@babel/traverse": 7.25.9
+      "@babel/types": 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -6352,6 +6522,7 @@ snapshots:
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
+    optional: true
 
   binary-extensions@2.3.0: {}
 
@@ -6460,6 +6631,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.1:
+    dependencies:
+      readdirp: 4.0.2
+
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
@@ -6487,6 +6662,7 @@ snapshots:
   compressible@2.0.18:
     dependencies:
       mime-db: 1.53.0
+    optional: true
 
   compression@1.7.5:
     dependencies:
@@ -6499,6 +6675,7 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   confbox@0.1.8: {}
 
@@ -6515,6 +6692,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.1: {}
+
+  cookie@1.0.2: {}
 
   core-util-is@1.0.3: {}
 
@@ -7588,7 +7767,8 @@ snapshots:
 
   mime-db@1.52.0: {}
 
-  mime-db@1.53.0: {}
+  mime-db@1.53.0:
+    optional: true
 
   mime-types@2.1.35:
     dependencies:
@@ -7655,6 +7835,7 @@ snapshots:
       on-headers: 1.0.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   mri@1.2.0: {}
 
@@ -7668,7 +7849,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  negotiator@0.6.4: {}
+  negotiator@0.6.4:
+    optional: true
 
   node-releases@2.0.18: {}
 
@@ -7710,12 +7892,14 @@ snapshots:
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
+    optional: true
 
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
 
-  on-headers@1.0.2: {}
+  on-headers@1.0.2:
+    optional: true
 
   once@1.4.0:
     dependencies:
@@ -7951,6 +8135,16 @@ snapshots:
       "@remix-run/router": 1.21.0
       react: 18.3.1
 
+  react-router@7.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      "@types/cookie": 0.6.0
+      cookie: 1.0.2
+      react: 18.3.1
+      set-cookie-parser: 2.7.1
+      turbo-stream: 2.4.0
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7974,6 +8168,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.0.2: {}
 
   regenerator-runtime@0.14.1: {}
 


### PR DESCRIPTION
[React Router v7](https://remix.run/blog/react-router-v7) is now available as a stable release. (It's basically Remix v3)

This PR is pretty much a replay of https://github.com/iTwin/kiwi/pull/105 with two main differences:
- Now using React Router v7 stable (instead of prerelease).
- Not using [prerendering](https://reactrouter.com/how-to/pre-rendering) (it was buggy last time).

Since we are having trouble with hosting the test-app on gh-pages, I figured it would be a good time to try this upgrade again, in case it helps us resolve the issues. It hasn't been fixed by this PR (I assume it was caused by the future flags in #145), but we can look at it in a separate PR.

Afaict, there is no real difference in behavior before/after this PR. But it's good to use React Router v7, as it unlocks new features. I'm interested in pre-rendering (obviously) and in declarative route configuration (which might help us reduce directory nesting).