### PR TITLE
use non-standard icon imports for SSR

### DIFF
--- a/apps/test-app/app/routes/icons.tsx
+++ b/apps/test-app/app/routes/icons.tsx
@@ -6,16 +6,19 @@ import { Icon, VisuallyHidden } from "@itwin/kiwi-react/bricks";
 import type { MetaFunction } from "react-router";
 import iconsListJson from "@itwin/kiwi-icons/icons-list.json";
 
+const allIcons = import.meta.glob(
+	"../../node_modules/@itwin/kiwi-icons/icons/*.svg",
+	{ eager: true },
+);
+
 const title = "Kiwi icons";
 export const meta: MetaFunction = () => {
 	return [{ title }, { name: "color-scheme", content: "dark" }];
 };
 
 function getIconHref(icon: string) {
-	return new URL(
-		`../../node_modules/@itwin/kiwi-icons/icons/${icon}`,
-		import.meta.url,
-	).href;
+	const module = allIcons[`../../node_modules/@itwin/kiwi-icons/icons/${icon}`];
+	return (module as { default: string })?.default;
 }
 
 export default function Page() {

--- a/apps/test-app/app/routes/sandbox.tsx
+++ b/apps/test-app/app/routes/sandbox.tsx
@@ -17,30 +17,17 @@ import {
 } from "@itwin/kiwi-react/bricks";
 import * as ListItem from "@itwin/kiwi-react-internal/src/bricks/ListItem.js";
 import type { MetaFunction } from "react-router";
+import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
+import searchIcon from "@itwin/kiwi-icons/search.svg";
+import panelLeftIcon from "@itwin/kiwi-icons/panel-left.svg";
+import filterIcon from "@itwin/kiwi-icons/filter.svg";
+import dismissIcon from "@itwin/kiwi-icons/dismiss.svg";
+import chevronDown from "@itwin/kiwi-icons/chevron-down.svg";
 
 const title = "Kiwi sandbox";
 export const meta: MetaFunction = () => {
 	return [{ title }, { name: "color-scheme", content: "dark" }];
 };
-
-const placeholderIcon = new URL(
-	"@itwin/kiwi-icons/placeholder.svg",
-	import.meta.url,
-).href;
-const searchIcon = new URL("@itwin/kiwi-icons/search.svg", import.meta.url)
-	.href;
-const panelLeftIcon = new URL(
-	"@itwin/kiwi-icons/panel-left.svg",
-	import.meta.url,
-).href;
-const filterIcon = new URL("@itwin/kiwi-icons/filter.svg", import.meta.url)
-	.href;
-const dismissIcon = new URL("@itwin/kiwi-icons/dismiss.svg", import.meta.url)
-	.href;
-const chevronDown = new URL(
-	"@itwin/kiwi-icons/chevron-down.svg",
-	import.meta.url,
-).href;
 
 const leftPanelLabelId = "left-panel";
 

--- a/apps/test-app/app/routes/tests/button/index.tsx
+++ b/apps/test-app/app/routes/tests/button/index.tsx
@@ -4,11 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { Button, Icon } from "@itwin/kiwi-react/bricks";
 import { useSearchParams } from "react-router";
-
-const placeholderIconHref = new URL(
-	"@itwin/kiwi-icons/placeholder.svg",
-	import.meta.url,
-).href;
+import placeholderIconHref from "@itwin/kiwi-icons/placeholder.svg";
 
 export const handle = { title: "Button" };
 

--- a/apps/test-app/app/routes/tests/icon-button/index.tsx
+++ b/apps/test-app/app/routes/tests/icon-button/index.tsx
@@ -4,11 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { IconButton, Icon } from "@itwin/kiwi-react/bricks";
 import { useSearchParams } from "react-router";
-
-const placeholderIcon = new URL(
-	"@itwin/kiwi-icons/placeholder.svg",
-	import.meta.url,
-).href;
+import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
 
 export const handle = { title: "IconButton" };
 

--- a/apps/test-app/app/routes/tests/icon/index.tsx
+++ b/apps/test-app/app/routes/tests/icon/index.tsx
@@ -4,13 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import { Icon } from "@itwin/kiwi-react/bricks";
 import { useSearchParams } from "react-router";
+import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
 
 export const handle = { title: "Icon" };
-
-const placeholderIcon = new URL(
-	"@itwin/kiwi-icons/placeholder.svg",
-	import.meta.url,
-).href;
 
 export default function Page() {
 	const size = useSizeParam();

--- a/apps/test-app/app/routes/tests/list/index.tsx
+++ b/apps/test-app/app/routes/tests/list/index.tsx
@@ -6,17 +6,13 @@ import * as ListItem from "@itwin/kiwi-react-internal/src/bricks/ListItem";
 import { Icon } from "@itwin/kiwi-react-internal/src/bricks/Icon";
 import { useSearchParams, type LinksFunction } from "react-router";
 import testStyles from "./index.css?url";
+import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
 
 export const handle = { title: "List" };
 
 export const links: LinksFunction = () => [
 	{ rel: "stylesheet", href: testStyles },
 ];
-
-const placeholderIcon = new URL(
-	"@itwin/kiwi-icons/placeholder.svg",
-	import.meta.url,
-).href;
 
 export default function Page() {
 	const [searchParams] = useSearchParams();

--- a/apps/test-app/app/routes/tests/text-box/index.tsx
+++ b/apps/test-app/app/routes/tests/text-box/index.tsx
@@ -5,13 +5,9 @@
 import { TextBox, Label, Field } from "@itwin/kiwi-react/bricks";
 import { useSearchParams } from "react-router";
 import { useId } from "react";
+import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
 
 export const handle = { title: "TextBox" };
-
-const placeholderIcon = new URL(
-	"@itwin/kiwi-icons/placeholder.svg",
-	import.meta.url,
-).href;
 
 function TextAffix({ children }: React.PropsWithChildren) {
 	return (


### PR DESCRIPTION
Replaces all instances of `new URL("….svg", import.meta.url)` with [Vite's asset import syntax](https://vite.dev/guide/assets.html#importing-asset-as-url) (i.e. `import icon from "….svg";`).

This is to support SSR/pre-rendering (in #156), which is [not supported](https://vite.dev/guide/assets.html#new-url-url-import-meta-url:~:text=Does%20not%20work%20with%20SSR) by Vite when using `import.meta.url`