### PR TITLE
Avoid shrinking `Icon` when in a flex container

### DIFF
--- a/packages/kiwi-react/src/bricks/Icon.css
+++ b/packages/kiwi-react/src/bricks/Icon.css
@@ -6,6 +6,7 @@
 	@layer base {
 		width: var(--🥝icon-size);
 		height: var(--🥝icon-size);
+		flex-shrink: 0;
 		color: var(--🥝icon-color);
 		transition: color 150ms ease-out;
 	}


### PR DESCRIPTION
Change the default [flex-shrink](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink#formal_definition) value of an `Icon` to avoid resize in a flex container.