### PR TITLE
create base fixture for more reliable tests

### DIFF
--- a/apps/test-app/app/root.tsx
+++ b/apps/test-app/app/root.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
 import {
 	Links,
 	Meta,
@@ -41,6 +42,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+	React.useEffect(function signalPageLoad() {
+		document.body.dataset.loaded = "true";
+	}, []);
+
 	return (
 		<Root>
 			<Outlet />

--- a/apps/test-app/app/routes/tests/anchor/index.spec.ts
+++ b/apps/test-app/app/routes/tests/anchor/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/button/index.spec.ts
+++ b/apps/test-app/app/routes/tests/button/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/checkbox/index.spec.ts
+++ b/apps/test-app/app/routes/tests/checkbox/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/divider/index.spec.ts
+++ b/apps/test-app/app/routes/tests/divider/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/dropdown-menu/index.spec.ts
+++ b/apps/test-app/app/routes/tests/dropdown-menu/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/field/index.spec.ts
+++ b/apps/test-app/app/routes/tests/field/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test.describe("default", () => {

--- a/apps/test-app/app/routes/tests/icon-button/index.spec.ts
+++ b/apps/test-app/app/routes/tests/icon-button/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/icon/index.spec.ts
+++ b/apps/test-app/app/routes/tests/icon/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/list/index.spec.ts
+++ b/apps/test-app/app/routes/tests/list/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/radio/index.spec.ts
+++ b/apps/test-app/app/routes/tests/radio/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/root/index.spec.ts
+++ b/apps/test-app/app/routes/tests/root/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/switch/index.spec.ts
+++ b/apps/test-app/app/routes/tests/switch/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/tabs/index.spec.ts
+++ b/apps/test-app/app/routes/tests/tabs/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/text-box/index.spec.ts
+++ b/apps/test-app/app/routes/tests/text-box/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 function toUrl(urlStr: string, type: "input" | "composition") {

--- a/apps/test-app/app/routes/tests/textarea/index.spec.ts
+++ b/apps/test-app/app/routes/tests/textarea/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/app/routes/tests/tooltip/index.spec.ts
+++ b/apps/test-app/app/routes/tests/tooltip/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test.describe("default", () => {

--- a/apps/test-app/app/routes/tests/tree/index.spec.ts
+++ b/apps/test-app/app/routes/tests/tree/index.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { test, expect } from "@playwright/test";
+import { test, expect } from "#playwright";
 import AxeBuilder from "@axe-core/playwright";
 
 test("default", async ({ page }) => {

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -10,6 +10,9 @@
 		"test": "tsx ./scripts/run-tests.cts pnpm exec playwright test",
 		"typecheck": "react-router typegen && tsc"
 	},
+	"imports": {
+		"#playwright": "./playwright.config.ts"
+	},
 	"dependencies": {
 		"@ariakit/react": "*",
 		"@itwin/kiwi-icons": "*",

--- a/apps/test-app/playwright.config.ts
+++ b/apps/test-app/playwright.config.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices, test as base } from "@playwright/test";
 
 /** See https://playwright.dev/docs/test-configuration. */
 export default defineConfig({
@@ -57,3 +57,17 @@ export default defineConfig({
 		},
 	},
 });
+
+export const test = base.extend({
+	page: async ({ page }, use) => {
+		const _goto = page.goto;
+		page.goto = async (url, options) => {
+			const result = await _goto.call(page, url, options);
+			await page.waitForSelector("body[data-loaded]", { timeout: 5000 });
+			return result;
+		};
+		await use(page);
+	},
+});
+
+export { expect } from "@playwright/test";


### PR DESCRIPTION
This PR defines a base [playwright fixture](https://playwright.dev/docs/test-fixtures), made available to all tests using [package imports](https://nodejs.org/api/packages.html#imports). This fixture overrides the `page.goto` function to wait for the `data-loaded` attribute, which gets added on the `<body>` element of every route in `test-app`. This helps ensure that test logic never runs too early.

All tests will now import `test` and `expect` from `#playwright` instead of `@playwright/test`.

**Note**: I also tried using a custom event instead of a data attribute, but found it unreliable because the event might be dispatched too early before playwright starts listening for it.