### PR TITLE
exclude `defaultValue` prop from `Checkbox`, `Radio` and `Switch`

### DIFF
--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -7,7 +7,8 @@ import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
 import { useFieldId } from "./Field.js";
 
-interface CheckboxProps extends Omit<Ariakit.CheckboxProps, "store"> {}
+interface CheckboxProps
+	extends Omit<Ariakit.CheckboxProps, "store" | "defaultValue"> {}
 
 export const Checkbox = React.forwardRef<
 	React.ElementRef<typeof Ariakit.Checkbox>,

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -7,7 +7,8 @@ import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
 import { useFieldId } from "./Field.js";
 
-interface RadioProps extends Omit<Ariakit.RadioProps, "store"> {}
+interface RadioProps
+	extends Omit<Ariakit.RadioProps, "store" | "defaultValue"> {}
 
 export const Radio = React.forwardRef<
 	React.ElementRef<typeof Ariakit.Radio>,

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -7,7 +7,8 @@ import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
 import { useFieldId } from "./Field.js";
 
-interface SwitchProps extends Omit<Ariakit.CheckboxProps, "store"> {
+interface SwitchProps
+	extends Omit<Ariakit.CheckboxProps, "store" | "defaultValue"> {
 	/** The default checked state of the toggle switch. */
 	defaultChecked?: boolean;
 	/** The controlled checked state of the toggle switch. */


### PR DESCRIPTION
Excluded `defaultValue` because it's intended for text inputs and causes confusion when used on checkable controls. See https://github.com/iTwin/kiwi/pull/135#discussion_r1838676423