### PR TITLE
require React 18 as peer dep

### DIFF
--- a/packages/kiwi-react/package.json
+++ b/packages/kiwi-react/package.json
@@ -51,7 +51,7 @@
 		"typescript": "5"
 	},
 	"peerDependencies": {
-		"react": ">=17.0.0",
-		"react-dom": ">=17.0.0"
+		"react": ">=18.0.0",
+		"react-dom": ">=18.0.0"
 	}
 }


### PR DESCRIPTION
Bumping peer dep requirement because we rely on React 18 features such as `useId`, which do not work in React 17. React 18 also has important bug fixes, optimizations, and important performance-oriented features (like transitions), which we want to be able to rely on.

Originally, we were thinking about supporting React 17 since consuming applications might not have updated to React 18 yet. However, it doesn't make sense to take the additional burden of supporting older React versions when React 18 has been out for 2.5 years (and React 19 is around the corner). Even AppUI [recently](https://github.com/iTwin/appui/pull/1054) dropped support for React 17. Together, hopefully we can pressure applications to stay up-to-date.