### PR TITLE
add `displayName` to all components

### DIFF
--- a/packages/kiwi-react/src/bricks/Anchor.tsx
+++ b/packages/kiwi-react/src/bricks/Anchor.tsx
@@ -30,3 +30,4 @@ export const Anchor = React.forwardRef<React.ElementRef<"a">, AnchorProps>(
 		);
 	},
 );
+Anchor.displayName = "Anchor";

--- a/packages/kiwi-react/src/bricks/Button.tsx
+++ b/packages/kiwi-react/src/bricks/Button.tsx
@@ -26,3 +26,4 @@ export const Button = React.forwardRef<
 		/>
 	);
 });
+Button.displayName = "Button";

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -25,3 +25,4 @@ export const Checkbox = React.forwardRef<
 		/>
 	);
 });
+Checkbox.displayName = "Checkbox";

--- a/packages/kiwi-react/src/bricks/Divider.tsx
+++ b/packages/kiwi-react/src/bricks/Divider.tsx
@@ -37,3 +37,4 @@ export const Divider = React.forwardRef<React.ElementRef<"div">, DividerProps>(
 		);
 	},
 );
+Divider.displayName = "Divider";

--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -45,6 +45,7 @@ function DropdownMenu(props: DropdownMenuProps) {
 		</Ariakit.MenuProvider>
 	);
 }
+DropdownMenu.displayName = "DropdownMenu.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -61,6 +62,7 @@ const DropdownMenuContent = React.forwardRef<
 		/>
 	);
 });
+DropdownMenuContent.displayName = "DropdownMenu.Content";
 
 // ----------------------------------------------------------------------------
 
@@ -84,6 +86,7 @@ const DropdownMenuButton = React.forwardRef<
 		/>
 	);
 });
+DropdownMenuButton.displayName = "DropdownMenu.Button";
 
 // ----------------------------------------------------------------------------
 
@@ -100,6 +103,7 @@ const DropdownMenuItem = React.forwardRef<
 		/>
 	);
 });
+DropdownMenuItem.displayName = "DropdownMenu.Item";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -36,3 +36,4 @@ export const Field = React.forwardRef<React.ElementRef<"div">, FieldProps>(
 		);
 	},
 );
+Field.displayName = "Field";

--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -47,6 +47,7 @@ export const Icon = React.forwardRef<React.ElementRef<"svg">, IconProps>(
 		);
 	},
 );
+Icon.displayName = "Icon";
 
 function toIconId(size: IconProps["size"]) {
 	if (size === "large") return "icon-large";
@@ -98,3 +99,4 @@ export const DisclosureArrow = React.forwardRef<
 		/>
 	);
 });
+DisclosureArrow.displayName = "DisclosureArrow";

--- a/packages/kiwi-react/src/bricks/IconButton.tsx
+++ b/packages/kiwi-react/src/bricks/IconButton.tsx
@@ -103,3 +103,4 @@ export const IconButton = React.forwardRef<
 		</Tooltip>
 	);
 });
+IconButton.displayName = "IconButton";

--- a/packages/kiwi-react/src/bricks/Kbd.tsx
+++ b/packages/kiwi-react/src/bricks/Kbd.tsx
@@ -38,3 +38,4 @@ export const Kbd = React.forwardRef<React.ElementRef<"kbd">, KbdProps>(
 		);
 	},
 );
+Kbd.displayName = "Kbd";

--- a/packages/kiwi-react/src/bricks/Label.tsx
+++ b/packages/kiwi-react/src/bricks/Label.tsx
@@ -24,3 +24,4 @@ export const Label = React.forwardRef<
 		/>
 	);
 });
+Label.displayName = "Label";

--- a/packages/kiwi-react/src/bricks/ListItem.tsx
+++ b/packages/kiwi-react/src/bricks/ListItem.tsx
@@ -23,6 +23,7 @@ const ListItem = React.forwardRef<React.ElementRef<"div">, ListItemProps>(
 		);
 	},
 );
+ListItem.displayName = "ListItem.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -41,6 +42,7 @@ const ListItemContent = React.forwardRef<
 		/>
 	);
 });
+ListItemContent.displayName = "ListItem.Content";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -25,3 +25,4 @@ export const Radio = React.forwardRef<
 		/>
 	);
 });
+Radio.displayName = "Radio";

--- a/packages/kiwi-react/src/bricks/Root.tsx
+++ b/packages/kiwi-react/src/bricks/Root.tsx
@@ -20,6 +20,7 @@ export const Root = ({ children }: { children: React.ReactNode }) => {
 		</>
 	);
 };
+Root.displayName = "Root";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -31,3 +31,4 @@ export const Switch = React.forwardRef<
 		/>
 	);
 });
+Switch.displayName = "Switch";

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -58,6 +58,7 @@ function Tabs(props: TabsProps) {
 		</Ariakit.TabProvider>
 	);
 }
+Tabs.displayName = "Tabs.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -88,6 +89,7 @@ const TabList = React.forwardRef<
 		/>
 	);
 });
+TabList.displayName = "Tabs.TabList";
 
 // ----------------------------------------------------------------------------
 
@@ -107,6 +109,7 @@ const Tab = React.forwardRef<React.ElementRef<typeof Ariakit.Tab>, TabProps>(
 		);
 	},
 );
+Tab.displayName = "Tabs.Tab";
 
 // ----------------------------------------------------------------------------
 
@@ -126,6 +129,7 @@ const TabPanel = React.forwardRef<
 		/>
 	);
 });
+TabPanel.displayName = "Tabs.TabPanel";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/TextBox.tsx
+++ b/packages/kiwi-react/src/bricks/TextBox.tsx
@@ -64,6 +64,7 @@ const TextBoxInput = React.forwardRef<
 		/>
 	);
 });
+TextBoxInput.displayName = "TextBox.Input";
 
 // ----------------------------------------------------------------------------
 
@@ -109,6 +110,7 @@ const TextBoxRoot = React.forwardRef<React.ElementRef<"div">, TextBoxRootProps>(
 		);
 	},
 );
+TextBoxRoot.displayName = "TextBox.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -126,6 +128,7 @@ const TextBoxIcon = React.forwardRef<
 		/>
 	);
 });
+TextBoxIcon.displayName = "TextBox.Icon";
 
 // ----------------------------------------------------------------------------
 
@@ -143,6 +146,7 @@ const TextBoxText = React.forwardRef<
 		/>
 	);
 });
+TextBoxText.displayName = "TextBox.Text";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/Textarea.tsx
+++ b/packages/kiwi-react/src/bricks/Textarea.tsx
@@ -38,3 +38,4 @@ export const Textarea = React.forwardRef<
 		/>
 	);
 });
+Textarea.displayName = "Textarea";

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -121,6 +121,7 @@ export const Tooltip = React.forwardRef<
 		</>
 	);
 });
+Tooltip.displayName = "Tooltip";
 
 const isBrowser = typeof document !== "undefined";
 

--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -20,6 +20,7 @@ export const Tree = React.forwardRef<React.ElementRef<"div">, TreeProps>(
 		);
 	},
 );
+Tree.displayName = "Tree.Root";
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Added `displayName` to all exported components. This helps with easier debugging in React Dev Tools and better error messages.

Ideally this should work automatically, but we need to add it explicitly because all our components use `React.forwardRef`, which causes React to "lose" the component's name.

Example on inspecting the `<Anchor>` component using React Dev Tools:

| Before | After |
| --- | --- |
| ![Component named "_c" with a ForwardRef badge](https://github.com/user-attachments/assets/8651b7af-0c15-478b-be54-809e5dd0a065) | ![Component named Anchor](https://github.com/user-attachments/assets/db664525-cec0-47c7-a183-633dc2c87dc3) | 