### PR TITLE
unmount `DropdownMenu` when closed

### DIFF
--- a/apps/test-app/app/routes/tests/dropdown-menu/index.spec.ts
+++ b/apps/test-app/app/routes/tests/dropdown-menu/index.spec.ts
@@ -11,16 +11,23 @@ test("default", async ({ page }) => {
 	const button = page.getByRole("button", { name: "Actions" });
 	const add = page.getByRole("menuitem", { name: "Add" });
 
+	const menu = page.getByRole("menu", { includeHidden: true });
+	await expect(menu).toHaveCount(0);
+
 	await button.click();
+	await expect(menu).toBeVisible();
 	await expect(add).toBeVisible();
 
 	await add.click();
+	await expect(menu).toHaveCount(0); // unmounted
 	await expect(add).not.toBeVisible();
 
 	await button.click();
+	await expect(menu).toBeVisible();
 	await expect(add).toBeVisible();
 
 	await page.click("body");
+	await expect(menu).toHaveCount(0); // unmounted
 	await expect(add).not.toBeVisible();
 });
 

--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -78,6 +78,7 @@ const DropdownMenuContent = React.forwardRef<
 	return (
 		<Ariakit.Menu
 			portal={!supportsPopover}
+			unmountOnHide
 			{...props}
 			style={{ zIndex: supportsPopover ? undefined : 9999, ...props.style }}
 			wrapperProps={{ popover: "manual" } as React.ComponentProps<"div">}


### PR DESCRIPTION
Enabled [`unmountOnHide`](https://ariakit.org/reference/menu#unmountonhide) by default, so that it gets removed from the DOM. Can be overridden using props from outside.

Updated the default test to validate it works (confirmed it fails when not enabling `unmountOnHide`).

See https://github.com/iTwin/kiwi/pull/171#discussion_r1865699652