### PR TITLE
hide `Tooltip` content from accessibility tree

### DIFF
--- a/apps/test-app/app/routes/tests/tooltip/index.spec.ts
+++ b/apps/test-app/app/routes/tests/tooltip/index.spec.ts
@@ -10,7 +10,7 @@ test.describe("default", () => {
 		await page.goto("/tests/tooltip");
 
 		const button = page.getByRole("button");
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await expect(button).toBeVisible();
 		await expect(tooltip).toBeHidden();
@@ -26,7 +26,7 @@ test.describe("default", () => {
 		);
 
 		const button = page.getByRole("button");
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await button.hover();
 		await expect(tooltip).toBeVisible();
@@ -34,7 +34,7 @@ test.describe("default", () => {
 
 	test("Keyboard focus should display the tooltip", async ({ page }) => {
 		const button = page.getByRole("button");
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await page.keyboard.press("Tab");
 		await expect(button).toBeFocused();
@@ -52,7 +52,7 @@ test.describe("hover", () => {
 		await page.goto("/tests/tooltip");
 
 		const button = page.getByRole("button");
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await button.hover();
 		await expect(tooltip).toBeVisible();
@@ -61,7 +61,7 @@ test.describe("hover", () => {
 	test("Mouse Out / Unhover should hide the tooltip", async ({ page }) => {
 		await page.mouse.move(0, 0);
 
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await expect(tooltip).toBeHidden();
 	});
@@ -69,7 +69,7 @@ test.describe("hover", () => {
 	test("Tooltip should stay displayed during hover (should not hide)", async ({
 		page,
 	}) => {
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await page.waitForTimeout(2000);
 		await expect(tooltip).toBeVisible();
@@ -85,7 +85,7 @@ test.describe("dismissal", () => {
 		await page.goto("/tests/tooltip");
 
 		const button = page.getByRole("button");
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await expect(button).toBeVisible();
 		await button.focus();
@@ -93,21 +93,21 @@ test.describe("dismissal", () => {
 	});
 
 	test("Pressing Escape should hide the tooltip", async ({ page }) => {
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await page.keyboard.press("Escape");
 		await expect(tooltip).toBeHidden();
 	});
 
 	test("Keyboard loss of focus should hide the tooltip", async ({ page }) => {
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await page.keyboard.press("Tab");
 		await expect(tooltip).toBeHidden();
 	});
 
 	test("Outside click should hide the tooltip", async ({ page }) => {
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await page.locator("body").click();
 		await expect(tooltip).toBeHidden();
@@ -161,7 +161,7 @@ test.describe("@a11y", () => {
 		await page.goto("/tests/tooltip");
 
 		const button = page.getByRole("button");
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await expect(button).toBeVisible();
 		await expect(tooltip).toBeHidden();
@@ -180,7 +180,7 @@ test.describe("@visual", () => {
 		await page.goto("/tests/tooltip");
 
 		const button = page.getByRole("button");
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await expect(button).toBeVisible();
 		await button.focus();
@@ -194,7 +194,7 @@ test.describe("@visual", () => {
 		await page.goto("/tests/tooltip?multi-line=true");
 
 		const button = page.getByRole("button");
-		const tooltip = page.getByRole("tooltip");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
 
 		await expect(button).toBeVisible();
 		await button.focus();

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -76,14 +76,6 @@ export const Tooltip = React.forwardRef<
 		[open, popover],
 	);
 
-	// Determine the correct aria attribute dynamically
-	const ariaProps =
-		type === "description"
-			? { "aria-describedby": id }
-			: type === "label"
-				? { "aria-labelledby": id }
-				: {};
-
 	return (
 		<>
 			<Ariakit.TooltipProvider
@@ -92,8 +84,13 @@ export const Tooltip = React.forwardRef<
 				open={openProp}
 				setOpen={setOpenProp}
 			>
-				<Ariakit.TooltipAnchor render={children} {...ariaProps} />
+				<Ariakit.TooltipAnchor
+					render={children}
+					{...(type === "description" && { "aria-describedby": id })}
+					{...(type === "label" && { "aria-labelledby": id })}
+				/>
 				<Ariakit.Tooltip
+					aria-hidden="true"
 					{...rest}
 					unmountOnHide={unmountOnHide}
 					className={cx("🥝-tooltip", className)}


### PR DESCRIPTION
Adds `aria-hidden="true"` to the `Tooltip` to avoid duplicate announcements. The tooltip content should already be associated with (or present in) the trigger element, so it doesn't need to be exposed again.

This was originally deferred from https://github.com/iTwin/kiwi/pull/48#discussion_r1778777088 because we wanted to add a "❌" button for dismissing the tooltip. However, such a button would only be for mouse users, so we could just make it not-focusable and then it should be ok.

<details>
<summary>Quick testing with VoiceOver</summary>

Confirmed that the tooltip content is still announced with the trigger element.

![](https://github.com/user-attachments/assets/c4e321ea-046e-4add-9ae6-354a16565a66)

Confirmed that the duplicate announcements are fixed.

| Before | After |
| --- | --- |
| The tooltip gets announced when moving between elements | No duplicate announcements even when tooltip is shown |
| <video width="150" src="https://github.com/user-attachments/assets/649fe0d8-60ed-4b25-9940-24b312a1985c"> | <video width="150" src="https://github.com/user-attachments/assets/6ec85230-c9f7-48e1-9f9f-14172ea8a41d"> |

</details>

---

While I'm here, I also removed the `ariaProps` intermediate variable because it was confusing me (It's aria props for the trigger only).