### PR TITLE
produce `development` build

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -23,6 +23,9 @@
 		"rules": {
 			"correctness": {
 				"noUnusedImports": "info"
+			},
+			"suspicious": {
+				"noConfusingLabels": "off"
 			}
 		}
 	},

--- a/packages/kiwi-react/package.json
+++ b/packages/kiwi-react/package.json
@@ -8,6 +8,8 @@
 	"exports": {
 		"./bricks": {
 			"@kiwi/source": "./src/bricks/index.ts",
+			"types": "./dist/bricks/index.d.ts",
+			"development": "./dist/DEV/bricks/index.js",
 			"default": "./dist/bricks/index.js"
 		},
 		"./package.json": "./package.json"
@@ -33,7 +35,9 @@
 		"ui"
 	],
 	"scripts": {
-		"build": "rm -rf dist && node scripts/build.js && tsc --outDir dist",
+		"build": "rm -rf dist && node scripts/build.js && pnpm run build:dev && pnpm run build:types",
+		"build:dev": "NODE_ENV=development node scripts/build.js",
+		"build:types": "tsc --outDir dist",
 		"dev": "tsc --watch --outDir dist"
 	},
 	"dependencies": {

--- a/packages/kiwi-react/scripts/build.js
+++ b/packages/kiwi-react/scripts/build.js
@@ -12,6 +12,8 @@ import {
 	staticVariablesTransform,
 } from "internal/visitors.js";
 
+const isDev = process.env.NODE_ENV === "development";
+
 const entryPoints = await fg("src/**/*.{ts,tsx}", {
 	onlyFiles: true,
 	ignore: ["**/*.d.ts"],
@@ -21,11 +23,12 @@ await esbuild.build({
 	entryPoints,
 	entryNames: "[dir]/[name]",
 	outbase: "src",
-	outdir: "dist",
+	outdir: isDev ? "dist/DEV" : "dist",
 	bundle: false,
 	format: "esm",
 	jsx: "automatic",
 	target: "es2021",
+	...(!isDev && { dropLabels: ["DEV"] }),
 });
 
 // Run esbuild again, only to inline bundled CSS inside `.css.ts` files
@@ -33,7 +36,7 @@ await esbuild.build({
 	entryPoints: await fg("src/**/*.css.ts", { onlyFiles: true }),
 	entryNames: "[dir]/[name]",
 	outbase: "src",
-	outdir: "dist",
+	outdir: isDev ? "dist/DEV" : "dist",
 	bundle: true,
 	format: "esm",
 	jsx: "automatic",

--- a/packages/kiwi-react/src/bricks/Anchor.tsx
+++ b/packages/kiwi-react/src/bricks/Anchor.tsx
@@ -30,4 +30,4 @@ export const Anchor = React.forwardRef<React.ElementRef<"a">, AnchorProps>(
 		);
 	},
 );
-Anchor.displayName = "Anchor";
+DEV: Anchor.displayName = "Anchor";

--- a/packages/kiwi-react/src/bricks/Button.tsx
+++ b/packages/kiwi-react/src/bricks/Button.tsx
@@ -26,4 +26,4 @@ export const Button = React.forwardRef<
 		/>
 	);
 });
-Button.displayName = "Button";
+DEV: Button.displayName = "Button";

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -26,4 +26,4 @@ export const Checkbox = React.forwardRef<
 		/>
 	);
 });
-Checkbox.displayName = "Checkbox";
+DEV: Checkbox.displayName = "Checkbox";

--- a/packages/kiwi-react/src/bricks/Divider.tsx
+++ b/packages/kiwi-react/src/bricks/Divider.tsx
@@ -37,4 +37,4 @@ export const Divider = React.forwardRef<React.ElementRef<"div">, DividerProps>(
 		);
 	},
 );
-Divider.displayName = "Divider";
+DEV: Divider.displayName = "Divider";

--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -67,7 +67,7 @@ function DropdownMenu(props: DropdownMenuProps) {
 		</Ariakit.MenuProvider>
 	);
 }
-DropdownMenu.displayName = "DropdownMenu.Root";
+DEV: DropdownMenu.displayName = "DropdownMenu.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -87,7 +87,7 @@ const DropdownMenuContent = React.forwardRef<
 		/>
 	);
 });
-DropdownMenuContent.displayName = "DropdownMenu.Content";
+DEV: DropdownMenuContent.displayName = "DropdownMenu.Content";
 
 // ----------------------------------------------------------------------------
 
@@ -111,7 +111,7 @@ const DropdownMenuButton = React.forwardRef<
 		/>
 	);
 });
-DropdownMenuButton.displayName = "DropdownMenu.Button";
+DEV: DropdownMenuButton.displayName = "DropdownMenu.Button";
 
 // ----------------------------------------------------------------------------
 
@@ -128,7 +128,7 @@ const DropdownMenuItem = React.forwardRef<
 		/>
 	);
 });
-DropdownMenuItem.displayName = "DropdownMenu.Item";
+DEV: DropdownMenuItem.displayName = "DropdownMenu.Item";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -36,4 +36,4 @@ export const Field = React.forwardRef<React.ElementRef<"div">, FieldProps>(
 		);
 	},
 );
-Field.displayName = "Field";
+DEV: Field.displayName = "Field";

--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -47,7 +47,7 @@ export const Icon = React.forwardRef<React.ElementRef<"svg">, IconProps>(
 		);
 	},
 );
-Icon.displayName = "Icon";
+DEV: Icon.displayName = "Icon";
 
 function toIconId(size: IconProps["size"]) {
 	if (size === "large") return "icon-large";
@@ -99,4 +99,4 @@ export const DisclosureArrow = React.forwardRef<
 		/>
 	);
 });
-DisclosureArrow.displayName = "DisclosureArrow";
+DEV: DisclosureArrow.displayName = "DisclosureArrow";

--- a/packages/kiwi-react/src/bricks/IconButton.tsx
+++ b/packages/kiwi-react/src/bricks/IconButton.tsx
@@ -120,4 +120,4 @@ export const IconButton = React.forwardRef<
 		</Tooltip>
 	);
 });
-IconButton.displayName = "IconButton";
+DEV: IconButton.displayName = "IconButton";

--- a/packages/kiwi-react/src/bricks/Kbd.tsx
+++ b/packages/kiwi-react/src/bricks/Kbd.tsx
@@ -33,4 +33,4 @@ export const Kbd = React.forwardRef<React.ElementRef<"kbd">, KbdProps>(
 		);
 	},
 );
-Kbd.displayName = "Kbd";
+DEV: Kbd.displayName = "Kbd";

--- a/packages/kiwi-react/src/bricks/Label.tsx
+++ b/packages/kiwi-react/src/bricks/Label.tsx
@@ -24,4 +24,4 @@ export const Label = React.forwardRef<
 		/>
 	);
 });
-Label.displayName = "Label";
+DEV: Label.displayName = "Label";

--- a/packages/kiwi-react/src/bricks/ListItem.tsx
+++ b/packages/kiwi-react/src/bricks/ListItem.tsx
@@ -23,7 +23,7 @@ const ListItem = React.forwardRef<React.ElementRef<"div">, ListItemProps>(
 		);
 	},
 );
-ListItem.displayName = "ListItem.Root";
+DEV: ListItem.displayName = "ListItem.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -42,7 +42,7 @@ const ListItemContent = React.forwardRef<
 		/>
 	);
 });
-ListItemContent.displayName = "ListItem.Content";
+DEV: ListItemContent.displayName = "ListItem.Content";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -26,4 +26,4 @@ export const Radio = React.forwardRef<
 		/>
 	);
 });
-Radio.displayName = "Radio";
+DEV: Radio.displayName = "Radio";

--- a/packages/kiwi-react/src/bricks/Root.tsx
+++ b/packages/kiwi-react/src/bricks/Root.tsx
@@ -21,7 +21,7 @@ export const Root = ({ children }: { children: React.ReactNode }) => {
 		</>
 	);
 };
-Root.displayName = "Root";
+DEV: Root.displayName = "Root";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -32,4 +32,4 @@ export const Switch = React.forwardRef<
 		/>
 	);
 });
-Switch.displayName = "Switch";
+DEV: Switch.displayName = "Switch";

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -58,7 +58,7 @@ function Tabs(props: TabsProps) {
 		</Ariakit.TabProvider>
 	);
 }
-Tabs.displayName = "Tabs.Root";
+DEV: Tabs.displayName = "Tabs.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -89,7 +89,7 @@ const TabList = React.forwardRef<
 		/>
 	);
 });
-TabList.displayName = "Tabs.TabList";
+DEV: TabList.displayName = "Tabs.TabList";
 
 // ----------------------------------------------------------------------------
 
@@ -109,7 +109,7 @@ const Tab = React.forwardRef<React.ElementRef<typeof Ariakit.Tab>, TabProps>(
 		);
 	},
 );
-Tab.displayName = "Tabs.Tab";
+DEV: Tab.displayName = "Tabs.Tab";
 
 // ----------------------------------------------------------------------------
 
@@ -129,7 +129,7 @@ const TabPanel = React.forwardRef<
 		/>
 	);
 });
-TabPanel.displayName = "Tabs.TabPanel";
+DEV: TabPanel.displayName = "Tabs.TabPanel";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/TextBox.tsx
+++ b/packages/kiwi-react/src/bricks/TextBox.tsx
@@ -64,7 +64,7 @@ const TextBoxInput = React.forwardRef<
 		/>
 	);
 });
-TextBoxInput.displayName = "TextBox.Input";
+DEV: TextBoxInput.displayName = "TextBox.Input";
 
 // ----------------------------------------------------------------------------
 
@@ -110,7 +110,7 @@ const TextBoxRoot = React.forwardRef<React.ElementRef<"div">, TextBoxRootProps>(
 		);
 	},
 );
-TextBoxRoot.displayName = "TextBox.Root";
+DEV: TextBoxRoot.displayName = "TextBox.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -128,7 +128,7 @@ const TextBoxIcon = React.forwardRef<
 		/>
 	);
 });
-TextBoxIcon.displayName = "TextBox.Icon";
+DEV: TextBoxIcon.displayName = "TextBox.Icon";
 
 // ----------------------------------------------------------------------------
 
@@ -146,7 +146,7 @@ const TextBoxText = React.forwardRef<
 		/>
 	);
 });
-TextBoxText.displayName = "TextBox.Text";
+DEV: TextBoxText.displayName = "TextBox.Text";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/src/bricks/Textarea.tsx
+++ b/packages/kiwi-react/src/bricks/Textarea.tsx
@@ -38,4 +38,4 @@ export const Textarea = React.forwardRef<
 		/>
 	);
 });
-Textarea.displayName = "Textarea";
+DEV: Textarea.displayName = "Textarea";

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -106,4 +106,4 @@ export const Tooltip = React.forwardRef<
 		</>
 	);
 });
-Tooltip.displayName = "Tooltip";
+DEV: Tooltip.displayName = "Tooltip";

--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -20,7 +20,7 @@ export const Tree = React.forwardRef<React.ElementRef<"div">, TreeProps>(
 		);
 	},
 );
-Tree.displayName = "Tree.Root";
+DEV: Tree.displayName = "Tree.Root";
 
 // ----------------------------------------------------------------------------
 
@@ -70,6 +70,7 @@ export const TreeItem = React.forwardRef<
 		</TreeItemContext.Provider>
 	);
 });
+DEV: TreeItem.displayName = "Tree.Item";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/kiwi-react/tsconfig.json
+++ b/packages/kiwi-react/tsconfig.json
@@ -25,7 +25,8 @@
 		"baseUrl": ".",
 		"emitDeclarationOnly": true,
 		"types": ["./types.d.ts"],
-		"preserveWatchOutput": true
+		"preserveWatchOutput": true,
+		"allowUnusedLabels": true
 	},
 	"include": ["src", "types.d.ts"],
 	"exclude": ["node_modules", "dist/**/*"]


### PR DESCRIPTION
This PR produces a `development` build for the `-react` package (the `-icons` package doesn't need it). The build output will be located in the `dist/DEV` folder  and exposed from `package.json` via the widely-recognized `"development"` [export condition](https://nodejs.org/api/packages.html#resolving-user-conditions).

The build output is generated by simply running the build script again with an environment variable (I could also pass args instead; not sure if one is better than the other).

I've decided to make use of `esbuild`'s ["Drop labels"](https://esbuild.github.io/api/#drop-labels) feature. [Labels](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label) are underutilized in JS and I did have to configure [biome](https://biomejs.dev/linter/rules/no-confusing-labels/) and [TS](https://www.typescriptlang.org/tsconfig/#allowUnusedLabels) to ignore the label, but I like the outcome. I think this is a much cleaner way of marking development-only code (compared to defining magic globals).

As a first step, I'm eliminating `displayName` from the production build. In the future, we could utilize this for things like development-only warnings.

x-ref: https://github.com/iTwin/kiwi/pull/170#issuecomment-2508068287