### PR TITLE
bump react to v19

### DIFF
--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -4,7 +4,7 @@
 	"sideEffects": false,
 	"type": "module",
 	"scripts": {
-		"build": "react-router typegen && react-router build && tsc",
+		"build": "react-router typegen && NODE_ENV=production react-router build && tsc",
 		"dev": "react-router dev",
 		"preview": "vite preview",
 		"test": "tsx ./scripts/run-tests.cts pnpm exec playwright test",
@@ -19,8 +19,8 @@
 		"@itwin/kiwi-react": "*",
 		"@react-router/node": "^7.0.2",
 		"isbot": "^5.1.17",
-		"react": "18",
-		"react-dom": "18",
+		"react": "19",
+		"react-dom": "19",
 		"react-router": "^7.0.2"
 	},
 	"devDependencies": {
@@ -28,8 +28,8 @@
 		"@playwright/test": "~1.49.0",
 		"@react-router/dev": "^7.0.2",
 		"@types/node": "*",
-		"@types/react": "*",
-		"@types/react-dom": "*",
+		"@types/react": "19",
+		"@types/react-dom": "19",
 		"esbuild": "^0.24.0",
 		"lightningcss": "^1.28.2",
 		"typescript": "5",

--- a/packages/kiwi-react/package.json
+++ b/packages/kiwi-react/package.json
@@ -46,12 +46,12 @@
 	},
 	"devDependencies": {
 		"@types/node": "*",
-		"@types/react": "*",
-		"@types/react-dom": "*",
+		"@types/react": "19",
+		"@types/react-dom": "19",
 		"esbuild": "^0.24.0",
 		"lightningcss": "^1.28.2",
-		"react": "18",
-		"react-dom": "18",
+		"react": "19",
+		"react-dom": "19",
 		"typescript": "5"
 	},
 	"peerDependencies": {

--- a/packages/kiwi-react/src/bricks/TextBox.tsx
+++ b/packages/kiwi-react/src/bricks/TextBox.tsx
@@ -153,7 +153,7 @@ DEV: TextBoxText.displayName = "TextBox.Text";
 const TextBoxRootContext = React.createContext<
 	| {
 			setDisabled: (disabled: boolean | undefined) => void;
-			inputRef: React.RefObject<HTMLInputElement>;
+			inputRef: React.RefObject<HTMLInputElement | null>;
 	  }
 	| undefined
 >(undefined);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
     dependencies:
       "@ariakit/react":
         specifier: "*"
-        version: 0.4.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.4.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@itwin/kiwi-icons":
         specifier: "*"
         version: link:../../packages/kiwi-icons
@@ -45,19 +45,19 @@ importers:
         version: link:../../packages/kiwi-react
       "@react-router/node":
         specifier: ^7.0.2
-        version: 7.0.2(react-router@7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.7.2)
+        version: 7.0.2(react-router@7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.2)
       isbot:
         specifier: ^5.1.17
         version: 5.1.17
       react:
-        specifier: "18"
-        version: 18.3.1
+        specifier: "19"
+        version: 19.0.0
       react-dom:
-        specifier: "18"
-        version: 18.3.1(react@18.3.1)
+        specifier: "19"
+        version: 19.0.0(react@19.0.0)
       react-router:
         specifier: ^7.0.2
-        version: 7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       "@axe-core/playwright":
         specifier: ^4.10.1
@@ -67,16 +67,16 @@ importers:
         version: 1.49.0
       "@react-router/dev":
         specifier: ^7.0.2
-        version: 7.0.2(@types/node@22.10.1)(lightningcss@1.28.2)(react-router@7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.7.2)(vite@6.0.2(@types/node@22.10.1)(lightningcss@1.28.2)(tsx@4.19.2)(yaml@2.6.1))
+        version: 7.0.2(@types/node@22.10.1)(lightningcss@1.28.2)(react-router@7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.2)(vite@6.0.2(@types/node@22.10.1)(lightningcss@1.28.2)(tsx@4.19.2)(yaml@2.6.1))
       "@types/node":
         specifier: "*"
         version: 22.10.1
       "@types/react":
-        specifier: "*"
-        version: 18.3.13
+        specifier: "19"
+        version: 19.0.1
       "@types/react-dom":
-        specifier: "*"
-        version: 18.3.1
+        specifier: "19"
+        version: 19.0.1
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -105,7 +105,7 @@ importers:
     dependencies:
       "@ariakit/react":
         specifier: ^0.4.15
-        version: 0.4.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.4.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -114,11 +114,11 @@ importers:
         specifier: "*"
         version: 22.10.1
       "@types/react":
-        specifier: "*"
-        version: 18.3.13
+        specifier: "19"
+        version: 19.0.1
       "@types/react-dom":
-        specifier: "*"
-        version: 18.3.1
+        specifier: "19"
+        version: 19.0.1
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -126,11 +126,11 @@ importers:
         specifier: ^1.28.2
         version: 1.28.2
       react:
-        specifier: "18"
-        version: 18.3.1
+        specifier: "19"
+        version: 19.0.0
       react-dom:
-        specifier: "18"
-        version: 18.3.1(react@18.3.1)
+        specifier: "19"
+        version: 19.0.0(react@19.0.0)
       typescript:
         specifier: "5"
         version: 5.7.2
@@ -1426,22 +1426,16 @@ packages:
         integrity: sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==,
       }
 
-  "@types/prop-types@15.7.13":
+  "@types/react-dom@19.0.1":
     resolution:
       {
-        integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==,
+        integrity: sha512-hljHij7MpWPKF6u5vojuyfV0YA4YURsQG7KT6SzV0Zs2BXAtgdTxG6A229Ub/xiWV4w/7JL8fi6aAyjshH4meA==,
       }
 
-  "@types/react-dom@18.3.1":
+  "@types/react@19.0.1":
     resolution:
       {
-        integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==,
-      }
-
-  "@types/react@18.3.13":
-    resolution:
-      {
-        integrity: sha512-ii/gswMmOievxAJed4PAHT949bpYjPKXvXo1v6cRB/kqc2ZR4n+SgyCyvyc5Fec5ez8VnUumI1Vk7j6fRyRogg==,
+        integrity: sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==,
       }
 
   ansi-regex@5.0.1:
@@ -2145,13 +2139,6 @@ packages:
         integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
       }
 
-  loose-envify@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
-      }
-    hasBin: true
-
   lru-cache@10.4.3:
     resolution:
       {
@@ -2399,13 +2386,13 @@ packages:
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
-  react-dom@18.3.1:
+  react-dom@19.0.0:
     resolution:
       {
-        integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==,
+        integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==,
       }
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.0.0
 
   react-refresh@0.14.2:
     resolution:
@@ -2427,10 +2414,10 @@ packages:
       react-dom:
         optional: true
 
-  react@18.3.1:
+  react@19.0.0:
     resolution:
       {
-        integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==,
+        integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==,
       }
     engines: { node: ">=0.10.0" }
 
@@ -2487,10 +2474,10 @@ packages:
         integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
       }
 
-  scheduler@0.23.2:
+  scheduler@0.25.0:
     resolution:
       {
-        integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
+        integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==,
       }
 
   semver@6.3.1:
@@ -2901,19 +2888,19 @@ snapshots:
 
   "@ariakit/core@0.4.14": {}
 
-  "@ariakit/react-core@0.4.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@ariakit/react-core@0.4.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@ariakit/core": 0.4.14
       "@floating-ui/dom": 1.6.12
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.2.2(react@18.3.1)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      use-sync-external-store: 1.2.2(react@19.0.0)
 
-  "@ariakit/react@0.4.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@ariakit/react@0.4.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
-      "@ariakit/react-core": 0.4.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      "@ariakit/react-core": 0.4.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   "@axe-core/playwright@4.10.1(playwright-core@1.49.0)":
     dependencies:
@@ -3444,7 +3431,7 @@ snapshots:
     dependencies:
       playwright: 1.49.0
 
-  "@react-router/dev@7.0.2(@types/node@22.10.1)(lightningcss@1.28.2)(react-router@7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.7.2)(vite@6.0.2(@types/node@22.10.1)(lightningcss@1.28.2)(tsx@4.19.2)(yaml@2.6.1))":
+  "@react-router/dev@7.0.2(@types/node@22.10.1)(lightningcss@1.28.2)(react-router@7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.2)(vite@6.0.2(@types/node@22.10.1)(lightningcss@1.28.2)(tsx@4.19.2)(yaml@2.6.1))":
     dependencies:
       "@babel/core": 7.26.0
       "@babel/generator": 7.26.3
@@ -3455,7 +3442,7 @@ snapshots:
       "@babel/traverse": 7.26.3
       "@babel/types": 7.26.3
       "@npmcli/package-json": 4.0.1
-      "@react-router/node": 7.0.2(react-router@7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.7.2)
+      "@react-router/node": 7.0.2(react-router@7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.2)
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.6
       chokidar: 4.0.1
@@ -3471,7 +3458,7 @@ snapshots:
       picomatch: 2.3.1
       prettier: 2.8.8
       react-refresh: 0.14.2
-      react-router: 7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       semver: 7.6.3
       set-cookie-parser: 2.7.1
       valibot: 0.41.0(typescript@5.7.2)
@@ -3492,10 +3479,10 @@ snapshots:
       - supports-color
       - terser
 
-  "@react-router/node@7.0.2(react-router@7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.7.2)":
+  "@react-router/node@7.0.2(react-router@7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.2)":
     dependencies:
       "@mjackson/node-fetch-server": 0.2.0
-      react-router: 7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       source-map-support: 0.5.21
       stream-slice: 0.1.2
       undici: 6.21.0
@@ -3564,15 +3551,12 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  "@types/prop-types@15.7.13": {}
-
-  "@types/react-dom@18.3.1":
+  "@types/react-dom@19.0.1":
     dependencies:
-      "@types/react": 18.3.13
+      "@types/react": 19.0.1
 
-  "@types/react@18.3.13":
+  "@types/react@19.0.1":
     dependencies:
-      "@types/prop-types": 15.7.13
       csstype: 3.1.3
 
   ansi-regex@5.0.1: {}
@@ -3979,10 +3963,6 @@ snapshots:
 
   lodash@4.17.21: {}
 
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
-
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -4106,27 +4086,24 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@18.3.1(react@18.3.1):
+  react-dom@19.0.0(react@19.0.0):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
+      react: 19.0.0
+      scheduler: 0.25.0
 
   react-refresh@0.14.2: {}
 
-  react-router@7.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       "@types/cookie": 0.6.0
       cookie: 1.0.2
-      react: 18.3.1
+      react: 19.0.0
       set-cookie-parser: 2.7.1
       turbo-stream: 2.4.0
     optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 19.0.0(react@19.0.0)
 
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
+  react@19.0.0: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -4176,9 +4153,7 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
+  scheduler@0.25.0: {}
 
   semver@6.3.1: {}
 
@@ -4281,9 +4256,9 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  use-sync-external-store@1.2.2(react@18.3.1):
+  use-sync-external-store@1.2.2(react@19.0.0):
     dependencies:
-      react: 18.3.1
+      react: 19.0.0
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
[React 19](https://react.dev/blog/2024/12/05/react-19) is here. Pretty uneventful upgrade for us; only two changes:
- Adjusted the type of ref is one place in `TextBox.tsx`.
- Set `NODE_ENV=production` when building test-app ([React Router wasn't already doing it](https://redirect.github.com/remix-run/react-router/issues/12138), which was causing a build error).

To ease the transition, the main package still allows React v18, but we might want to restrict to just v19 in the future to encourage consumers to upgrade.