### PR TITLE
Fix overflowing sandbox

### DIFF
--- a/apps/test-app/app/sandbox.module.css
+++ b/apps/test-app/app/sandbox.module.css
@@ -41,7 +41,7 @@
 	background-color: var(--kiwi-color-bg-surface-primary);
 	min-block-size: 0;
 
-	contain: size layout;
+	contain: size layout; /* prevent unnecessary overflow */
 	display: flex;
 	flex-direction: column;
 	gap: 12px;


### PR DESCRIPTION
We noticed the sandbox was overflowing. There was a few different causes depending on the browser. In Firefox, the `<input type=range>` element was the cause and setting `display: block` to override its UA applied `display: inline-block` fixed this. That didn’t work for Chrome and Safari, so I figured we’d use `size` and `layout` containment for the entire left panel which still allows contents to protrude, but it makes it so that the contents don’t effect the size of the left panel or the layout outside (and the layout outside has no affect on content inside).

I would have liked to get to the root of why the overflowing list was causing the overflow even though it was in the flex layout with its height constricted, but I couldn’t figure it out.