### PR TITLE
replace `vite preview` with `serve`

### DIFF
--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "react-router typegen && NODE_ENV=production react-router build && tsc",
 		"dev": "react-router dev",
-		"preview": "vite preview",
+		"preview": "pnpx serve build/client -L -p 1800",
 		"test": "tsx ./scripts/run-tests.cts pnpm exec playwright test",
 		"typecheck": "react-router typegen && tsc"
 	},


### PR DESCRIPTION
This updates the `test-app#preview` command to use [`serve`](https://npmjs.com/serve) instead of `vite preview`, because the latter was causing random hydration errors in #192.

(We are able to just serve the `build/client/` directory because we don't do any real SSR; it's all static files.)

---

The `test-app#preview` command mainly gets used by the playwright config (including in CI), and this PR's CI is passing. Alternatively, it can be useful for manually testing the prod build by running this command from the project root: `pnpm run build && pnpm --filter=@itwin/test-app run preview`.