### PR TITLE
fix hydration mismatch in test-app

### DIFF
--- a/apps/test-app/app/~utils.tsx
+++ b/apps/test-app/app/~utils.tsx
@@ -85,11 +85,10 @@ export function useColorScheme() {
 
 /**
  * Returns whether the specified media query matches, watching for any changes.
- * Returns `undefined` when `window` is unavailable (e.g. during SSR/prerendering).
+ * Returns `undefined` when `window` is unavailable (e.g. during SSR/prerendering + hydration).
  */
 export function useMediaQuery(query: string) {
-	const getSnapshot = React.useCallback(() => {
-		if (typeof window === "undefined") return undefined;
+	const getClientSnapshot = React.useCallback(() => {
 		return window.matchMedia?.(query).matches;
 	}, [query]);
 
@@ -102,7 +101,11 @@ export function useMediaQuery(query: string) {
 		[query],
 	);
 
-	return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+	return React.useSyncExternalStore(
+		subscribe,
+		getClientSnapshot,
+		() => undefined, // undefined during SSR and also during hydration
+	);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
There was an issue from #196, where the `useMediaQuery` hook in test-app was returning different values during SSR vs hydration. This caused the `/sandbox` page to be rendered in a broken state (mix of light and dark themes) when visiting the URL directly.

The fix was to return the same value (`undefined`) during SSR *and* during hydration. This is made possible because [`getServerSnapshot`](https://react.dev/reference/react/useSyncExternalStore#parameters:~:text=during%20server%20rendering%20and%20during%20hydration) conveniently gets called during hydration as well.

**To test:** Switch your system theme to **light**, then compare [`/sandbox` (main)](https://supreme-barnacle-pl8jn8m.pages.github.io/sandbox/) vs [`/sandbox` (this PR)](https://supreme-barnacle-pl8jn8m.pages.github.io/198/sandbox/). (Alternatively, visit the URLs, then switch the theme in browser dev-tools, then refresh)