### PR TITLE
fix TS `customConditions` to work in IDE

### DIFF
--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -4,11 +4,11 @@
 	"sideEffects": false,
 	"type": "module",
 	"scripts": {
-		"build": "react-router typegen && NODE_ENV=production react-router build && tsc",
+		"build": "NODE_ENV=production react-router build && pnpm run typecheck",
 		"dev": "react-router dev",
 		"preview": "pnpx serve build/client -L -p 1800",
 		"test": "tsx ./scripts/run-tests.cts pnpm exec playwright test",
-		"typecheck": "react-router typegen && tsc"
+		"typecheck": "react-router typegen && tsc -p tsconfig.build.json"
 	},
 	"imports": {
 		"#playwright": "./playwright.config.ts"

--- a/apps/test-app/tsconfig.build.json
+++ b/apps/test-app/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"customConditions": ["@kiwi/source"]
+		"customConditions": []
 	}
 }

--- a/apps/test-app/tsconfig.json
+++ b/apps/test-app/tsconfig.json
@@ -31,6 +31,9 @@
 		"rootDirs": [".", "./.react-router/types"],
 
 		// Vite takes care of building everything, not tsc.
-		"noEmit": true
+		"noEmit": true,
+
+		// Use TSX source directly for better IDE experience.
+		"customConditions": ["@kiwi/source"]
 	}
 }


### PR DESCRIPTION
It looks like the `customConditions` strategy from https://github.com/iTwin/kiwi/pull/141 stopped working recently (maybe after `typescript` version was bumped in https://github.com/iTwin/kiwi/pull/181).

This PR flips the tsconfigs so that `tsconfig.json` is used by the IDE and `tsconfig.build.json` is used for the prod build.

As a result, making a type change in `packages/` will be instantly reflected in `apps/` by VSCode.