### PR TITLE
change package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This monorepo is a [pnpm workspace](https://pnpm.io/workspaces) which can be con
 
 These are the packages of the Kiwi design system:
 
-- [`@itwin/kiwi-react`](./packages/kiwi-react/): A React component library.
-- [`@itwin/kiwi-icons`](./packages/kiwi-icons/): A standalone SVG icon library.
+- [`@itwin/itwinui-react`](./packages/kiwi-react/): A React component library.
+- [`@itwin/itwinui-icons`](./packages/kiwi-icons/): A standalone SVG icon library.
 
 ### Apps ([`./apps/*`](./apps/))
 

--- a/apps/test-app/app/icons.tsx
+++ b/apps/test-app/app/icons.tsx
@@ -2,12 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Icon, VisuallyHidden } from "@itwin/kiwi-react/bricks";
+import { Icon, VisuallyHidden } from "@itwin/itwinui-react/bricks";
 import type { MetaFunction } from "react-router";
-import iconsListJson from "@itwin/kiwi-icons/icons-list.json";
+import iconsListJson from "@itwin/itwinui-icons/icons-list.json";
 
 const allIcons = import.meta.glob(
-	"../node_modules/@itwin/kiwi-icons/icons/*.svg",
+	"../node_modules/@itwin/itwinui-icons/icons/*.svg",
 	{ eager: true },
 );
 
@@ -17,7 +17,7 @@ export const meta: MetaFunction = () => {
 };
 
 function getIconHref(icon: string) {
-	const module = allIcons[`../node_modules/@itwin/kiwi-icons/icons/${icon}`];
+	const module = allIcons[`../node_modules/@itwin/itwinui-icons/icons/${icon}`];
 	return (module as { default: string })?.default;
 }
 

--- a/apps/test-app/app/index.tsx
+++ b/apps/test-app/app/index.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import globalStyles from "./index.css?url";
 import { Link, type MetaFunction, type LinksFunction } from "react-router";
-import { Anchor, Divider } from "@itwin/kiwi-react/bricks";
+import { Anchor, Divider } from "@itwin/itwinui-react/bricks";
 import styles from "./index.module.css";
 import { toKebabCase } from "./~utils.tsx";
 

--- a/apps/test-app/app/root.tsx
+++ b/apps/test-app/app/root.tsx
@@ -11,7 +11,7 @@ import {
 	ScrollRestoration,
 	type LinksFunction,
 } from "react-router";
-import { Root } from "@itwin/kiwi-react/bricks";
+import { Root } from "@itwin/itwinui-react/bricks";
 import { ColorSchemeProvider, useColorScheme } from "./~utils.tsx";
 
 export const links: LinksFunction = () => {

--- a/apps/test-app/app/sandbox.tsx
+++ b/apps/test-app/app/sandbox.tsx
@@ -13,16 +13,16 @@ import {
 	IconButton,
 	TextBox,
 	VisuallyHidden,
-} from "@itwin/kiwi-react/bricks";
-import * as Tree from "@itwin/kiwi-react-internal/src/bricks/Tree.js";
+} from "@itwin/itwinui-react/bricks";
+import * as Tree from "@itwin/itwinui-react-internal/src/bricks/Tree.js";
 import type { MetaFunction } from "react-router";
-import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
-import searchIcon from "@itwin/kiwi-icons/search.svg";
-import panelLeftIcon from "@itwin/kiwi-icons/panel-left.svg";
-import filterIcon from "@itwin/kiwi-icons/filter.svg";
-import dismissIcon from "@itwin/kiwi-icons/dismiss.svg";
-import lockIcon from "@itwin/kiwi-icons/lock.svg";
-import showIcon from "@itwin/kiwi-icons/visibility-show.svg";
+import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
+import searchIcon from "@itwin/itwinui-icons/search.svg";
+import panelLeftIcon from "@itwin/itwinui-icons/panel-left.svg";
+import filterIcon from "@itwin/itwinui-icons/filter.svg";
+import dismissIcon from "@itwin/itwinui-icons/dismiss.svg";
+import lockIcon from "@itwin/itwinui-icons/lock.svg";
+import showIcon from "@itwin/itwinui-icons/visibility-show.svg";
 
 const title = "Kiwi sandbox";
 export const meta: MetaFunction = () => {

--- a/apps/test-app/app/tests/anchor/index.tsx
+++ b/apps/test-app/app/tests/anchor/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { Anchor } from "@itwin/kiwi-react/bricks";
+import { Anchor } from "@itwin/itwinui-react/bricks";
 
 export const handle = { title: "Anchor" };
 

--- a/apps/test-app/app/tests/button/index.tsx
+++ b/apps/test-app/app/tests/button/index.tsx
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { Button, Icon } from "@itwin/kiwi-react/bricks";
-import placeholderIconHref from "@itwin/kiwi-icons/placeholder.svg";
+import { Button, Icon } from "@itwin/itwinui-react/bricks";
+import placeholderIconHref from "@itwin/itwinui-icons/placeholder.svg";
 
 export const handle = { title: "Button" };
 

--- a/apps/test-app/app/tests/checkbox/index.tsx
+++ b/apps/test-app/app/tests/checkbox/index.tsx
@@ -8,7 +8,7 @@ import {
 	Field,
 	Label,
 	VisuallyHidden,
-} from "@itwin/kiwi-react/bricks";
+} from "@itwin/itwinui-react/bricks";
 import { useId } from "react";
 
 export const handle = { title: "Checkbox" };

--- a/apps/test-app/app/tests/divider/index.tsx
+++ b/apps/test-app/app/tests/divider/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { Divider } from "@itwin/kiwi-react/bricks";
+import { Divider } from "@itwin/itwinui-react/bricks";
 
 export const handle = { title: "Divider" };
 

--- a/apps/test-app/app/tests/dropdown-menu/index.tsx
+++ b/apps/test-app/app/tests/dropdown-menu/index.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { DropdownMenu } from "@itwin/kiwi-react/bricks";
+import { DropdownMenu } from "@itwin/itwinui-react/bricks";
 import { definePage } from "~/~utils.tsx";
 
 export const handle = { title: "DropdownMenu" };

--- a/apps/test-app/app/tests/field/index.tsx
+++ b/apps/test-app/app/tests/field/index.tsx
@@ -10,7 +10,7 @@ import {
 	Label,
 	Radio,
 	Switch,
-} from "@itwin/kiwi-react/bricks";
+} from "@itwin/itwinui-react/bricks";
 
 export const handle = { title: "Field" };
 

--- a/apps/test-app/app/tests/icon-button/index.tsx
+++ b/apps/test-app/app/tests/icon-button/index.tsx
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { IconButton, Icon } from "@itwin/kiwi-react/bricks";
-import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
+import { IconButton, Icon } from "@itwin/itwinui-react/bricks";
+import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
 
 export const handle = { title: "IconButton" };
 

--- a/apps/test-app/app/tests/icon/index.tsx
+++ b/apps/test-app/app/tests/icon/index.tsx
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { Icon } from "@itwin/kiwi-react/bricks";
-import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
+import { Icon } from "@itwin/itwinui-react/bricks";
+import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
 
 export const handle = { title: "Icon" };
 

--- a/apps/test-app/app/tests/kbd/index.tsx
+++ b/apps/test-app/app/tests/kbd/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { Kbd } from "@itwin/kiwi-react/bricks";
+import { Kbd } from "@itwin/itwinui-react/bricks";
 
 export const handle = { title: "Kbd" };
 

--- a/apps/test-app/app/tests/list/index.tsx
+++ b/apps/test-app/app/tests/list/index.tsx
@@ -3,11 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import * as ListItem from "@itwin/kiwi-react-internal/src/bricks/ListItem";
-import { Icon } from "@itwin/kiwi-react-internal/src/bricks/Icon";
+import * as ListItem from "@itwin/itwinui-react-internal/src/bricks/ListItem";
+import { Icon } from "@itwin/itwinui-react-internal/src/bricks/Icon";
 import type { LinksFunction } from "react-router";
 import testStyles from "./index.css?url";
-import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
+import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
 
 export const handle = { title: "List" };
 

--- a/apps/test-app/app/tests/radio/index.tsx
+++ b/apps/test-app/app/tests/radio/index.tsx
@@ -3,7 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage, type VariantProps } from "~/~utils.tsx";
-import { Radio, Label, VisuallyHidden, Field } from "@itwin/kiwi-react/bricks";
+import {
+	Radio,
+	Label,
+	VisuallyHidden,
+	Field,
+} from "@itwin/itwinui-react/bricks";
 import { useId } from "react";
 
 export const handle = { title: "Radio" };

--- a/apps/test-app/app/tests/root/index.tsx
+++ b/apps/test-app/app/tests/root/index.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Button, Root } from "@itwin/kiwi-react/bricks";
+import { Button, Root } from "@itwin/itwinui-react/bricks";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useColorScheme } from "~/~utils.tsx";

--- a/apps/test-app/app/tests/switch/index.tsx
+++ b/apps/test-app/app/tests/switch/index.tsx
@@ -3,7 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage, type VariantProps } from "~/~utils.tsx";
-import { Switch, Label, VisuallyHidden, Field } from "@itwin/kiwi-react/bricks";
+import {
+	Switch,
+	Label,
+	VisuallyHidden,
+	Field,
+} from "@itwin/itwinui-react/bricks";
 import { useId } from "react";
 
 export const handle = { title: "Switch" };

--- a/apps/test-app/app/tests/tabs/index.tsx
+++ b/apps/test-app/app/tests/tabs/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { Tabs } from "@itwin/kiwi-react/bricks";
+import { Tabs } from "@itwin/itwinui-react/bricks";
 
 export const handle = { title: "Tabs" };
 

--- a/apps/test-app/app/tests/tests.tsx
+++ b/apps/test-app/app/tests/tests.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import globalStyles from "./tests.css?url";
-import { VisuallyHidden } from "@itwin/kiwi-react/bricks";
+import { VisuallyHidden } from "@itwin/itwinui-react/bricks";
 import {
 	Outlet,
 	useMatches,

--- a/apps/test-app/app/tests/text-box/index.tsx
+++ b/apps/test-app/app/tests/text-box/index.tsx
@@ -3,9 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage, type VariantProps } from "~/~utils.tsx";
-import { TextBox, Label, Field } from "@itwin/kiwi-react/bricks";
+import { TextBox, Label, Field } from "@itwin/itwinui-react/bricks";
 import { useId } from "react";
-import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
+import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
 
 export const handle = { title: "TextBox" };
 

--- a/apps/test-app/app/tests/textarea/index.tsx
+++ b/apps/test-app/app/tests/textarea/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { Field, Label, TextBox } from "@itwin/kiwi-react/bricks";
+import { Field, Label, TextBox } from "@itwin/itwinui-react/bricks";
 
 export const handle = { title: "Textarea" };
 

--- a/apps/test-app/app/tests/tooltip/index.tsx
+++ b/apps/test-app/app/tests/tooltip/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import { Tooltip, Button, VisuallyHidden } from "@itwin/kiwi-react/bricks";
+import { Tooltip, Button, VisuallyHidden } from "@itwin/itwinui-react/bricks";
 
 export const handle = { title: "Tooltip" };
 

--- a/apps/test-app/app/tests/tree/index.tsx
+++ b/apps/test-app/app/tests/tree/index.tsx
@@ -4,21 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
 import React from "react";
-import { Icon, IconButton } from "@itwin/kiwi-react/bricks";
-import * as Tree from "@itwin/kiwi-react-internal/src/bricks/Tree.js";
+import { Icon, IconButton } from "@itwin/itwinui-react/bricks";
+import * as Tree from "@itwin/itwinui-react-internal/src/bricks/Tree.js";
 
 export const handle = { title: "Tree" };
 
 const placeholderIcon = new URL(
-	"@itwin/kiwi-icons/placeholder.svg",
+	"@itwin/itwinui-icons/placeholder.svg",
 	import.meta.url,
 ).href;
 const unlockIcon = new URL(
-	"@itwin/kiwi-icons/lock-unlocked.svg",
+	"@itwin/itwinui-icons/lock-unlocked.svg",
 	import.meta.url,
 ).href;
 const showIcon = new URL(
-	"@itwin/kiwi-icons/visibility-show.svg",
+	"@itwin/itwinui-icons/visibility-show.svg",
 	import.meta.url,
 ).href;
 

--- a/apps/test-app/app/tokens.tsx
+++ b/apps/test-app/app/tokens.tsx
@@ -6,7 +6,7 @@ import globalStyles from "./tokens.css?url";
 import * as Ariakit from "@ariakit/react";
 import type * as React from "react";
 import type { MetaFunction, LinksFunction } from "react-router";
-import { Button, Divider, Icon } from "@itwin/kiwi-react/bricks";
+import { Button, Divider, Icon } from "@itwin/itwinui-react/bricks";
 import { parseTokens } from "internal/visitors.js";
 import rawLightTokens from "internal/theme-light.json";
 import rawDarkTokens from "internal/theme-dark.json";

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -15,8 +15,8 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "*",
-		"@itwin/kiwi-icons": "*",
-		"@itwin/kiwi-react": "*",
+		"@itwin/itwinui-icons": "workspace:*",
+		"@itwin/itwinui-react": "workspace:*",
 		"@react-router/node": "^7.0.2",
 		"isbot": "^5.1.17",
 		"react": "19",

--- a/apps/test-app/tsconfig.json
+++ b/apps/test-app/tsconfig.json
@@ -26,7 +26,9 @@
 		"baseUrl": ".",
 		"paths": {
 			"~/*": ["./app/*"],
-			"@itwin/kiwi-react-internal/*": ["./node_modules/@itwin/kiwi-react/*"]
+			"@itwin/itwinui-react-internal/*": [
+				"./node_modules/@itwin/itwinui-react/*"
+			]
 		},
 		"rootDirs": [".", "./.react-router/types"],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"description": "Monorepo for the kiwi design system",
 	"scripts": {
 		"build": "pnpm --filter=\"./packages/**\" --filter=\"./apps/**\" build",
-		"build:icons": "pnpm --filter=@itwin/kiwi-icons build",
+		"build:icons": "pnpm --filter=@itwin/itwinui-icons build",
 		"dev": "npm run build:icons && npm run dev:app &",
 		"dev:app": "pnpm --filter=@itwin/test-app dev",
 		"format": "biome format .",

--- a/packages/kiwi-icons/README.md
+++ b/packages/kiwi-icons/README.md
@@ -1,29 +1,29 @@
-# @itwin/kiwi-icons
+# @itwin/itwinui-icons
 
 Icons for the Kiwi design system. Each icon is available as an SVG symbol sprite and contains multiple resolutions of the same icon using [`<symbol>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol) elements. This allows the icon to be used at different sizes with increasing detail and quality. Currently supported symbols as identified by their `id` attribute values are: `icon`, `icon-large`.
 
 ## Usage
 
-Preferred usage is with the `Icon` component from `@itwin/kiwi-react`:
+Preferred usage is with the `Icon` component from `@itwin/itwinui-react`:
 
 1. Import the icon you want to use.
 
    Using the [`import.meta`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta) feature to get the URL of the icon (does not work with SSR):
 
    ```tsx
-   const placeholderIcon = new URL("@itwin/kiwi-icons/placeholder.svg", import.meta.url).href;
+   const placeholderIcon = new URL("@itwin/itwinui-icons/placeholder.svg", import.meta.url).href;
    ```
 
    Or a static import:
 
    ```tsx
-   import placeholderIcon from "@itwin/kiwi-icons/placeholder.svg";
+   import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
    ```
 
 2. Render the `Icon` component.
 
    ```tsx
-   import { Icon } from "@itwin/kiwi-react";
+   import { Icon } from "@itwin/itwinui-react";
 
    <Icon href={placeholderIcon} />
 
@@ -45,19 +45,19 @@ Preferred usage is with the `Icon` component from `@itwin/kiwi-react`:
    ```
 
 > [!IMPORTANT]
-> Icons of `@itwin/kiwi-icons` should always be used as external resources. Do not inline the SVG content directly in your HTML or React components.
+> Icons of `@itwin/itwinui-icons` should always be used as external resources. Do not inline the SVG content directly in your HTML or React components.
 
 ## Bundler configuration
 
 ### Vite
 
-Within your Vite configuration file, you will need to configure `assetsInlineLimit` option to ensure SVG icons from `@itwin/kiwi-icons` are not inlined:
+Within your Vite configuration file, you will need to configure `assetsInlineLimit` option to ensure SVG icons from `@itwin/itwinui-icons` are not inlined:
 
 ```ts
 defineConfig({
 	build: {
 		assetsInlineLimit: (filePath) => {
-			if (filePath.includes("@itwin/kiwi-icons/")) return false;
+			if (filePath.includes("@itwin/itwinui-icons/")) return false;
 			return undefined;
 		},
 	},

--- a/packages/kiwi-icons/package.json
+++ b/packages/kiwi-icons/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "@itwin/kiwi-icons",
+	"name": "@itwin/itwinui-icons",
 	"private": true,
 	"type": "module",
-	"version": "0.1.0",
+	"version": "5.0.0-alpha.0",
 	"license": "CC-BY-3.0",
 	"exports": {
 		"./*.svg": "./icons/*.svg",

--- a/packages/kiwi-react/README.md
+++ b/packages/kiwi-react/README.md
@@ -1,4 +1,4 @@
-# @itwin/kiwi-react
+# @itwin/itwinui-react
 
 A React component library for the Kiwi design system.
 
@@ -7,7 +7,7 @@ A React component library for the Kiwi design system.
 To use components from the Kiwi design system in your app, you’ll need to wrap your app’s UI with Kiwi’s `<Root>` component, and specify the required `colorScheme` and `density` props:
 
 ```jsx
-import { Root } from "@itwin/kiwi-react/bricks";
+import { Root } from "@itwin/itwinui-react/bricks";
 
 export function App() {
 	return (
@@ -20,7 +20,7 @@ export function App() {
 
 This will ensure Kiwi’s styles are loaded to either the document or the encompassing shadow root.
 
-Once that’s in place you can import and use components from `@itwin/kiwi-react/bricks`.
+Once that’s in place you can import and use components from `@itwin/itwinui-react/bricks`.
 
 ## Contributing
 

--- a/packages/kiwi-react/package.json
+++ b/packages/kiwi-react/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "@itwin/kiwi-react",
+	"name": "@itwin/itwinui-react",
 	"private": true,
 	"type": "module",
-	"version": "0.1.0",
+	"version": "5.0.0-alpha.0",
 	"license": "MIT",
 	"sideEffects": false,
 	"exports": {

--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -15,11 +15,11 @@ interface IconProps extends Omit<BaseProps<"svg">, "children"> {
 }
 
 /**
- * Icon component that provides fill and sizing to the SVGs from `@itwin/kiwi-icons`.
+ * Icon component that provides fill and sizing to the SVGs from `@itwin/itwinui-icons`.
  * It uses an external symbol sprite to render the icon based on the specified `size`.
  *
  * ```tsx
- * const arrowIcon = new URL("@itwin/kiwi-icons/icons/arrow.svg", import.meta.url).href;
+ * const arrowIcon = new URL("@itwin/itwinui-icons/icons/arrow.svg", import.meta.url).href;
  * <Icon href={arrowIcon} />
  * ```
  *

--- a/packages/kiwi-react/src/bricks/IconButton.tsx
+++ b/packages/kiwi-react/src/bricks/IconButton.tsx
@@ -68,7 +68,7 @@ type IconButtonProps = IconButtonBaseProps & IconButtonExtraProps;
  * ```tsx
  * <IconButton
  *   label="Reveal full content"
- *   icon={new URL("@itwin/kiwi-icons/icons/arrow.svg", import.meta.url).href}
+ *   icon={new URL("@itwin/itwinui-icons/icons/arrow.svg", import.meta.url).href}
  * />
  * ```
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,11 +37,11 @@ importers:
       "@ariakit/react":
         specifier: "*"
         version: 0.4.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@itwin/kiwi-icons":
-        specifier: "*"
+      "@itwin/itwinui-icons":
+        specifier: workspace:*
         version: link:../../packages/kiwi-icons
-      "@itwin/kiwi-react":
-        specifier: "*"
+      "@itwin/itwinui-react":
+        specifier: workspace:*
         version: link:../../packages/kiwi-react
       "@react-router/node":
         specifier: ^7.0.2


### PR DESCRIPTION
This is in preparation for publishing. The packages have been renamed.

- `@itwin/kiwi-react` → `@itwin/itwinui-react`
- `@itwin/kiwi-icons` → `@itwin/itwinui-icons`

The versions have been set to `5.0.0-alpha.0`. The actual version number doesn't matter too much right now; we will be publishing to the `alpha` npm tag.

I've also changed the specifiers for these packages in `test-app#package.json` from `*` to `workspace:*`. This is not strictly necessary but more correct and helps avoid conflicts with other versions of those packages that exist in the NPM registry.