### PR TITLE
use MIT license for icons

### DIFF
--- a/packages/kiwi-icons/LICENSE.md
+++ b/packages/kiwi-icons/LICENSE.md
@@ -1,0 +1,9 @@
+# MIT License
+
+Copyright © 2024 Bentley Systems, Incorporated. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/kiwi-icons/package.json
+++ b/packages/kiwi-icons/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "@itwin/itwinui-icons",
 	"type": "module",
-	"version": "5.0.0-alpha.0",
-	"license": "CC-BY-3.0",
+	"version": "5.0.0-alpha.1",
+	"license": "MIT",
 	"exports": {
 		"./*.svg": "./icons/*.svg",
 		"./icons-list.json": "./icons-list.json"
 	},
-	"files": ["icons/*.svg", "icons-list.json"],
+	"files": ["icons/*.svg", "icons-list.json", "LICENSE.md"],
 	"description": "A standalone SVG icon library",
 	"author": "Bentley Systems",
 	"homepage": "https://github.com/iTwin/kiwi",


### PR DESCRIPTION
We are going with MIT license for the icons library. This is a change from the past where we've licensed our icons library under CC BY 3.0.


- Added missing `LICENSE.md` file to kiwi-icons source and updated corresponding fields in `package.json`.
- Updated `package.json#version` as well, so I can make a release after this merges.