### PR TITLE
use single `typescript` version across the monorepo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,6 @@
 	"[jsonc]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
-	"explorer.sortOrderLexicographicOptions": "unicode"
+	"explorer.sortOrderLexicographicOptions": "unicode",
+	"typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"internal": "workspace:*",
 		"lefthook": "^1.8.5",
 		"prettier": "3.3.3",
-		"tsx": "^4.19.2"
+		"tsx": "^4.19.2",
+		"typescript": "~5.7.2"
 	},
 	"engines": {
 		"node": ">=22.11.0"
@@ -30,7 +31,8 @@
 	"packageManager": "pnpm@9.14.4",
 	"pnpm": {
 		"overrides": {
-			"cookie@<0.7.0": ">=0.7.0"
+			"cookie@<0.7.0": ">=0.7.0",
+			"typescript": "5.7.2"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   cookie@<0.7.0: ">=0.7.0"
+  typescript: 5.7.2
 
 importers:
   .:
@@ -31,6 +32,9 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
+      typescript:
+        specifier: 5.7.2
+        version: 5.7.2
 
   apps/test-app:
     dependencies:
@@ -87,7 +91,7 @@ importers:
         specifier: ^1.28.2
         version: 1.28.2
       typescript:
-        specifier: "5"
+        specifier: 5.7.2
         version: 5.7.2
       vite:
         specifier: ^6.0.2
@@ -135,7 +139,7 @@ importers:
         specifier: "19"
         version: 19.0.0(react@19.0.0)
       typescript:
-        specifier: "5"
+        specifier: 5.7.2
         version: 5.7.2
 
 packages:
@@ -1243,7 +1247,7 @@ packages:
     peerDependencies:
       "@react-router/serve": ^7.0.2
       react-router: ^7.0.2
-      typescript: ^5.1.0
+      typescript: 5.7.2
       vite: ^5.1.0
       wrangler: ^3.28.2
     peerDependenciesMeta:
@@ -1262,7 +1266,7 @@ packages:
     engines: { node: ">=20.0.0" }
     peerDependencies:
       react-router: 7.0.2
-      typescript: ^5.1.0
+      typescript: 5.7.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2636,7 +2640,7 @@ packages:
     engines: { node: ^18 || >=20 }
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: 5.7.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2712,7 +2716,7 @@ packages:
         integrity: sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==,
       }
     peerDependencies:
-      typescript: ">=5"
+      typescript: 5.7.2
     peerDependenciesMeta:
       typescript:
         optional: true


### PR DESCRIPTION
I noticed an issue in #208 where my IDE wasn't raising a typescript error that was happening during build. This was because VSCode was using an older typescript version than the one we use in our repo.

I fixed this by setting changing our vscode settings to prefer the workspace version of typescript (see [docs](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript)).

This required installing `typescript` in the main `package.json`, which made me realize we should also force synchronize the typescript version everywhere using `overrides`.