### PR TITLE
remove type assertion for `popover`

### DIFF
--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -44,8 +44,8 @@ function DropdownMenu(props: DropdownMenuProps) {
 	} = props;
 
 	const store = Ariakit.useMenuStore();
-	const open = Ariakit.useStoreState(store, (store) => store.open);
-	const popover = Ariakit.useStoreState(store, (store) => store.popoverElement);
+	const open = Ariakit.useStoreState(store, (state) => state.open);
+	const popover = Ariakit.useStoreState(store, (state) => state.popoverElement);
 
 	React.useEffect(
 		function syncPopoverWithOpenState() {
@@ -82,7 +82,7 @@ const DropdownMenuContent = forwardRef<"div", DropdownMenuContentProps>(
 				unmountOnHide
 				{...props}
 				style={{ zIndex: supportsPopover ? undefined : 9999, ...props.style }}
-				wrapperProps={{ popover: "manual" } as React.ComponentProps<"div">}
+				wrapperProps={{ popover: "manual" }}
 				className={cx("🥝-dropdown-menu", props.className)}
 				ref={forwardedRef}
 			/>

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -102,7 +102,7 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 							zIndex: supportsPopover ? undefined : 9999,
 							...props.style,
 						}}
-						wrapperProps={{ popover: "manual" } as React.ComponentProps<"div">}
+						wrapperProps={{ popover: "manual" }}
 						portal={!supportsPopover}
 					>
 						{content}


### PR DESCRIPTION
It seems like after recent updates (to TS and React versions), the `popover` types are available without any hacks, so I was able to remove the type assertion.

While I was here, I also corrected the name of a `store` variable to `state`.