### PR TITLE
add JSDoc comments to all components

### DIFF
--- a/packages/kiwi-react/src/bricks/Anchor.tsx
+++ b/packages/kiwi-react/src/bricks/Anchor.tsx
@@ -11,6 +11,16 @@ interface AnchorProps extends FocusableProps<"a"> {
 	tone?: "neutral" | "accent" | "critical";
 }
 
+/**
+ * A styled anchor element, typically used for navigating to a different location.
+ *
+ * Example:
+ * ```tsx
+ * <Anchor href="https://www.example.com">Example</Anchor>
+ * ```
+ *
+ * Supports a `tone` prop to change the tone (color) of the anchor.
+ */
 export const Anchor = forwardRef<"a", AnchorProps>((props, forwardedRef) => {
 	const { tone = "neutral", ...rest } = props;
 	return (

--- a/packages/kiwi-react/src/bricks/Button.tsx
+++ b/packages/kiwi-react/src/bricks/Button.tsx
@@ -9,7 +9,11 @@ import { forwardRef, type FocusableProps } from "./~utils.js";
 type ButtonProps = FocusableProps<"button"> &
 	(
 		| {
-				/** @default "solid" */
+				/**
+				 * The variant of the button, i.e. solid, outline, or ghost.
+				 *
+				 * @default "solid"
+				 */
 				variant?: "solid";
 				/**
 				 * The tone of the button. Most buttons should be neutral.
@@ -27,6 +31,26 @@ type ButtonProps = FocusableProps<"button"> &
 		  }
 	);
 
+/**
+ * A styled button element which allows the user to perform an action when clicked.
+ *
+ * Example:
+ * ```tsx
+ * <Button onClick={() => doSomething()}>Click me</Button>
+ * ```
+ *
+ * Start and end icons can be added by passing `Icon` as children.
+ *
+ * ```tsx
+ * <Button>
+ *   <Icon href={…} />
+ *   Click me
+ *   <Icon href={…} />
+ * </Button>
+ * ```
+ *
+ * The button's appearance can be customized using the `variant` and `tone` props.
+ */
 export const Button = forwardRef<"button", ButtonProps>(
 	(props, forwardedRef) => {
 		const { variant = "solid", tone = "neutral", ...rest } = props;

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -19,6 +19,21 @@ type CheckboxOwnProps = Pick<
 
 interface CheckboxProps extends InputBaseProps, CheckboxOwnProps {}
 
+/**
+ * A styled checkbox element, typically used for selecting one or more options from a list.
+ *
+ * Works well the `Field` and `Label` components.
+ *
+ * ```tsx
+ * <Field>
+ *   <Label>Check me</Label>
+ *   <Checkbox />
+ * </Field>
+ * ```
+ *
+ * Underneath, it's an HTML checkbox, i.e. `<input type="checkbox">`, so it supports the same props,
+ * including `value`, `defaultChecked`, `checked`, and `onChange`.
+ */
 export const Checkbox = forwardRef<"input", CheckboxProps>(
 	(props, forwardedRef) => {
 		const fieldId = useFieldId();

--- a/packages/kiwi-react/src/bricks/Divider.tsx
+++ b/packages/kiwi-react/src/bricks/Divider.tsx
@@ -18,7 +18,7 @@ interface DividerProps
 }
 
 /**
- * The `Divider` component can be used for grouping and dividing content within a layout.
+ * A styled "separator" element (e.g. `<hr>`), useful for grouping and dividing content within a layout.
  *
  * A `Divider` can be oriented horizontally or vertically (using the `orientation` prop),
  * and can be a semantic divider or a purely presentational one (using the `presentational` prop).

--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -20,19 +20,24 @@ interface DropdownMenuProps
 	> {}
 
 /**
- * Dropdown menu component displays a list of actions or commands.
+ * A dropdown menu displays a list of actions or commands when the menu button is clicked.
  *
+ * `DropdownMenu` is a compound component with subcomponents exposed for different parts.
+ *
+ * Example:
  * ```tsx
  * <DropdownMenu.Root>
- *		<DropdownMenu.Button>Actions</DropdownMenu.Button>
+ *   <DropdownMenu.Button>Actions</DropdownMenu.Button>
  *
- *		<DropdownMenu.Content>
- *			<DropdownMenu.Item>Add</DropdownMenu.Item>
- *			<DropdownMenu.Item>Edit</DropdownMenu.Item>
- *			<DropdownMenu.Item>Delete</DropdownMenu.Item>
- *		</DropdownMenu.Content>
+ *   <DropdownMenu.Content>
+ *     <DropdownMenu.Item>Add</DropdownMenu.Item>
+ *     <DropdownMenu.Item>Edit</DropdownMenu.Item>
+ *     <DropdownMenu.Item>Delete</DropdownMenu.Item>
+ *   </DropdownMenu.Content>
  * </DropdownMenu.Root>
  * ```
+ *
+ * **Note**: `DropdownMenu` should not be used for navigation; it is only intended for actions.
  */
 function DropdownMenu(props: DropdownMenuProps) {
 	const {
@@ -74,6 +79,11 @@ DEV: DropdownMenu.displayName = "DropdownMenu.Root";
 
 interface DropdownMenuContentProps extends FocusableProps {}
 
+/**
+ * The actual "menu" portion containing the items shown within the dropdown.
+ *
+ * Should be used as a child of `DropdownMenu.Root`.
+ */
 const DropdownMenuContent = forwardRef<"div", DropdownMenuContentProps>(
 	(props, forwardedRef) => {
 		return (
@@ -95,6 +105,23 @@ DEV: DropdownMenuContent.displayName = "DropdownMenu.Content";
 
 interface DropdownMenuButtonProps extends FocusableProps<"button"> {}
 
+/**
+ * The button that triggers the dropdown menu to open.  Should be used as a child of `DropdownMenu.Root`.
+ *
+ * Example:
+ * ```tsx
+ * <DropdownMenu.Button>Actions</DropdownMenu.Button>
+ * ```
+ *
+ * By default it will render a solid `Button` with a disclosure arrow. This can be
+ * customized by passing a `render` prop.
+ *
+ * ```tsx
+ * <DropdownMenu.Button
+ *   render={<IconButton variant="ghost" label="More" icon={<Icon href={…} />}  />}
+ * />
+ * ```
+ */
 const DropdownMenuButton = forwardRef<"button", DropdownMenuButtonProps>(
 	(props, forwardedRef) => {
 		const { accessibleWhenDisabled = true, children, ...rest } = props;
@@ -117,25 +144,33 @@ const DropdownMenuButton = forwardRef<"button", DropdownMenuButtonProps>(
 DEV: DropdownMenuButton.displayName = "DropdownMenu.Button";
 
 // ----------------------------------------------------------------------------
+
 interface DropdownMenuItemProps extends FocusableProps {
 	/**
 	 * A string defining the keyboard shortcut(s) associated with the menu item.
-	 * Shortcuts should be formatted as a single string with keys separated by the '+' character.
-	 * For example: "Ctrl+S" or "Alt+Enter".
 	 *
-	 * @example
-	 * // A single shortcut:
-	 * shortcuts: "Ctrl+S"
+	 * ```tsx
+	 * shortcuts="S" // A single key shortcut
+	 * ```
 	 *
-	 * @example
-	 * // A multi-key combination:
-	 * shortcuts: "Ctrl+Shift+S"
+	 * Multiple keys should be separated by the '+' character.
 	 *
-	 * @default undefined
+	 * ```tsx
+	 * shortcuts="Ctrl+Shift+S" // A multi-key combination
+	 * ```
 	 */
 	shortcuts?: string;
 }
 
+/**
+ * A single menu item within the dropdown menu. Should be used as a child of `DropdownMenu.Content`.
+ *
+ * Example:
+ * ```tsx
+ * <DropdownMenu.Item>Add</DropdownMenu.Item>
+ * <DropdownMenu.Item>Edit</DropdownMenu.Item>
+ * ```
+ */
 const DropdownMenuItem = forwardRef<"div", DropdownMenuItemProps>(
 	(props, forwardedRef) => {
 		const { shortcuts, ...rest } = props;

--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -16,6 +16,26 @@ interface FieldProps extends BaseProps {
 	layout?: "inline";
 }
 
+/**
+ * A container for form controls. It manages ID associations provides a consistent layout and spacing.
+ *
+ * Example:
+ * ```tsx
+ * <Field>
+ *   <Label>Label</Label>
+ *   <TextBox.Input />
+ * </Field>
+ * ```
+ *
+ * Supports a `layout` prop, which can be set to `inline` to align the label and control horizontally.
+ *
+ * Should contain a `Label` component paired with a form control. Supported form controls include:
+ * - `TextBox.Input`
+ * - `TextBox.Textarea`
+ * - `Checkbox`
+ * - `Radio`
+ * - `Switch`
+ */
 export const Field = forwardRef<"div", FieldProps>((props, forwardedRef) => {
 	const fieldId = React.useId();
 	const { className, layout, ...rest } = props;

--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -19,7 +19,7 @@ interface IconProps extends Omit<BaseProps<"svg">, "children"> {
  * It uses an external symbol sprite to render the icon based on the specified `size`.
  *
  * ```tsx
- * const arrowIcon = new URL("@itwin/itwinui-icons/icons/arrow.svg", import.meta.url).href;
+ * const arrowIcon = new URL("@itwin/itwinui-icons/arrow.svg", import.meta.url).href;
  * <Icon href={arrowIcon} />
  * ```
  *

--- a/packages/kiwi-react/src/bricks/IconButton.tsx
+++ b/packages/kiwi-react/src/bricks/IconButton.tsx
@@ -68,7 +68,7 @@ type IconButtonProps = IconButtonBaseProps & IconButtonExtraProps;
  * ```tsx
  * <IconButton
  *   label="Reveal full content"
- *   icon={new URL("@itwin/itwinui-icons/icons/arrow.svg", import.meta.url).href}
+ *   icon={new URL("@itwin/itwinui-icons/arrow.svg", import.meta.url).href}
  * />
  * ```
  *
@@ -91,6 +91,7 @@ type IconButtonProps = IconButtonBaseProps & IconButtonExtraProps;
  *   isActive={isActive}
  *   onClick={() => setIsActive(!isActive)}
  * />
+ * ```
  */
 export const IconButton = forwardRef<"button", IconButtonProps>(
 	(props, forwardedRef) => {

--- a/packages/kiwi-react/src/bricks/Label.tsx
+++ b/packages/kiwi-react/src/bricks/Label.tsx
@@ -9,6 +9,26 @@ import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface LabelProps extends BaseProps<"label"> {}
 
+/**
+ * A styled wrapper over the HTML `<label>` element, used for labelling form controls.
+ * 
+ * Can be used standalone:
+
+ * ```tsx
+ * <Label htmlFor="my-input">Label</Label>
+ * <TextBox.Input id="my-input" />
+ * ```
+ * 
+ * Or within a `Field` component to automatically manage ID associations:
+ * 
+ * ```tsx
+ * <Field>
+ *   <Label>Label</Label>
+ *   <TextBox.Input />
+ * </Field>
+ * ```
+ * 
+ */
 export const Label = forwardRef<"label", LabelProps>((props, forwardedRef) => {
 	const fieldId = useFieldId();
 

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -13,6 +13,21 @@ type RadioOwnProps = Pick<Ariakit.RadioProps, "value" | "checked" | "onChange">;
 
 interface RadioProps extends InputBaseProps, RadioOwnProps {}
 
+/**
+ * A styled radio input element, typically used for selecting a single option from a list.
+ *
+ * Works well with the `Field` and `Label` components.
+ *
+ * ```tsx
+ * <Field>
+ *   <Label>Choose one</Label>
+ *   <Radio />
+ * </Field>
+ * ```
+ *
+ * Underneath, it's an HTML radio input, i.e. `<input type="radio">`, so it supports the same props,
+ * including `value`, `defaultChecked`, `checked`, and `onChange`.
+ */
 export const Radio = forwardRef<"input", RadioProps>((props, forwardedRef) => {
 	const fieldId = useFieldId();
 

--- a/packages/kiwi-react/src/bricks/Root.tsx
+++ b/packages/kiwi-react/src/bricks/Root.tsx
@@ -36,8 +36,17 @@ interface RootProps extends BaseProps {
 }
 
 /**
- * Component to be used at the root of your application. It ensures that kiwi styles are loaded
+ * Component to be used at the root of your application. It ensures that kiwi styles and fonts are loaded
  * and automatically applied to the current page or the encompassing shadow-root.
+ *
+ * Make sure to specify the `colorScheme` and `density` props.
+ *
+ * Example:
+ * ```tsx
+ * <Root colorScheme="dark" density="dense">
+ *   <App />
+ * </Root>
+ * ```
  */
 export const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 	const { children, synchronizeColorScheme = false, ...rest } = props;

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -21,6 +21,21 @@ interface SwitchProps extends InputBaseProps, CheckboxOwnProps {
 	checked?: boolean;
 }
 
+/**
+ * A toggle switch element, typically used for enabling or disabling a feature.
+ *
+ * Works well with the `Field` and `Label` components.
+ *
+ * ```tsx
+ * <Field>
+ *   <Label>Enable feature</Label>
+ *   <Switch />
+ * </Field>
+ * ```
+ *
+ * Underneath, it's an HTML checkbox, i.e. `<input type="checkbox">`, so it supports the same props,
+ * including `value`, `defaultChecked`, `checked`, and `onChange`.
+ */
 export const Switch = forwardRef<"input", SwitchProps>(
 	(props, forwardedRef) => {
 		const fieldId = useFieldId();

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -21,6 +21,34 @@ interface TabsProps
 		| "children"
 	> {}
 
+/**
+ * A set of tabs that can be used to switch between different views.
+ *
+ * `Tabs` is a compound component with subcomponents exposed for different parts.
+ *
+ * Example:
+ * ```tsx
+ * <Tabs.Root>
+ *   <Tabs.TabList>
+ *     <Tabs.Tab id="tab-1">Tab 1</Tabs.Tab>
+ *     <Tabs.Tab id="tab-2">Tab 2</Tabs.Tab>
+ *     <Tabs.Tab id="tab-3">Tab 3</Tabs.Tab>
+ *   </Tabs.TabList>
+ *
+ *   <Tabs.TabPanel tabId="tab-1">Tab 1 content</Tabs.TabPanel>
+ *   <Tabs.TabPanel tabId="tab-2">Tab 2 content</Tabs.TabPanel>
+ *   <Tabs.TabPanel tabId="tab-3">Tab 3 content</Tabs.TabPanel>
+ * </Tabs.Root>
+ * ```
+ *
+ * The tabs and their panels are connected by matching the `id` prop on the `Tabs.Tab` component with
+ * the `tabId` prop on the `Tabs.TabPanel` component.
+ *
+ * The `Tabs` component automatically manages the selected tab state. The initially selected tab can be set using `defaultSelectedId`.
+ * To take full control the selected tab state, use the `selectedId` and `setSelectedId` props together.
+ *
+ * **Note**: `Tabs` should _not_ be used for navigation; it is only intended for switching smaller views within an existing page.
+ */
 function Tabs(props: TabsProps) {
 	const {
 		defaultSelectedId,
@@ -68,6 +96,19 @@ interface TabListProps extends BaseProps {
 	tone?: "neutral" | "accent";
 }
 
+/**
+ * A simple container for the tab buttons.
+ * Should be used as a child of `Tabs.Root` and consist of the individual `Tabs.Tab` components.
+ *
+ * Example:
+ * ```tsx
+ * <Tabs.TabList>
+ *   <Tabs.Tab id="tab-1">Tab 1</Tabs.Tab>
+ *   <Tabs.Tab id="tab-2">Tab 2</Tabs.Tab>
+ *   <Tabs.Tab id="tab-3">Tab 3</Tabs.Tab>
+ * </Tabs.TabList>
+ * ```
+ */
 const TabList = forwardRef<"div", TabListProps>((props, forwardedRef) => {
 	const { tone = "neutral", ...rest } = props;
 	const viewTransitionName = `🥝active-stripe-${React.useId().replaceAll(":", "_")}`;
@@ -95,6 +136,17 @@ interface TabProps
 	extends FocusableProps<"button">,
 		Pick<Ariakit.TabProps, "id"> {}
 
+/**
+ * An individual tab button that switches the selected tab panel when clicked.
+ *
+ * Should be used as a child of `Tabs.TabList` and be paired with a `Tabs.TabPanel`,
+ * connected using an id.
+ *
+ * Example:
+ * ```tsx
+ * <Tabs.Tab id="tab-1">Tab 1</Tabs.Tab>
+ * ```
+ */
 const Tab = forwardRef<"button", TabProps>((props, forwardedRef) => {
 	return (
 		<Ariakit.Tab
@@ -113,6 +165,15 @@ interface TabPanelProps
 	extends BaseProps<"div">,
 		Pick<Ariakit.TabPanelProps, "tabId" | "unmountOnHide"> {}
 
+/**
+ * The actual content of a tab, shown when the tab is selected. Should be used as a child of `Tabs.Root`.
+ * The `tabId` prop should match the `id` prop of the corresponding `Tabs.Tab` component.
+ *
+ * Example:
+ * ```tsx
+ * <Tabs.TabPanel tabId="tab-1">Tab 1 content</Tabs.TabPanel>
+ * ```
+ */
 const TabPanel = forwardRef<"div", TabPanelProps>((props, forwardedRef) => {
 	return (
 		<Ariakit.TabPanel

--- a/packages/kiwi-react/src/bricks/Text.tsx
+++ b/packages/kiwi-react/src/bricks/Text.tsx
@@ -27,7 +27,7 @@ interface TextProps extends BaseProps {
 }
 
 /**
- * An element with text styles applied.
+ * An element with text styles applied. Useful for paragraphs, headings, and other text content.
  *
  * Example usage:
  * ```tsx

--- a/packages/kiwi-react/src/bricks/TextBox.tsx
+++ b/packages/kiwi-react/src/bricks/TextBox.tsx
@@ -31,7 +31,7 @@ interface TextBoxInputProps extends Omit<BaseInputProps, "children" | "type"> {
 }
 
 /**
- * Input component that allows users to enter text based values.
+ * An input component that allows users to enter text based values.
  *
  * Example usage:
  * ```tsx
@@ -39,6 +39,19 @@ interface TextBoxInputProps extends Omit<BaseInputProps, "children" | "type"> {
  * ```
  *
  * To add additional decorations, see `TextBox.Root` component.
+ *
+ * Works well with the `Field` and `Label` components.
+ * ```tsx
+ * <Field>
+ *   <Label>Enter your name</Label>
+ *   <TextBox.Input />
+ * </Field>
+ * ```
+ *
+ * Underneath, it's an HTML input, i.e. `<input>`, so it supports the same props, including
+ * `value`, `defaultValue`, `onChange`, and `disabled`.
+ *
+ * For a multiline text input, use the `TextBox.Textarea` component.
  */
 const TextBoxInput = forwardRef<"input", TextBoxInputProps>(
 	(props, forwardedRef) => {
@@ -71,14 +84,25 @@ DEV: TextBoxInput.displayName = "TextBox.Input";
 interface TextBoxRootProps extends BaseProps {}
 
 /**
- * Root component allows adding additional decorations to text based inputs.
+ * Compound component for a text input. Allows adding additional decorations.
  *
  * Example usage to add an end icon:
  * ```tsx
  * <TextBox.Root>
- * 	<TextBox.Input defaultValue="Hello" />
- * 	<TextBox.Icon href={...} />
+ *   <TextBox.Input defaultValue="Hello" />
+ *   <TextBox.Icon href={...} />
  * </TextBox.Root>
+ * ```
+ *
+ * Works well with the `Field` and `Label` components.
+ * ```tsx
+ * <Field>
+ *   <Label>Enter your name</Label>
+ *   <TextBox.Root>
+ *     <TextBox.Input />
+ *     <TextBox.Icon href={…} />
+ *   </TextBox.Root>
+ * </Field>
  * ```
  */
 const TextBoxRoot = forwardRef<"div", TextBoxRootProps>(
@@ -116,6 +140,9 @@ DEV: TextBoxRoot.displayName = "TextBox.Root";
 
 interface TextBoxIconProps extends React.ComponentProps<typeof Icon> {}
 
+/**
+ * A static icon decoration for the `TextBox.Root` component. Can be added before or after the `TextBox.Input`.
+ */
 const TextBoxIcon = forwardRef<"svg", TextBoxIconProps>(
 	(props, forwardedRef) => {
 		return (
@@ -133,6 +160,9 @@ DEV: TextBoxIcon.displayName = "TextBox.Icon";
 
 interface TextBoxTextProps extends BaseProps<"span"> {}
 
+/**
+ * A static text decoration for the `TextBox.Root` component. Can be added before or after the `TextBox.Input`.
+ */
 const TextBoxText = forwardRef<"span", TextBoxTextProps>(
 	(props, forwardedRef) => {
 		return (

--- a/packages/kiwi-react/src/bricks/Textarea.tsx
+++ b/packages/kiwi-react/src/bricks/Textarea.tsx
@@ -10,12 +10,23 @@ import { forwardRef, type FocusableProps } from "./~utils.js";
 interface TextareaProps extends FocusableProps<"textarea"> {}
 
 /**
- * Textarea component that allows users to enter multiline text values.
+ * A styled textarea element that allows users to enter multiline text values.
  *
  * Example usage:
  * ```tsx
  * <TextBox.Textarea defaultValue="Hello" />
  * ```
+ *
+ * Works well with the `Field` and `Label` components.
+ * ```tsx
+ * <Field>
+ *   <Label>Leave a comment, be kind</Label>
+ *   <TextBox.Textarea />
+ * </Field>
+ * ```
+ *
+ * Underneath, it's an HTML textarea, i.e. `<textarea>`, so it supports the same props, including
+ * `value`, `defaultValue`, `onChange`, and `disabled`.
  */
 export const Textarea = forwardRef<"textarea", TextareaProps>(
 	(props, forwardedRef) => {

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -12,13 +12,17 @@ interface TooltipProps
 		Pick<Ariakit.TooltipProps, "open" | "unmountOnHide">,
 		Pick<Ariakit.TooltipProviderProps, "defaultOpen" | "setOpen"> {
 	/**
-	 * The content to be displayed inside the tooltip.
+	 * The content to be displayed inside the tooltip when the trigger element is hovered or focused.
 	 */
 	content: React.ReactNode;
 
 	/**
 	 * The element that will trigger the tooltip when hovered or focused.
 	 * Common examples include buttons, links, or form controls.
+	 *
+	 * **Note**: The trigger must be a single interactive element. Do not add a
+	 * tooltip to a non-interactive static element (such as a `<div>` or `<svg>`). Also,
+	 * the trigger element must forward its ref and spread its props.
 	 */
 	children: React.ReactElement;
 
@@ -35,7 +39,7 @@ interface TooltipProps
 }
 
 /**
- * Tooltip component that provides additional information or context for a trigger element.
+ * A tooltip component that provides additional information or context for an interactive trigger element.
  *
  * Example usage:
  *
@@ -45,7 +49,10 @@ interface TooltipProps
  * </Tooltip>
  * ```
  *
- * **Note**: If `type` is set to `"none"`, the tooltip will not use ARIA attributes and will unmount when hidden.
+ * **Note**: The trigger element must be a single interactive element, such as a button or link. Do not add a
+ * tooltip to a non-interactive static element (such as a `<div>` or `<svg>`).
+ *
+ * **Note**: If `type` is set to `"none"`, the tooltip will not use ARIA attributes.
  */
 export const Tooltip = forwardRef<"div", TooltipProps>(
 	(props, forwardedRef) => {

--- a/packages/kiwi-react/src/bricks/VisuallyHidden.tsx
+++ b/packages/kiwi-react/src/bricks/VisuallyHidden.tsx
@@ -7,6 +7,19 @@ import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface VisuallyHiddenProps extends BaseProps<"span"> {}
 
+/**
+ * A visually hidden element that is still accessible to screen readers and other assistive technology.
+ *
+ * This is useful when you want to provide a text alternative to a visual element (e.g. an icon or symbol).
+ *
+ * Example:
+ * ```tsx
+ * <span aria-hidden="true">⭐</span>
+ * <VisuallyHidden>Favorite</VisuallyHidden>
+ * ```
+ *
+ * **Note**: The `IconButton` component utilizes `VisuallyHidden` internally when the `label` prop is set.
+ */
 export const VisuallyHidden = forwardRef<"span", VisuallyHiddenProps>(
 	(props, forwardedRef) => {
 		return <Ariakit.VisuallyHidden {...props} ref={forwardedRef} />;


### PR DESCRIPTION
Adds basic JSDoc comments to all publicly-exported components. This is very important now that we have published an initial version of the library.

Going forward, we should keep adding/updating JSDocs together with actual code. It's the best way to ensure our documentation stays current.