### PR TITLE
fix imports

### DIFF
--- a/apps/test-app/app/sandbox.tsx
+++ b/apps/test-app/app/sandbox.tsx
@@ -15,7 +15,7 @@ import {
 	TextBox,
 	VisuallyHidden,
 } from "@itwin/itwinui-react/bricks";
-import * as Tree from "@itwin/itwinui-react-internal/src/bricks/Tree.js";
+import * as Tree from "@itwin/itwinui-react-internal/src/bricks/Tree.tsx";
 import { useSearchParams, type MetaFunction } from "react-router";
 import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
 import searchIcon from "@itwin/itwinui-icons/search.svg";

--- a/apps/test-app/app/tests/checkbox/index.tsx
+++ b/apps/test-app/app/tests/checkbox/index.tsx
@@ -9,7 +9,7 @@ import {
 	Label,
 	VisuallyHidden,
 } from "@itwin/itwinui-react/bricks";
-import { useId } from "react";
+import * as React from "react";
 
 export const handle = { title: "Checkbox" };
 
@@ -29,7 +29,7 @@ export default definePage(
 );
 
 function VisualTest({ checked, indeterminate, disabled }: VariantProps) {
-	const id = useId();
+	const id = React.useId();
 
 	return (
 		<>

--- a/apps/test-app/app/tests/list/index.tsx
+++ b/apps/test-app/app/tests/list/index.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
 import * as ListItem from "@itwin/itwinui-react-internal/src/bricks/ListItem";
-import { Icon } from "@itwin/itwinui-react-internal/src/bricks/Icon";
+import { Icon } from "@itwin/itwinui-react/bricks";
 import type { LinksFunction } from "react-router";
 import testStyles from "./index.css?url";
 import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";

--- a/apps/test-app/app/tests/radio/index.tsx
+++ b/apps/test-app/app/tests/radio/index.tsx
@@ -9,7 +9,7 @@ import {
 	VisuallyHidden,
 	Field,
 } from "@itwin/itwinui-react/bricks";
-import { useId } from "react";
+import * as React from "react";
 
 export const handle = { title: "Radio" };
 
@@ -43,7 +43,7 @@ export default definePage(
 );
 
 function VisualTest({ checked, disabled }: VariantProps) {
-	const id = useId();
+	const id = React.useId();
 
 	return (
 		<>

--- a/apps/test-app/app/tests/switch/index.tsx
+++ b/apps/test-app/app/tests/switch/index.tsx
@@ -9,7 +9,7 @@ import {
 	VisuallyHidden,
 	Field,
 } from "@itwin/itwinui-react/bricks";
-import { useId } from "react";
+import * as React from "react";
 
 export const handle = { title: "Switch" };
 
@@ -26,7 +26,7 @@ export default definePage(
 );
 
 function VisualTest({ checked, disabled }: VariantProps) {
-	const id = useId();
+	const id = React.useId();
 
 	return (
 		<>

--- a/apps/test-app/app/tests/tree/index.tsx
+++ b/apps/test-app/app/tests/tree/index.tsx
@@ -3,24 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { definePage } from "~/~utils.tsx";
-import React from "react";
+import * as React from "react";
 import { Icon, IconButton } from "@itwin/itwinui-react/bricks";
-import * as Tree from "@itwin/itwinui-react-internal/src/bricks/Tree.js";
+import * as Tree from "@itwin/itwinui-react-internal/src/bricks/Tree.tsx";
+import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
+import unlockIcon from "@itwin/itwinui-icons/lock-unlocked.svg";
+import showIcon from "@itwin/itwinui-icons/visibility-show.svg";
 
 export const handle = { title: "Tree" };
-
-const placeholderIcon = new URL(
-	"@itwin/itwinui-icons/placeholder.svg",
-	import.meta.url,
-).href;
-const unlockIcon = new URL(
-	"@itwin/itwinui-icons/lock-unlocked.svg",
-	import.meta.url,
-).href;
-const showIcon = new URL(
-	"@itwin/itwinui-icons/visibility-show.svg",
-	import.meta.url,
-).href;
 
 export default definePage(function Page({
 	overflow = false,

--- a/packages/kiwi-react/src/bricks/Spinner.tsx
+++ b/packages/kiwi-react/src/bricks/Spinner.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as Ariakit from "@ariakit/react";
 import cx from "classnames";
-import { VisuallyHidden } from "@itwin/itwinui-react/bricks";
+import { VisuallyHidden } from "./VisuallyHidden.js";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface SpinnerProps extends BaseProps {


### PR DESCRIPTION
These changes are mostly for consistency reasons.

Of note:
- We should avoid referencing the package name from within the package.
- We should avoid default React import (i.e. `import React`)
- `Icon` is publicly exported, so no need to import it from the internal path.
- SVGs should be imported using Vite's magic syntax (instead of `import.meta.url`). See #157 