### PR TITLE
Implement presentational foundation for `<Description>`

### DIFF
--- a/packages/kiwi-react/src/bricks/Description.css
+++ b/packages/kiwi-react/src/bricks/Description.css
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+.🥝-description:is(.🥝-text) {
+	@layer modifiers {
+		&:where([data-kiwi-tone="neutral"]) {
+			color: var(--kiwi-color-text-neutral-tertiary);
+		}
+
+		&:where([data-kiwi-tone="critical"]) {
+			color: var(--kiwi-color-text-critical-base);
+		}
+	}
+}

--- a/packages/kiwi-react/src/bricks/Description.tsx
+++ b/packages/kiwi-react/src/bricks/Description.tsx
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { forwardRef, type BaseProps } from "./~utils.js";
+import cx from "classnames";
+import { Text } from "./Text.js";
+
+interface DescriptionProps extends BaseProps {
+	tone?: "neutral" | "critical";
+}
+
+/**
+ * An additional description for a form control.
+ *
+ * Should not include content without an adequate text alternative.
+ *
+ * Either give this component an `id` and manually associate with a form control
+ * * using `aria-describedby` on said control or use the `<Field>` component *
+ * (WIP).
+ */
+export const Description = forwardRef<"div", DescriptionProps>(
+	(props, forwardedRef) => {
+		return (
+			<Text
+				{...props}
+				variant="caption-md"
+				data-kiwi-tone={props.tone ?? "neutral"}
+				className={cx("🥝-description", props.className)}
+				ref={forwardedRef}
+			/>
+		);
+	},
+);

--- a/packages/kiwi-react/src/bricks/Description.tsx
+++ b/packages/kiwi-react/src/bricks/Description.tsx
@@ -7,6 +7,10 @@ import cx from "classnames";
 import { Text } from "./Text.js";
 
 interface DescriptionProps extends BaseProps {
+	/**
+	 * The tone of the description.
+	 * @default "neutral"
+	 */
 	tone?: "neutral" | "critical";
 }
 

--- a/packages/kiwi-react/src/bricks/styles.css
+++ b/packages/kiwi-react/src/bricks/styles.css
@@ -9,6 +9,7 @@
 @import "./Anchor.css" layer(kiwi.components);
 @import "./Button.css" layer(kiwi.components);
 @import "./Checkbox.css" layer(kiwi.components);
+@import "./Description.css" layer(kiwi.components);
 @import "./Divider.css" layer(kiwi.components);
 @import "./DropdownMenu.css" layer(kiwi.components);
 @import "./IconButton.css" layer(kiwi.components);


### PR DESCRIPTION
This pull request implements a presentational `<Description>` component internally for now (with the plans to expose it publicly). We’ll need to add the wiring bit to the `<Field>` component as any relevant `aria-` attributes get set on the form control (i.e. they reference the `id` of the description). At this point it’s really just a composition of the `<Text variant="caption-md">` with a prop for setting the `tone`: `neutral` (default) and `critical`. I haven’t included tests for this at this point. I’ll do that when I add the actual functionality in the next PR.

<img width="184" alt="A Field component with a label “input example” above a text box with a description underneath “Supporting text”. The description is 10px and using the color/text/neutral/tertiary colour." src="https://github.com/user-attachments/assets/17c9497e-6997-4638-b496-4124af9ff86e" />

<img width="182" alt="A Field component with a label “input example” above a text box with a description underneath “Supporting text”. The description is 10px and using the color/text/critical/base colour." src="https://github.com/user-attachments/assets/072d15fc-ddf0-4e0e-b5bd-d3e2868d408d" />
