### PR TITLE
use toolbar pattern in `Tree.Actions`

### DIFF
--- a/packages/kiwi-react/src/bricks/IconButton.tsx
+++ b/packages/kiwi-react/src/bricks/IconButton.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
+import * as Ariakit from "@ariakit/react";
 import { Button } from "./Button.js";
 import { VisuallyHidden } from "./VisuallyHidden.js";
 import { Icon } from "./Icon.js";
@@ -97,10 +98,15 @@ export const IconButton = forwardRef<"button", IconButtonProps>(
 	(props, forwardedRef) => {
 		const { label, icon, isActive, labelVariant, ...rest } = props;
 
+		const toolbar = Ariakit.useToolbarContext();
+
 		const button = (
 			<Button
 				aria-pressed={isActive}
 				{...rest}
+				render={
+					toolbar ? <Ariakit.ToolbarItem render={props.render} /> : props.render
+				}
 				className={cx("🥝-icon-button", props.className)}
 				ref={forwardedRef}
 			>

--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -106,13 +106,13 @@ interface TreeItemActionsProps extends BaseProps {}
 const TreeItemActions = forwardRef<"div", TreeItemActionsProps>(
 	(props, forwardedRef) => {
 		return (
-			<Ariakit.Role.div
+			<Ariakit.Toolbar
 				{...props}
 				className={cx("🥝-tree-item-actions", props.className)}
 				ref={forwardedRef}
 			>
 				{props.children}
-			</Ariakit.Role.div>
+			</Ariakit.Toolbar>
 		);
 	},
 );


### PR DESCRIPTION
This is a very simple change: `Tree.Actions` now uses[ Ariakit's `Toolbar` component](https://ariakit.org/components/toolbar) which implements the [ARIA toolbar pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) to reduce the number of tab stops (instead using arrow keys for navigating between items). The `IconButton` will look for toolbar context and become a toolbar item if one is found (when rendered inside `Tree.Actions`).