### PR TITLE
Add `focusable` prop to `Tabs.TabPanel` component

### DIFF
--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -163,7 +163,7 @@ DEV: Tab.displayName = "Tabs.Tab";
 
 interface TabPanelProps
 	extends FocusableProps<"div">,
-		Pick<Ariakit.TabPanelProps, "tabId" | "unmountOnHide"> {}
+		Pick<Ariakit.TabPanelProps, "tabId" | "unmountOnHide" | "focusable"> {}
 
 /**
  * The actual content of a tab, shown when the tab is selected. Should be used as a child of `Tabs.Root`.

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -162,7 +162,7 @@ DEV: Tab.displayName = "Tabs.Tab";
 // ----------------------------------------------------------------------------
 
 interface TabPanelProps
-	extends BaseProps<"div">,
+	extends FocusableProps<"div">,
 		Pick<Ariakit.TabPanelProps, "tabId" | "unmountOnHide"> {}
 
 /**

--- a/packages/kiwi-react/src/bricks/~utils.ts
+++ b/packages/kiwi-react/src/bricks/~utils.ts
@@ -61,5 +61,5 @@ export type FocusableProps<ElementType extends React.ElementType = "div"> =
 	BaseProps<ElementType> &
 		Pick<
 			Ariakit.FocusableProps,
-			"disabled" | "accessibleWhenDisabled" | "autoFocus" | "focusable"
+			"disabled" | "accessibleWhenDisabled" | "autoFocus"
 		>;

--- a/packages/kiwi-react/src/bricks/~utils.ts
+++ b/packages/kiwi-react/src/bricks/~utils.ts
@@ -61,5 +61,5 @@ export type FocusableProps<ElementType extends React.ElementType = "div"> =
 	BaseProps<ElementType> &
 		Pick<
 			Ariakit.FocusableProps,
-			"disabled" | "accessibleWhenDisabled" | "autoFocus"
+			"disabled" | "accessibleWhenDisabled" | "autoFocus" | "focusable"
 		>;


### PR DESCRIPTION
This PR adds `focusable` prop to `Tabs.TabPanel` component. Additionally props type of `Tabs.TabPanel` are changed from `BaseProps` to `FocusableProps`.