### PR TITLE
Do not destructure class names from props

### DIFF
--- a/packages/kiwi-react/src/bricks/Description.tsx
+++ b/packages/kiwi-react/src/bricks/Description.tsx
@@ -28,7 +28,7 @@ interface DescriptionProps extends BaseProps {
 export const Description = forwardRef<"div", DescriptionProps>(
 	(props, forwardedRef) => {
 		const generatedId = React.useId();
-		const { className, id = generatedId, tone, ...rest } = props;
+		const { id = generatedId, tone, ...rest } = props;
 		useFieldRegisterDescribedBy(id);
 
 		return (
@@ -37,7 +37,7 @@ export const Description = forwardRef<"div", DescriptionProps>(
 				id={id}
 				variant="caption-md"
 				data-kiwi-tone={tone ?? "neutral"}
-				className={cx("🥝-description", className)}
+				className={cx("🥝-description", props.className)}
 				ref={forwardedRef}
 			/>
 		);

--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -38,14 +38,14 @@ interface FieldProps extends BaseProps {
  */
 export const Field = forwardRef<"div", FieldProps>((props, forwardedRef) => {
 	const fieldId = React.useId();
-	const { className, layout, ...rest } = props;
+	const { layout, ...rest } = props;
 
 	return (
 		<FieldIdContext.Provider value={fieldId}>
 			<FieldDescribedByProvider>
 				<Ariakit.Role
 					{...rest}
-					className={cx("🥝-field", className)}
+					className={cx("🥝-field", props.className)}
 					data-kiwi-layout={layout}
 					ref={forwardedRef}
 				/>

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -59,7 +59,6 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 		const {
 			content,
 			children,
-			className,
 			type = "description",
 			id = React.useId(),
 			defaultOpen: defaultOpenProp,
@@ -102,7 +101,7 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 						aria-hidden="true"
 						{...rest}
 						unmountOnHide={unmountOnHide}
-						className={cx("🥝-tooltip", className)}
+						className={cx("🥝-tooltip", props.className)}
 						ref={forwardedRef}
 						id={id}
 						style={{

--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -37,8 +37,7 @@ interface TreeItemProps extends Omit<BaseProps, "content"> {
 }
 
 const TreeItem = forwardRef<"div", TreeItemProps>((props, forwardedRef) => {
-	const { selected, content, children, className, expanded, style, ...rest } =
-		props;
+	const { selected, content, children, expanded, style, ...rest } = props;
 
 	const parentContext = React.useContext(TreeItemContext);
 	const level = parentContext ? parentContext.level + 1 : 1;
@@ -60,7 +59,7 @@ const TreeItem = forwardRef<"div", TreeItemProps>((props, forwardedRef) => {
 					data-kiwi-expanded={expanded}
 					data-kiwi-selected={selected}
 					data-kiwi-parent-selected={parentContext?.selected}
-					className={cx("🥝-tree-item", className)}
+					className={cx("🥝-tree-item", props.className)}
 					style={
 						{
 							...style,


### PR DESCRIPTION
This PR makes the code style consist for using `props.className` with `cx` (from `classnames`). We don’t need to destructure the `className` property. For discussion see: https://github.com/iTwin/kiwi/pull/232#discussion_r1913651108
