### PR TITLE
Adding a Dismiss Icon to Kiwi

### DIFF
--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -113,6 +113,7 @@ export const Dismiss = forwardRef<"svg", DismissProps>(
 						height="16"
 						viewBox="0 0 16 16"
 						fill="currentColor"
+						render={props.render}
 					>
 						<path d="M4.853 4.146a.5.5 0 1 0-.707.708L7.293 8l-3.147 3.146a.5.5 0 0 0 .707.708L8 8.707l3.146 3.147a.5.5 0 0 0 .707-.708L8.707 8l3.146-3.146a.5.5 0 1 0-.707-.708L8 7.293 4.853 4.146Z" />
 					</Ariakit.Role.svg>


### PR DESCRIPTION
In this PR I present the addition of a 'dismiss' icon to the project. As part of the 'Chip' component work we discussed in detail ( [here](https://github.com/iTwin/kiwi/pull/253) and [here](https://github.com/iTwin/kiwi/pull/253#discussion_r1924396363) ) about how to approach the use of a button within the Chip.

The initial implementation was purposefully sub-standard to trigger the decision making process that we arrived at.

The consensus is to use IconButton from within the KIWI library - however we don't have access to the Icons from within KIWI.  

This PR adds a Dismiss Icon to the Kiwi project, establishing the approach for future Icon usage and for other components to make use of the icon.

Visual representation of the Icon is as follows : 

<img width="164" alt="image" src="https://github.com/user-attachments/assets/c15ea8d2-d3ab-461f-85cf-c68371894f50" />

Looking at the design I can see that there is a 'small' 16x16 and 'large' 24x24 version. Do we want to add a prop and parameterise this?

(ps - this is branched off Chip-Dismiss and E2E are failing on Chip and will do until this is merged)
 