### PR TITLE
Stop `onClick` event propagation of tree item expander and actions

### DIFF
--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -220,11 +220,10 @@ const TreeItemActions = forwardRef<"div", TreeItemActionsProps>(
 			},
 			[],
 		);
-		const onClick = useEventHandlers(props.onClick, handleClick);
 		return (
 			<Ariakit.Toolbar
 				{...rest}
-				onClick={onClick}
+				onClick={useEventHandlers(props.onClick, handleClick)}
 				className={cx("🥝-tree-item-actions", props.className)}
 				data-kiwi-visible={visible}
 				ref={forwardedRef}
@@ -253,14 +252,13 @@ const TreeItemExpander = forwardRef<"button", TreeItemExpanderProps>(
 			},
 			[],
 		);
-		const onClick = useEventHandlers(props.onClick, handleClick);
 		return (
 			<IconButton
 				icon={<TreeChevron />}
 				label="Toggle"
 				aria-expanded={expanded === undefined ? undefined : expanded}
 				{...props}
-				onClick={onClick}
+				onClick={useEventHandlers(props.onClick, handleClick)}
 				className={cx("🥝-tree-item-expander", props.className)}
 				variant="ghost"
 				labelVariant="visually-hidden"

--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -10,6 +10,7 @@ import { IconButton } from "./IconButton.js";
 import { Icon } from "./Icon.js";
 import { forwardRef, type BaseProps } from "./~utils.js";
 import { VisuallyHidden } from "./VisuallyHidden.js";
+import { useEventHandlers } from "./~hooks.js";
 
 // ----------------------------------------------------------------------------
 
@@ -213,9 +214,17 @@ interface TreeItemActionsProps extends BaseProps {
 const TreeItemActions = forwardRef<"div", TreeItemActionsProps>(
 	(props, forwardedRef) => {
 		const { visible, ...rest } = props;
+		const handleClick = React.useCallback(
+			(event: React.MouseEvent<HTMLDivElement>) => {
+				event.stopPropagation();
+			},
+			[],
+		);
+		const onClick = useEventHandlers(props.onClick, handleClick);
 		return (
 			<Ariakit.Toolbar
 				{...rest}
+				onClick={onClick}
 				className={cx("🥝-tree-item-actions", props.className)}
 				data-kiwi-visible={visible}
 				ref={forwardedRef}
@@ -238,12 +247,20 @@ const TreeItemExpander = forwardRef<"button", TreeItemExpanderProps>(
 	(props, forwardedRef) => {
 		const context = React.useContext(TreeItemContext);
 		const expanded = context?.expanded;
+		const handleClick = React.useCallback(
+			(event: React.MouseEvent<HTMLButtonElement>) => {
+				event.stopPropagation();
+			},
+			[],
+		);
+		const onClick = useEventHandlers(props.onClick, handleClick);
 		return (
 			<IconButton
 				icon={<TreeChevron />}
 				label="Toggle"
 				aria-expanded={expanded === undefined ? undefined : expanded}
 				{...props}
+				onClick={onClick}
 				className={cx("🥝-tree-item-expander", props.className)}
 				variant="ghost"
 				labelVariant="visually-hidden"


### PR DESCRIPTION
This PR quick fixes an issue where the _Tree item expander click selects tree item_ https://github.com/iTwin/viewer-components-react/issues/1149 by stopping the [onClick event propagation](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation) of `TreeItemExpander` and `TreeItemActions` components.

Alternatively, we could expose key modifiers (`ctrl` & `shift`) in `onSelectedChange` of the `Tree.Item` component (this way consumers wouldn't have to rely on the `onClick` of a `Tree.Item`).
Long term we should probably support `single` and `multi` selection modes out of the box.
