### PR TITLE
Chip - isChecked

### DIFF
--- a/packages/kiwi-react/src/bricks/Chip.tsx
+++ b/packages/kiwi-react/src/bricks/Chip.tsx
@@ -14,6 +14,11 @@ interface ChipProps extends BaseProps<"div"> {
 	 * @default "solid"
 	 */
 	variant?: "solid" | "outline";
+
+	/**
+	 * Determines if the chip is in a "checked" state.
+	 */
+	isChecked?: boolean;
 }
 
 /**


### PR DESCRIPTION
As part of the development of the Chip component a property was added to the design in Figma called 'isChecked'. The input from the design team included this :

"isChecked is similar to our checkbox, switch or radio. for example, if a chip was in a group that were acting as filter tags, you might 'check' them to toggle them active/inactive."

[Google Material Reference ](https://m3.material.io/components/chips/guidelines#8d453d50-8d8e-43aa-9ae3-87ed134d2e64)

This simple change extends the component interface to include the above prop - the idea being that the Chip States PR will make use of this prop and a propose "data-kiwi-checked" attribute to allow for state combinations to be effectively represented.

Tests are passing and tests do not need to be updated for this change.