### PR TITLE
make `onExpandedChange` consistent with `onSelectedChange`

### DIFF
--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -134,9 +134,10 @@ const TreeItem = forwardRef<"div", TreeItemProps>((props, forwardedRef) => {
 	const level = parentContext ? parentContext.level + 1 : 1;
 
 	const handleClick = (event: React.MouseEvent) => {
-		event.stopPropagation();
+		if (selected === undefined) return;
 
-		if (selected !== undefined) onSelectedChange?.(!selected);
+		event.stopPropagation(); // Avoid selecting parent treeitem
+		onSelectedChange?.(!selected);
 	};
 
 	const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -144,9 +145,10 @@ const TreeItem = forwardRef<"div", TreeItemProps>((props, forwardedRef) => {
 			return;
 		}
 
+		if (expanded === undefined) return;
+
 		if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
-			event.stopPropagation();
-			event.preventDefault();
+			event.preventDefault(); // Prevent scrolling
 
 			onExpandedChange?.(event.key === "ArrowRight");
 		}


### PR DESCRIPTION
I noticed that `onExpandedChange` was being called even when `expanded` was `undefined` so I added an early return. This should avoid situations like https://github.com/iTwin/kiwi/pull/234#pullrequestreview-2582385667 where the consumer needs to add an additional check in their `onExpandedChange` callback.

While I was here, I also validated the usages of `preventDefault()` and `stopPropagation()`, removing unnecessary ones and adding code comments to the necessary ones.