### PR TITLE
update `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-*       @mayank99 @GerardasB @RichardHill @knowler
+*       @iTwin/codename-kiwi


### PR DESCRIPTION
Updated `CODEOWNERS` to reference the whole [team](https://github.com/orgs/iTwin/teams/codename-kiwi) instead of individuals.