### PR TITLE
Sharding e2e playwright tests in CI

### DIFF
--- a/apps/test-app/playwright.config.ts
+++ b/apps/test-app/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
 	/* Opt out of parallel tests on CI. */
 	workers: process.env.CI ? 1 : undefined,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: [[process.env.CI ? "github" : "html", { open: "never" }]],
+	reporter: [["html", { open: "never" }]],
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
Implemented sharding for the e2e playwright tests in the CI. The [`fullyParallel`](https://playwright.dev/docs/api/class-testproject#test-project-fully-parallel) tests are now divided into 4 shards that in turns cuts the CI tests run time by half or 1/3rds.

Removed the upload of the HTML report since I believe it was not being used in the CI anyways (https://github.com/iTwin/kiwi/pull/346#discussion_r1943090299).

~Changed the reporter in the CI to `"github"` (https://github.com/iTwin/kiwi/pull/346#discussion_r1943090299). In the future, I/we can look for better Github annotation reporters if needed.~ Not adding the github annotator to avoid duplicate annotations (https://github.com/iTwin/kiwi/pull/346#discussion_r1943270101).