### PR TITLE
Ensure description order matches composition order

### DIFF
--- a/apps/test-app/app/tests/field/index.spec.ts
+++ b/apps/test-app/app/tests/field/index.spec.ts
@@ -54,10 +54,8 @@ test.describe("default", () => {
 	});
 
 	test("with explicit id", async ({ page }) => {
-		await page.goto("/tests/field?control=input&controlId=example");
-		await expect(page.getByRole("textbox")).toHaveAccessibleName(
-			"input example",
-		);
+		await page.goto("/tests/field?customControlId");
+		await expect(page.getByRole("textbox")).toHaveAccessibleName("Example");
 	});
 
 	const description = "Supporting text";
@@ -77,6 +75,20 @@ test.describe("default", () => {
 		await page.goto(`tests/field?descriptions=${descriptions.join(";")}`);
 		await expect(page.getByRole("textbox")).toHaveAccessibleDescription(
 			descriptions.join(" "),
+		);
+	});
+
+	test("with custom description ids", async ({ page }) => {
+		await page.goto("tests/field?customDescriptionIds");
+		await expect(page.getByRole("textbox")).toHaveAccessibleDescription(
+			"Supporting text. More supporting text.",
+		);
+	});
+
+	test("with custom aria-describedby", async ({ page }) => {
+		await page.goto("tests/field?customAriaDescribedBy");
+		await expect(page.getByRole("textbox")).toHaveAccessibleDescription(
+			"Custom description.",
 		);
 	});
 });

--- a/apps/test-app/app/tests/field/index.tsx
+++ b/apps/test-app/app/tests/field/index.tsx
@@ -30,7 +30,6 @@ export default definePage(
 		layout,
 		labelPlacement = "before",
 		descriptions,
-		controlId,
 	}) {
 		const Control = controls[control];
 		const ControlLabel = asLabel ? "span" : Label;
@@ -44,20 +43,23 @@ export default definePage(
 					{labelPlacement === "before" ? (
 						<ControlLabel>{control} example</ControlLabel>
 					) : null}
-					<Control id={controlId} />
+					<Control />
 					{labelPlacement === "after" ? (
 						<ControlLabel>{control} example</ControlLabel>
 					) : null}
-					{descriptions
-						?.split(";")
-						.map((description) => (
-							<Description key={description}>{description}</Description>
-						)) || null}
+					{descriptions?.split(";").map((description) => (
+						<Description key={description}>{description}</Description>
+					))}
 				</Field>
 			</form>
 		);
 	},
-	{ visual: VisualTest },
+	{
+		visual: VisualTest,
+		customAriaDescribedBy: CustomAriaDescribedByTest,
+		customControlId: CustomControlIdTest,
+		customDescriptionIds: CustomDescriptionIdsTest,
+	},
 );
 
 function VisualTest({ controlType }: VariantProps) {
@@ -167,5 +169,35 @@ function VisualTestForCheckableControls() {
 				<span>Switch control</span>
 			</Field>
 		</div>
+	);
+}
+
+function CustomAriaDescribedByTest() {
+	return (
+		<Field>
+			<Label>Example</Label>
+			<TextBox.Input aria-describedby="custom-description" />
+			<div id="custom-description">Custom description.</div>
+		</Field>
+	);
+}
+
+function CustomDescriptionIdsTest() {
+	return (
+		<Field>
+			<Label>Example</Label>
+			<TextBox.Input />
+			<Description id="a">Supporting text.</Description>
+			<Description id="b">More supporting text.</Description>
+		</Field>
+	);
+}
+
+function CustomControlIdTest() {
+	return (
+		<Field>
+			<Label>Example</Label>
+			<TextBox.Input id="custom" />
+		</Field>
 	);
 }

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
-import { FieldControl, useFieldDescribedBy } from "./Field.js";
+import { FieldControl } from "./Field.js";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 
 type InputBaseProps = Omit<
@@ -37,7 +37,6 @@ interface CheckboxProps extends InputBaseProps, CheckboxOwnProps {}
 export const Checkbox = forwardRef<"input", CheckboxProps>(
 	(props, forwardedRef) => {
 		const { id, ...rest } = props;
-		const describedBy = useFieldDescribedBy(props["aria-describedby"]);
 
 		return (
 			<FieldControl
@@ -48,7 +47,6 @@ export const Checkbox = forwardRef<"input", CheckboxProps>(
 						accessibleWhenDisabled
 						{...rest}
 						className={cx("🥝-checkbox", props.className)}
-						aria-describedby={describedBy}
 						ref={forwardedRef}
 					/>
 				}

--- a/packages/kiwi-react/src/bricks/Description.tsx
+++ b/packages/kiwi-react/src/bricks/Description.tsx
@@ -2,11 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import * as React from "react";
 import { forwardRef, type BaseProps } from "./~utils.js";
 import cx from "classnames";
 import { Text } from "./Text.js";
-import { useFieldRegisterDescribedBy } from "./Field.js";
+import { FieldDescription } from "./Field.js";
 
 interface DescriptionProps extends BaseProps {
 	/**
@@ -27,18 +26,20 @@ interface DescriptionProps extends BaseProps {
  */
 export const Description = forwardRef<"div", DescriptionProps>(
 	(props, forwardedRef) => {
-		const generatedId = React.useId();
-		const { id = generatedId, tone, ...rest } = props;
-		useFieldRegisterDescribedBy(id);
+		const { id, tone, ...rest } = props;
 
 		return (
-			<Text
-				{...rest}
+			<FieldDescription
 				id={id}
-				variant="caption-md"
-				data-kiwi-tone={tone ?? "neutral"}
-				className={cx("🥝-description", props.className)}
-				ref={forwardedRef}
+				render={
+					<Text
+						{...rest}
+						variant="caption-md"
+						data-kiwi-tone={tone ?? "neutral"}
+						className={cx("🥝-description", props.className)}
+						ref={forwardedRef}
+					/>
+				}
 			/>
 		);
 	},

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
-import { FieldControl, useFieldDescribedBy } from "./Field.js";
+import { FieldControl } from "./Field.js";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 
 type InputBaseProps = Omit<FocusableProps<"input">, "defaultValue" | "value">;
@@ -30,7 +30,6 @@ interface RadioProps extends InputBaseProps, RadioOwnProps {}
  */
 export const Radio = forwardRef<"input", RadioProps>((props, forwardedRef) => {
 	const { id, ...rest } = props;
-	const describedBy = useFieldDescribedBy(props["aria-describedby"]);
 
 	return (
 		<FieldControl
@@ -41,7 +40,6 @@ export const Radio = forwardRef<"input", RadioProps>((props, forwardedRef) => {
 					accessibleWhenDisabled
 					{...rest}
 					className={cx("🥝-checkbox", "🥝-radio", props.className)}
-					aria-describedby={describedBy}
 					ref={forwardedRef}
 				/>
 			}

--- a/packages/kiwi-react/src/bricks/Select.tsx
+++ b/packages/kiwi-react/src/bricks/Select.tsx
@@ -12,7 +12,7 @@ import {
 	type FocusableProps,
 } from "./~utils.js";
 import { DisclosureArrow } from "./Icon.js";
-import { FieldControl, useFieldDescribedBy } from "./Field.js";
+import { FieldControl } from "./Field.js";
 
 const supportsHas = isBrowser && CSS?.supports?.("selector(:has(+ *))");
 
@@ -92,7 +92,6 @@ const HtmlSelect = forwardRef<"select", HtmlSelectProps>(
 		const { id, variant = "solid", ...rest } = props;
 
 		const setIsHtmlSelect = React.useContext(HtmlSelectContext);
-		const describedBy = useFieldDescribedBy(props["aria-describedby"]);
 
 		React.useEffect(
 			function updateContext() {
@@ -110,7 +109,6 @@ const HtmlSelect = forwardRef<"select", HtmlSelectProps>(
 						<Ariakit.Role.select
 							{...rest}
 							className={cx("🥝-button", "🥝-select", props.className)}
-							aria-describedby={describedBy}
 							data-kiwi-tone="neutral"
 							data-kiwi-variant={variant}
 							ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
 import * as Ariakit from "@ariakit/react";
-import { FieldControl, useFieldDescribedBy } from "./Field.js";
+import { FieldControl } from "./Field.js";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 
 type InputBaseProps = Omit<FocusableProps<"input">, "defaultValue" | "value">;
@@ -39,7 +39,6 @@ interface SwitchProps extends InputBaseProps, CheckboxOwnProps {
 export const Switch = forwardRef<"input", SwitchProps>(
 	(props, forwardedRef) => {
 		const { id, ...rest } = props;
-		const describedBy = useFieldDescribedBy(props["aria-describedby"]);
 
 		return (
 			<FieldControl
@@ -50,7 +49,6 @@ export const Switch = forwardRef<"input", SwitchProps>(
 						accessibleWhenDisabled
 						{...rest}
 						className={cx("🥝-switch", props.className)}
-						aria-describedby={describedBy}
 						role="switch"
 						ref={forwardedRef}
 					/>

--- a/packages/kiwi-react/src/bricks/TextBox.tsx
+++ b/packages/kiwi-react/src/bricks/TextBox.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import * as Ariakit from "@ariakit/react";
 import cx from "classnames";
-import { FieldControl, useFieldDescribedBy } from "./Field.js";
+import { FieldControl } from "./Field.js";
 import { Icon } from "./Icon.js";
 import { useMergedRefs } from "./~hooks.js";
 import { type FocusableProps, type BaseProps, forwardRef } from "./~utils.js";
@@ -55,7 +55,6 @@ interface TextBoxInputProps extends Omit<BaseInputProps, "children" | "type"> {
 const TextBoxInput = forwardRef<"input", TextBoxInputProps>(
 	(props, forwardedRef) => {
 		const { id, ...rest } = props;
-		const describedBy = useFieldDescribedBy(props["aria-describedby"]);
 		const rootContext = React.useContext(TextBoxRootContext);
 		const setDisabled = rootContext?.setDisabled;
 		React.useEffect(() => {
@@ -69,7 +68,6 @@ const TextBoxInput = forwardRef<"input", TextBoxInputProps>(
 					<Ariakit.Role.input
 						readOnly={props.disabled}
 						{...rest}
-						aria-describedby={describedBy}
 						className={cx({ "🥝-text-box": !rootContext }, props.className)}
 						/**
 						 * Use an empty string as a placeholder to fix baseline alignment in Safari.
@@ -117,7 +115,6 @@ interface TextareaProps extends FocusableProps<"textarea"> {}
 const TextBoxTextarea = forwardRef<"textarea", TextareaProps>(
 	(props, forwardedRef) => {
 		const { id, ...rest } = props;
-		const describedBy = useFieldDescribedBy(props["aria-describedby"]);
 
 		return (
 			<FieldControl
@@ -128,7 +125,6 @@ const TextBoxTextarea = forwardRef<"textarea", TextareaProps>(
 						readOnly={props.disabled}
 						{...rest}
 						className={cx("🥝-text-box", props.className)}
-						aria-describedby={describedBy}
 						/**
 						 * Use an empty string as a placeholder to fix baseline alignment in Safari.
 						 * @see https://bugs.webkit.org/show_bug.cgi?id=142968


### PR DESCRIPTION
Resolved #341

Stacked on #343

This pull request refactors how we’ve implemented the context for field descriptions to use Ariakit’s `Collection` instead. In doing so, we now have stabilty over the order the the description `id`s are added to the `aria-describedby` attribute on the control. Before since everything was tracked in a `Set` (which is ordered), if we conditionally rendered a description it could show up at the end after descriptions that were already rendered.

## For design system consumers

A side effect here is now we aren’t using consumer-supplied content from the `aria-describedby` prop on the control. I think this is fine, but it is a change that could affect consumers (seems unlikely though). Instead, use `<Description>` and if you need a custom `id` for the description, you can do so, and that will be added to the `aria-describedby` of the control automatically within `<Field>`.

## For the design system team

Now when implementing new controls, we only need to wrap it with `<FieldControl>`, set the `type`, and pass the `id`. The `useFieldDescribedBy()` hook has been removed.

## Reviewing

- [Introduction of internal `FieldDescription` component](https://github.com/iTwin/kiwi/pull/348/files#diff-ae5a07a8444db996a731c2ffdf4ebc7bfeb812912aa06f1cb9c88c8c396b45d8R185-R202)
- [Use `FieldDescription` instead of remove `useFieldRegisterDescribedBy()` hook for `Description` component](https://github.com/iTwin/kiwi/pull/348/files#diff-d1994be1f9d5cfbd440eca5f3d7d571b99faae89aed4b296b572ad167d0ec4bd)
- Removes usage of `useFieldDescribedBy()` hook for all controls (changes all the same):
  - [`TextBox.Input` and `TextBox.Textarea`](https://github.com/iTwin/kiwi/pull/348/files/9b4d349d60d130cbefb0bc872c5ec459166a83ce#diff-fb6a1125e591b9e5de474070e17334d1cd67b9d48b0f6e6fc02f6c8048036fdd)
  - [`Switch`](https://github.com/iTwin/kiwi/pull/348/files/9b4d349d60d130cbefb0bc872c5ec459166a83ce#diff-534b36f9cb43fdd0613064011d16f80134bbdd8f606ffc65b9f0a510083def16)
  - [`Radio`](https://github.com/iTwin/kiwi/pull/348/files#diff-e4dc7274df0736070372bedd03913a40c84763698aedfb3b9f72837448a07433)
  - [`Select`](https://github.com/iTwin/kiwi/pull/348/files#diff-3eae1395643e8dc5bc56d0992658f62f709870462423402e4a9ee4be16224d17)
  - [`Checkbox`](https://github.com/iTwin/kiwi/pull/348/files#diff-8703fa8a060b6a45e06af7605998fdcb379311db7d4b5275ee3c916a760eb0f0)
- [Removal of `FieldDescribedBy` provider, context, and hooks](https://github.com/iTwin/kiwi/pull/348/files#diff-ae5a07a8444db996a731c2ffdf4ebc7bfeb812912aa06f1cb9c88c8c396b45d8L42-L138)
- [Get description IDs within `FieldControl` and use for `aria-describedby`](https://github.com/iTwin/kiwi/pull/348/files#diff-ae5a07a8444db996a731c2ffdf4ebc7bfeb812912aa06f1cb9c88c8c396b45d8L202-L214)

## Testing

- `/tests/field?descriptions=Supporting text;More supporting text`
- `/tests/field?customAriaDescribedBy`
- `/tests/field?customDescriptionIds`
- `/tests/field?customControlId`

## Future

- This unblocks the work on the error messages which will be implemented next (#250).
- [We also need to resolve issues with controls nested in labels](https://github.com/iTwin/kiwi/pull/348#discussion_r1945421175)