### PR TITLE
replace `Chip` children with new `label` prop

### DIFF
--- a/apps/test-app/app/tests/chip/index.tsx
+++ b/apps/test-app/app/tests/chip/index.tsx
@@ -12,7 +12,7 @@ export default definePage(
 	function Page() {
 		return (
 			<>
-				<Chip>Value</Chip>
+				<Chip label="Value" />
 			</>
 		);
 	},
@@ -21,16 +21,14 @@ export default definePage(
 
 function VisualTest() {
 	// Permutations for visual testing without dismiss functionality
-	const permutations = [["solid"], ["outline"]] as const;
+	const permutations = ["solid", "outline"] as const;
 
 	return (
 		<div style={{ display: "grid", gap: 4 }}>
-			{permutations.map(([variant]) => {
-				const props = { variant } as React.ComponentProps<typeof Chip>;
-
+			{permutations.map((variant) => {
 				return (
-					<div key={variant} style={{ display: "flex", gap: 4 }}>
-						<Chip {...props}>{variant}</Chip>
+					<div key={variant}>
+						<Chip variant={variant} label={variant} />
 					</div>
 				);
 			})}
@@ -40,26 +38,24 @@ function VisualTest() {
 
 function DismissTest() {
 	// Permutations for visual testing with dismiss functionality
-	const permutations = [["solid"], ["outline"]] as const;
+	const permutations = ["solid", "outline"] as const;
 
 	const [isDismissed, setIsDismissed] = React.useState(false);
 
 	return (
 		<div style={{ display: "grid", gap: 4 }}>
-			{permutations.map(([variant]) => {
-				const props = { variant };
-
+			{permutations.map((variant) => {
 				return (
-					<div key={variant} style={{ display: "flex", gap: 4 }}>
+					<div key={variant}>
 						<Chip
-							{...props}
+							key={variant}
+							variant={variant}
+							label={variant}
 							onDismiss={() => {
 								setIsDismissed(true);
 							}}
-							data-dismissed={isDismissed ? "true" : "false"}
-						>
-							{variant}
-						</Chip>
+							data-dismissed={isDismissed}
+						/>
 					</div>
 				);
 			})}

--- a/packages/kiwi-react/src/bricks/Chip.tsx
+++ b/packages/kiwi-react/src/bricks/Chip.tsx
@@ -9,7 +9,12 @@ import { forwardRef, type BaseProps } from "./~utils.js";
 import { IconButton } from "./IconButton.js";
 import { Dismiss } from "./Icon.js";
 
-interface ChipProps extends BaseProps<"div"> {
+interface ChipProps extends Omit<BaseProps<"div">, "children"> {
+	/**
+	 * The label displayed inside the chip.
+	 */
+	label: React.ReactNode;
+
 	/**
 	 * The variant style of the Chip.
 	 * Use "solid" for primary states and "outline" for less prominent states.
@@ -28,14 +33,14 @@ interface ChipProps extends BaseProps<"div"> {
  * Chip is a UI component used to represent an item, attribute, or action in a compact visual style.
  * It supports two visual variants: `solid` for primary emphasis and `outline` for less prominent states.
  *
- * Example : Render a Chip with the default "solid" variant
+ * Example:
  * ```tsx
- * <Chip>Default Chip</Chip>
- * <Chip variant="outline">Outline Chip</Chip>
+ * <Chip label="Value" />
+ * <Chip label="Value" variant="outline" />
  * ```
  */
 export const Chip = forwardRef<"div", ChipProps>((props, forwardedRef) => {
-	const { variant = "solid", onDismiss, children, ...rest } = props;
+	const { variant = "solid", onDismiss, label, ...rest } = props;
 
 	const baseId = React.useId();
 	const labelId = `${baseId}-label`;
@@ -48,7 +53,7 @@ export const Chip = forwardRef<"div", ChipProps>((props, forwardedRef) => {
 			className={cx("🥝-chip", props.className)}
 			ref={forwardedRef}
 		>
-			<span id={labelId}>{children}</span>
+			<span id={labelId}>{label}</span>
 			{onDismiss && (
 				<IconButton
 					id={dismissIconId}

--- a/packages/kiwi-react/src/bricks/Chip.tsx
+++ b/packages/kiwi-react/src/bricks/Chip.tsx
@@ -13,7 +13,7 @@ interface ChipProps extends Omit<BaseProps<"div">, "children"> {
 	/**
 	 * The label displayed inside the chip.
 	 */
-	label: React.ReactNode;
+	label: string;
 
 	/**
 	 * The variant style of the Chip.


### PR DESCRIPTION
This addresses the pending issue noted in https://github.com/iTwin/kiwi/pull/253#discussion_r1932557770. The `children` prop has been replaced with `label` to avoid confusion and explain the presence of wrapping and sibling elements added in #253.

Breaking change:

```diff
- <Chip>Value</Chip>
+ <Chip label="Value" />
```

> [!NOTE]
> This PR merged with the type of `label` set to `string` (see [thread](https://github.com/iTwin/design-system/pull/349#discussion_r1943854475)), but it was later expanded to `ReactNode` in #736.