### PR TITLE
Prefix all `&[data-attribute]`s with `:where`

### DIFF
--- a/packages/kiwi-react/src/bricks/Anchor.css
+++ b/packages/kiwi-react/src/bricks/Anchor.css
@@ -23,15 +23,15 @@
 	}
 
 	@layer modifiers {
-		&[data-kiwi-tone="neutral"] {
+		&:where([data-kiwi-tone="neutral"]) {
 			--🥝anchor-color: var(--kiwi-color-text-neutral-primary);
 		}
 
-		&[data-kiwi-tone="accent"] {
+		&:where([data-kiwi-tone="accent"]) {
 			--🥝anchor-color: var(--kiwi-color-text-accent-strong);
 		}
 
-		&[data-kiwi-tone="critical"] {
+		&:where([data-kiwi-tone="critical"]) {
 			--🥝anchor-color: var(--kiwi-color-text-critical-base);
 
 			&:focus-visible {

--- a/packages/kiwi-react/src/bricks/Button.css
+++ b/packages/kiwi-react/src/bricks/Button.css
@@ -130,7 +130,7 @@
 	}
 
 	@layer modifiers {
-		&[data-kiwi-variant="solid"] {
+		&:where([data-kiwi-variant="solid"]) {
 			--🥝button-background-color: var(--🌀button-state--default, var(--🥝button-bg--solid-default))
 				var(--🌀button-state--hover, var(--✨bg--solid-hover))
 				var(--🌀button-state--pressed, var(--✨bg--solid-pressed))
@@ -172,7 +172,7 @@
 			}
 		}
 
-		&[data-kiwi-variant="outline"] {
+		&:where([data-kiwi-variant="outline"]) {
 			--🥝button-background-color: var(--🌀button-state--default, var(--✨bg--outline-default))
 				var(--🌀button-state--hover, var(--✨bg--outline-hover))
 				var(--🌀button-state--pressed, var(--✨bg--outline-pressed))
@@ -184,7 +184,7 @@
 			box-shadow: var(--✨shadow-border);
 		}
 
-		&[data-kiwi-variant="ghost"] {
+		&:where([data-kiwi-variant="ghost"]) {
 			--🥝button-background-color: var(--🌀button-state--default, var(--✨bg--ghost-default))
 				var(--🌀button-state--hover, var(--✨bg--ghost-hover))
 				var(--🌀button-state--pressed, var(--✨bg--ghost-pressed))

--- a/packages/kiwi-react/src/bricks/Chip.css
+++ b/packages/kiwi-react/src/bricks/Chip.css
@@ -30,11 +30,11 @@
 	}
 
 	@layer modifiers {
-		&[data-kiwi-variant="solid"] {
+		&:where([data-kiwi-variant="solid"]) {
 			background-color: var(--kiwi-color-bg-neutral-base);
 		}
 
-		&[data-kiwi-variant="outline"] {
+		&:where([data-kiwi-variant="outline"]) {
 			background-color: var(--kiwi-color-bg-surface-primary);
 		}
 	}

--- a/packages/kiwi-react/src/bricks/Icon.css
+++ b/packages/kiwi-react/src/bricks/Icon.css
@@ -12,11 +12,11 @@
 	}
 
 	@layer modifiers {
-		&[data-kiwi-size="regular"] {
+		&:where([data-kiwi-size="regular"]) {
 			--🥝icon-size: 1rem;
 		}
 
-		&[data-kiwi-size="large"] {
+		&:where([data-kiwi-size="large"]) {
 			--🥝icon-size: 1.5rem;
 		}
 	}

--- a/packages/kiwi-react/src/bricks/Kbd.css
+++ b/packages/kiwi-react/src/bricks/Kbd.css
@@ -20,19 +20,18 @@
 	}
 
 	@layer modifiers {
-		&[data-kiwi-variant="solid"],
-		&[data-kiwi-variant="muted"] {
+		&:where([data-kiwi-variant="solid"], [data-kiwi-variant="muted"]) {
 			border-radius: 4px;
 			background-color: var(--kiwi-color-bg-neutral-base);
 			padding-inline: 4px;
 		}
 
-		&[data-kiwi-variant="solid"] {
+		&:where([data-kiwi-variant="solid"]) {
 			box-shadow: var(--kiwi-shadow-button-base-inset), var(--✨shadow-border),
 				var(--kiwi-shadow-button-base-drop);
 		}
 
-		&[data-kiwi-variant="ghost"] {
+		&:where([data-kiwi-variant="ghost"]) {
 			color: var(--kiwi-color-text-neutral-tertiary);
 		}
 	}


### PR DESCRIPTION
While working on #320 I ran into a specificity issue with overriding `--🥝icon-size` which was a result of lack of `:where`.