### PR TITLE
make `<TextBox>` `::placeholder` not selectable

### DIFF
--- a/packages/kiwi-react/src/bricks/TextBox.css
+++ b/packages/kiwi-react/src/bricks/TextBox.css
@@ -84,6 +84,7 @@
 			&::placeholder {
 				color: var(--✨color--placeholder);
 				opacity: 1;
+				user-select: none;
 			}
 		}
 


### PR DESCRIPTION
Added `&::placeholder { user-select: none; }` so placeholder text can't be selected.  To test, do a select all (macOS: <kbd>⌘</kbd> + <kbd>A</kbd>) on a page.

| Before | After |
| --- | --- |
| ![Search placeholder text is selected](https://github.com/user-attachments/assets/4f37f7c7-84dd-47c8-aa9d-447f806b11fc) | ![Search placeholder text is not selected](https://github.com/user-attachments/assets/01457c9d-de96-4457-8ad9-b8462196d592) |