### PR TITLE
allow inheriting `Icon` size

### DIFF
--- a/packages/kiwi-react/src/bricks/Icon.css
+++ b/packages/kiwi-react/src/bricks/Icon.css
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝-icon {
 	@layer base {
-		width: var(--🥝icon-size);
-		height: var(--🥝icon-size);
+		width: var(--🥝icon-size, 1rem);
+		height: var(--🥝icon-size, 1rem);
 		flex-shrink: 0;
 		color: var(--🥝icon-color);
 		transition: color 150ms ease-out;

--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -32,7 +32,7 @@ interface IconProps extends Omit<BaseProps<"svg">, "children"> {
  * **Note**: This component is meant to be used with decorative icons, so it adds `aria-hidden` by default.
  */
 export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
-	const { href, size = "regular", ...rest } = props;
+	const { href, size, ...rest } = props;
 	const iconId = toIconId(size);
 	return (
 		<Ariakit.Role.svg


### PR DESCRIPTION
By not explicitly setting `data-kiwi-size`, we can allow `--🥝icon-size` to be inherited. Useful in situations like https://github.com/iTwin/kiwi/pull/353#discussion_r1960659419 where a parent element wants to control the size of its children.