### PR TITLE
add `alt` prop to `<Icon>`

### DIFF
--- a/apps/test-app/app/tests/icon/index.spec.ts
+++ b/apps/test-app/app/tests/icon/index.spec.ts
@@ -12,6 +12,14 @@ test("default", async ({ page }) => {
 	await expect(icon).toHaveAttribute("aria-hidden", "true");
 });
 
+test("alt prop", async ({ page }) => {
+	await page.goto("/tests/icon?alt=Help me");
+
+	const icon = page.getByRole("img");
+	await expect(icon).toHaveAccessibleName("Help me");
+	await expect(icon).not.toHaveAttribute("aria-hidden");
+});
+
 test.describe("@visual", () => {
 	test("default", async ({ page }) => {
 		await page.goto("/tests/icon");

--- a/apps/test-app/app/tests/icon/index.tsx
+++ b/apps/test-app/app/tests/icon/index.tsx
@@ -9,8 +9,14 @@ import placeholderIcon from "@itwin/itwinui-icons/placeholder.svg";
 export const handle = { title: "Icon" };
 
 export default definePage(
-	function Page({ size = "regular" }) {
-		return <Icon size={size as "regular" | "large"} href={placeholderIcon} />;
+	function Page({ size = "regular", alt }) {
+		return (
+			<Icon
+				alt={alt}
+				size={size as "regular" | "large"}
+				href={placeholderIcon}
+			/>
+		);
 	},
 	{ renderProp: RenderPropTest },
 );

--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -8,10 +8,29 @@ import * as Ariakit from "@ariakit/react";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface IconProps extends Omit<BaseProps<"svg">, "children"> {
-	/** URL of the symbol sprite. */
+	/**
+	 * URL of the symbol sprite.
+	 *
+	 * Should be a URL to an `.svg` file from `@itwin/itwinui-icons`.
+	 */
 	href?: string;
-	/** Size of the icon. Defaults to `regular`. */
+	/**
+	 * Size of the icon. This affects the icon's physical dimensions, as well as the
+	 * actual SVG contents (different sizes might have different fidelity).
+	 *
+	 * Defaults to `"regular"` (16px) and can be optionally set to `"large"` (24px).
+	 */
 	size?: "regular" | "large";
+	/**
+	 * Alternative text describing the icon.
+	 *
+	 * When this prop is passed, the SVG gets rendered as `role="img"` and labelled
+	 * using the provided text.
+	 *
+	 * This prop is not required if the icon is purely decorative. By default, the icon
+	 * will be hidden from the accessibility tree.
+	 */
+	alt?: string;
 }
 
 /**
@@ -29,14 +48,25 @@ interface IconProps extends Omit<BaseProps<"svg">, "children"> {
  * <Icon render={<svg><path d="…" fill="currentColor" /></svg>} />
  * ```
  *
- * **Note**: This component is meant to be used with decorative icons, so it adds `aria-hidden` by default.
+ * By default, this component assumes that the icon is decorative, so it adds `aria-hidden` by default.
+ *
+ * If the icon is semantically meaningful, the `alt` prop can be used to provide alternative text.
+ *
+ * ```tsx
+ * <Icon href={…} alt="Help" />
+ * ```
  */
 export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
-	const { href, size, ...rest } = props;
+	const { href, size, alt, ...rest } = props;
+
 	const iconId = toIconId(size);
+	const isDecorative = !alt;
+
 	return (
 		<Ariakit.Role.svg
-			aria-hidden
+			aria-hidden={isDecorative ? "true" : undefined}
+			role={isDecorative ? undefined : "img"}
+			aria-label={isDecorative ? undefined : alt}
 			{...rest}
 			data-kiwi-size={size}
 			className={cx("🥝-icon", props.className)}


### PR DESCRIPTION
This adds an `alt` prop to `<Icon>` for the (hopefully) rare case when an icon is not decorative. This comes from recent discussions around wanting to provide an equivalent alternative when the icon conveys something meaningful and does not already have supplementary text.

---

When `alt` is passed, the `<svg>` element will:
- not have `aria-hidden="true"`
- have `role="img"`
- have `aria-label={alt}`.

I was thinking of using the [recommended](https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/#basic-alternative-descriptions-using-the-svg-tag-group-2) `aria-labelledby` + `<title>` technique, but decided against it because it wouldn't work with the `render` prop (which overrides `children`) and would also in an undesirable browser-provided tooltip.