### PR TITLE
Pass through `style` of `<Tree.Item>`

### DIFF
--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -144,7 +144,6 @@ const TreeItem = forwardRef<"div", TreeItemProps>((props, forwardedRef) => {
 		icon,
 		label,
 		actions,
-		style,
 		onSelectedChange,
 		onExpandedChange,
 		onClick: onClickProp,


### PR DESCRIPTION
This PR fixes an issue where `style` prop would not be passed through for the `<Tree.Item>` component (introduced with https://github.com/iTwin/kiwi/pull/234). It is needed for our consumers when setting up virtualization.