### PR TITLE
require `<Text>` to have `variant`

### DIFF
--- a/apps/test-app/app/sandbox.tsx
+++ b/apps/test-app/app/sandbox.tsx
@@ -223,7 +223,7 @@ function Layout(
 function EmptyState() {
 	return (
 		<div className={styles.emptyState}>
-			<Text>No layers</Text>
+			<Text variant="body-sm">No layers</Text>
 			<Button>Create a layer</Button>
 		</div>
 	);
@@ -232,7 +232,7 @@ function EmptyState() {
 function NoResultsState() {
 	return (
 		<div style={{ textAlign: "center" }}>
-			<Text>No results found</Text>
+			<Text variant="body-sm">No results found</Text>
 		</div>
 	);
 }

--- a/packages/kiwi-react/src/bricks/Text.tsx
+++ b/packages/kiwi-react/src/bricks/Text.tsx
@@ -10,7 +10,7 @@ interface TextProps extends BaseProps {
 	/**
 	 * The typography variant to use.
 	 */
-	variant?:
+	variant:
 		| "display-lg"
 		| "display-md"
 		| "display-sm"


### PR DESCRIPTION
Temporary measure to prevent misuse until we figure out what to use as the default.

https://github.com/iTwin/design-system/issues/393#issuecomment-2685819172