### PR TITLE
remove `children` from `<Tree.Item>`

### DIFF
--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -50,7 +50,7 @@ DEV: Tree.displayName = "Tree.Root";
 
 // ----------------------------------------------------------------------------
 
-interface TreeItemProps extends Omit<BaseProps, "content"> {
+interface TreeItemProps extends Omit<BaseProps, "content" | "children"> {
 	/** Specifies the nesting level of the tree item. Nesting levels start at 1. */
 	"aria-level": number;
 	/** Defines tree item position in the current level of tree items. Integer greater than or equal to 1. */
@@ -139,7 +139,6 @@ const TreeItem = forwardRef<"div", TreeItemProps>((props, forwardedRef) => {
 	const {
 		"aria-level": level,
 		selected,
-		children,
 		expanded,
 		icon,
 		label,


### PR DESCRIPTION
`children` was unused and therefore should not be allowed in the props interface.

Normally, the linter would help catch such bugs, however https://github.com/biomejs/biome/discussions/5152 (see also https://github.com/iTwin/design-system/pull/390#discussion_r1969886757).