### PR TITLE
update `<Anchor>` visuals

### DIFF
--- a/apps/test-app/app/tests/anchor/index.tsx
+++ b/apps/test-app/app/tests/anchor/index.tsx
@@ -28,9 +28,9 @@ function VisualTest() {
 	const tones = ["neutral", "accent", "critical"] as const;
 
 	return (
-		<div style={{ display: "grid", gap: 4 }}>
+		<div style={{ display: "grid", gap: 4, justifyContent: "start" }}>
 			{tones.map((tone) => (
-				<Anchor key={tone} tone={tone} href="https://bentley.com">
+				<Anchor key={tone} tone={tone} href="https://example.com">
 					Example
 				</Anchor>
 			))}

--- a/packages/kiwi-react/src/bricks/Anchor.css
+++ b/packages/kiwi-react/src/bricks/Anchor.css
@@ -3,18 +3,46 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .🥝-anchor {
+	--✨color--default: var(--ids-color-text-neutral-primary);
+	--✨color--accent: var(--ids-color-text-accent-strong);
+	--✨color--accent-hover: color-mix(
+		in oklch,
+		var(--✨color--accent) 100%,
+		var(--ids-color-glow-hue) var(--ids-color-text-glow-strong-hover-\%)
+	);
+	--✨color--accent-pressed: color-mix(
+		in oklch,
+		var(--✨color--accent) 100%,
+		var(--ids-color-glow-hue) var(--ids-color-text-glow-strong-pressed-\%)
+	);
+	--✨color--critical: var(--ids-color-text-critical-base);
+	--✨color--critical-hover: color-mix(
+		in oklch,
+		var(--✨color--critical) 100%,
+		var(--ids-color-glow-hue) var(--ids-color-text-glow-strong-hover-\%)
+	);
+	--✨color--critical-pressed: color-mix(
+		in oklch,
+		var(--✨color--critical) 100%,
+		var(--ids-color-glow-hue) var(--ids-color-text-glow-strong-pressed-\%)
+	);
+	--✨color--disabled: var(--ids-color-text-neutral-disabled);
+
 	@layer base {
 		cursor: pointer;
 		font-size: var(--ids-font-size-12);
 		font-weight: 500;
-		text-underline-offset: 0.25ex;
-		text-decoration-color: inherit;
+		text-underline-offset: var(--🌀anchor-state--default, 2px) var(--🌀anchor-state--hover, 3px)
+			var(--🌀anchor-state--pressed, 3px);
+		text-decoration-color: var(--🌀anchor-state--default, currentColor)
+			var(--🌀anchor-state--hover, currentColor) var(--🌀anchor-state--pressed, transparent);
 
 		border-radius: 4px;
 
-		color: var(--🥝anchor-color);
+		color: var(--🥝anchor-color, var(--✨color--default));
 
-		transition: color 150ms ease-out, text-decoration-color 150ms ease-out;
+		transition: all 150ms ease-out;
+		transition-property: color, text-decoration-color, text-underline-offset;
 
 		&:where(button) {
 			border: none;
@@ -23,39 +51,46 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-tone="neutral"]) {
-			--🥝anchor-color: var(--ids-color-text-neutral-primary);
-		}
-
 		&:where([data-kiwi-tone="accent"]) {
-			--🥝anchor-color: var(--ids-color-text-accent-strong);
+			--🥝anchor-color: var(--🌀anchor-state--default, var(--✨color--accent))
+				var(--🌀anchor-state--hover, var(--✨color--accent-hover))
+				var(--🌀anchor-state--pressed, var(--✨color--accent-pressed));
 		}
 
 		&:where([data-kiwi-tone="critical"]) {
-			--🥝anchor-color: var(--ids-color-text-critical-base);
-
-			&:focus-visible {
-				outline-color: var(--🥝anchor-color);
-			}
+			--🥝anchor-color: var(--🌀anchor-state--default, var(--✨color--critical))
+				var(--🌀anchor-state--hover, var(--✨color--critical-hover))
+				var(--🌀anchor-state--pressed, var(--✨color--critical-pressed));
 		}
 	}
 
 	@layer states {
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				text-decoration-color: transparent;
+				--🌀anchor-state: var(--🌀anchor-state--hover);
 			}
 		}
 
 		&:where(:active) {
-			text-decoration-color: transparent;
+			--🌀anchor-state: var(--🌀anchor-state--pressed);
+		}
+
+		&:where(:focus-visible) {
+			outline-offset: 2px;
 		}
 
 		&:where([disabled], :disabled, [aria-disabled="true"]) {
-			--🥝anchor-color-text: var(--ids-color-text-neutral-disabled);
-
+			--🥝anchor-color: var(--✨color--disabled);
 			cursor: not-allowed;
-			text-decoration-color: transparent;
+			text-decoration: none;
 		}
+	}
+
+	@layer base.🌀 {
+		/* https://kizu.dev/cyclic-toggles/ */
+		--🌀anchor-state: var(--🌀anchor-state--default);
+		--🌀anchor-state--default: var(--🌀anchor-state,);
+		--🌀anchor-state--hover: var(--🌀anchor-state,);
+		--🌀anchor-state--pressed: var(--🌀anchor-state,);
 	}
 }


### PR DESCRIPTION
This updates the `<Anchor>` component to match the latest [Figma design](https://www.figma.com/design/VcGw3L2IIlboxNlOdsKdai/%F0%9F%A5%9D-Kiwi-Component-Library?node-id=12080-1966&t=AurR6PXuUp4HIHrB-4).

Notable visual changes:
- Hover state now has an underline with a slightly larger offset.
- Text color gets a glow during hover/pressed states (for accent and critical variants only).
- Focus indicator is now consistent across all variants and has a 2px offset (vs 1px global).

Cyclic toggles (🌀) and static variables (✨) are used for CSS organization.

---

<details>
<summary>Screen recording showing hover/focus-visible/pressed states in action</summary>

https://github.com/user-attachments/assets/020251d4-ac22-4f58-b275-c6a9a4afee78

</details>

---

Also updated the test route to use smaller-width anchors (instead of full-width) and point to example.com (I kept getting directed to bentley.com when clicking the anchors, which was annoying).