### PR TITLE
import from individual Ariakit entrypoints

### DIFF
--- a/packages/kiwi-react/src/bricks/Anchor.tsx
+++ b/packages/kiwi-react/src/bricks/Anchor.tsx
@@ -3,7 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
+import { Focusable } from "@ariakit/react/focusable";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 
 interface AnchorProps extends FocusableProps<"a"> {
@@ -24,15 +25,12 @@ interface AnchorProps extends FocusableProps<"a"> {
 export const Anchor = forwardRef<"a", AnchorProps>((props, forwardedRef) => {
 	const { tone = "neutral", ...rest } = props;
 	return (
-		<Ariakit.Role.a
+		<Role.a
 			{...rest}
 			data-kiwi-tone={tone}
 			className={cx("🥝-anchor", props.className)}
 			render={
-				<Ariakit.Focusable
-					accessibleWhenDisabled
-					render={props.render || <a />}
-				/>
+				<Focusable accessibleWhenDisabled render={props.render || <a />} />
 			}
 			ref={forwardedRef}
 		/>

--- a/packages/kiwi-react/src/bricks/Avatar.tsx
+++ b/packages/kiwi-react/src/bricks/Avatar.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface AvatarProps extends BaseProps<"span"> {
@@ -60,7 +60,7 @@ export const Avatar = forwardRef<"span", AvatarProps>((props, forwardedRef) => {
 	const isDecorative = !alt;
 
 	return (
-		<Ariakit.Role.span
+		<Role.span
 			role={isDecorative ? undefined : "img"}
 			aria-label={isDecorative ? undefined : alt}
 			{...rest}
@@ -73,7 +73,7 @@ export const Avatar = forwardRef<"span", AvatarProps>((props, forwardedRef) => {
 					{initials?.substring(0, 1)}
 				</abbr>
 			)}
-		</Ariakit.Role.span>
+		</Role.span>
 	);
 });
 DEV: Avatar.displayName = "Avatar";

--- a/packages/kiwi-react/src/bricks/Badge.tsx
+++ b/packages/kiwi-react/src/bricks/Badge.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface BadgeProps extends Omit<BaseProps<"span">, "children"> {
@@ -38,7 +38,7 @@ export const Badge = forwardRef<"span", BadgeProps>((props, forwardedRef) => {
 	const { tone = "neutral", variant = "solid", label, ...rest } = props;
 
 	return (
-		<Ariakit.Role.span
+		<Role.span
 			{...rest}
 			data-kiwi-tone={tone}
 			data-kiwi-variant={variant}
@@ -46,7 +46,7 @@ export const Badge = forwardRef<"span", BadgeProps>((props, forwardedRef) => {
 			ref={forwardedRef}
 		>
 			{label}
-		</Ariakit.Role.span>
+		</Role.span>
 	);
 });
 DEV: Badge.displayName = "Badge";

--- a/packages/kiwi-react/src/bricks/Button.tsx
+++ b/packages/kiwi-react/src/bricks/Button.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Button as AkButton } from "@ariakit/react/button";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 import { useGhostAlignment } from "./GhostAligner.js";
 
@@ -59,7 +59,7 @@ export const Button = forwardRef<"button", ButtonProps>(
 		const ghostAlignment = useGhostAlignment();
 
 		return (
-			<Ariakit.Button
+			<AkButton
 				accessibleWhenDisabled
 				{...rest}
 				data-kiwi-variant={variant}

--- a/packages/kiwi-react/src/bricks/Checkbox.tsx
+++ b/packages/kiwi-react/src/bricks/Checkbox.tsx
@@ -3,7 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import {
+	Checkbox as AkCheckbox,
+	type CheckboxProps as AkCheckboxProps,
+} from "@ariakit/react/checkbox";
 import { FieldControl } from "./Field.js";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 
@@ -13,7 +16,7 @@ type InputBaseProps = Omit<
 >;
 
 type CheckboxOwnProps = Pick<
-	Ariakit.CheckboxProps,
+	AkCheckboxProps,
 	"value" | "defaultChecked" | "checked" | "onChange"
 >;
 
@@ -43,7 +46,7 @@ export const Checkbox = forwardRef<"input", CheckboxProps>(
 				type="checkable"
 				id={id}
 				render={
-					<Ariakit.Checkbox
+					<AkCheckbox
 						accessibleWhenDisabled
 						{...rest}
 						className={cx("🥝-checkbox", props.className)}

--- a/packages/kiwi-react/src/bricks/Chip.tsx
+++ b/packages/kiwi-react/src/bricks/Chip.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
 import * as React from "react";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import { forwardRef, type BaseProps } from "./~utils.js";
 import { IconButton } from "./IconButton.js";
 import { Dismiss } from "./Icon.js";
@@ -47,7 +47,7 @@ export const Chip = forwardRef<"div", ChipProps>((props, forwardedRef) => {
 	const dismissIconId = `${baseId}-dismiss`;
 
 	return (
-		<Ariakit.Role.div
+		<Role.div
 			data-kiwi-variant={variant}
 			{...rest}
 			className={cx("🥝-chip", props.className)}
@@ -66,7 +66,7 @@ export const Chip = forwardRef<"div", ChipProps>((props, forwardedRef) => {
 					onClick={onDismiss}
 				/>
 			)}
-		</Ariakit.Role.div>
+		</Role.div>
 	);
 });
 DEV: Chip.displayName = "Chip";

--- a/packages/kiwi-react/src/bricks/Divider.tsx
+++ b/packages/kiwi-react/src/bricks/Divider.tsx
@@ -3,12 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
+import { Separator, type SeparatorProps } from "@ariakit/react/separator";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface DividerProps
 	extends BaseProps<"hr">,
-		Pick<Ariakit.SeparatorProps, "orientation"> {
+		Pick<SeparatorProps, "orientation"> {
 	/**
 	 * If true, the divider will be purely presentational and will not have any associated semantics.
 	 *
@@ -26,7 +27,7 @@ interface DividerProps
 export const Divider = forwardRef<"hr", DividerProps>((props, forwardedRef) => {
 	const { presentational, ...rest } = props;
 
-	const Comp = presentational ? Ariakit.Role : Ariakit.Separator;
+	const Comp = presentational ? Role : Separator;
 
 	return (
 		<Comp

--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -4,19 +4,28 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
 import * as ListItem from "./ListItem.js";
 import { Button } from "./Button.js";
 import { Kbd } from "./Kbd.js";
 import { Checkmark, DisclosureArrow } from "./Icon.js";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 import { usePopoverApi } from "./~hooks.js";
+import {
+	MenuProvider,
+	useMenuContext,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuItemCheckbox,
+	type MenuItemCheckboxProps,
+	type MenuProviderProps,
+} from "@ariakit/react/menu";
 
 // ----------------------------------------------------------------------------
 
 interface DropdownMenuProps
 	extends Pick<
-		Ariakit.MenuProviderProps,
+		MenuProviderProps,
 		"children" | "placement" | "open" | "setOpen" | "defaultOpen"
 	> {}
 
@@ -50,14 +59,14 @@ function DropdownMenu(props: DropdownMenuProps) {
 	} = props;
 
 	return (
-		<Ariakit.MenuProvider
+		<MenuProvider
 			placement={placement}
 			defaultOpen={defaultOpenProp}
 			open={openProp}
 			setOpen={setOpenProp}
 		>
 			{children}
-		</Ariakit.MenuProvider>
+		</MenuProvider>
 	);
 }
 DEV: DropdownMenu.displayName = "DropdownMenu.Root";
@@ -73,10 +82,10 @@ interface DropdownMenuContentProps extends FocusableProps {}
  */
 const DropdownMenuContent = forwardRef<"div", DropdownMenuContentProps>(
 	(props, forwardedRef) => {
-		const popover = usePopoverApi(Ariakit.useMenuContext());
+		const popover = usePopoverApi(useMenuContext());
 
 		return (
-			<Ariakit.Menu
+			<Menu
 				portal={popover.portal}
 				unmountOnHide
 				{...props}
@@ -116,7 +125,7 @@ const DropdownMenuButton = forwardRef<"button", DropdownMenuButtonProps>(
 	(props, forwardedRef) => {
 		const { accessibleWhenDisabled = true, children, ...rest } = props;
 		return (
-			<Ariakit.MenuButton
+			<MenuButton
 				accessibleWhenDisabled
 				render={
 					<Button accessibleWhenDisabled={accessibleWhenDisabled}>
@@ -174,7 +183,7 @@ const DropdownMenuItem = forwardRef<"div", DropdownMenuItemProps>(
 		const hasShortcuts = shortcutKeys.length > 0;
 
 		return (
-			<Ariakit.MenuItem
+			<MenuItem
 				accessibleWhenDisabled
 				{...rest}
 				render={<ListItem.Root render={props.render} />}
@@ -191,7 +200,7 @@ const DropdownMenuItem = forwardRef<"div", DropdownMenuItemProps>(
 						))}
 					</ListItem.Decoration>
 				)}
-			</Ariakit.MenuItem>
+			</MenuItem>
 		);
 	},
 );
@@ -201,10 +210,7 @@ DEV: DropdownMenuItem.displayName = "DropdownMenu.Item";
 
 interface DropdownMenuCheckboxItemProps
 	extends Omit<FocusableProps, "onChange">,
-		Pick<
-			Ariakit.MenuItemCheckboxProps,
-			"checked" | "onChange" | "name" | "value"
-		> {}
+		Pick<MenuItemCheckboxProps, "checked" | "onChange" | "name" | "value"> {}
 
 /**
  * A single menu item within the dropdown menu. Should be used as a child of `DropdownMenu.Content`.
@@ -220,7 +226,7 @@ const DropdownMenuCheckboxItem = forwardRef<
 	DropdownMenuCheckboxItemProps
 >((props, forwardedRef) => {
 	return (
-		<Ariakit.MenuItemCheckbox
+		<MenuItemCheckbox
 			accessibleWhenDisabled
 			value={props.defaultChecked ? "on" : undefined} // For defaultChecked to work
 			{...props}
@@ -232,7 +238,7 @@ const DropdownMenuCheckboxItem = forwardRef<
 			<ListItem.Decoration
 				render={<Checkmark className="🥝-dropdown-menu-checkmark" />}
 			/>
-		</Ariakit.MenuItemCheckbox>
+		</MenuItemCheckbox>
 	);
 });
 DEV: DropdownMenuCheckboxItem.displayName = "DropdownMenu.CheckboxItem";

--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -3,8 +3,17 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
-import * as Ariakit from "@ariakit/react";
 import cx from "classnames";
+import { Role } from "@ariakit/react/role";
+import {
+	useCollectionStore,
+	Collection,
+	useCollectionContext,
+	CollectionItem,
+	type CollectionProps,
+	type CollectionItemProps,
+} from "@ariakit/react/collection";
+import { useStoreState } from "@ariakit/react/store";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 // ----------------------------------------------------------------------------
@@ -41,7 +50,7 @@ export const Field = forwardRef<"div", FieldProps>((props, forwardedRef) => {
 	return (
 		<FieldCollection
 			render={
-				<Ariakit.Role.div
+				<Role.div
 					{...rest}
 					className={cx("🥝-field", props.className)}
 					data-kiwi-layout={layout}
@@ -56,7 +65,7 @@ DEV: Field.displayName = "Field";
 // ----------------------------------------------------------------------------
 
 type CollectionStoreItem = NonNullable<
-	ReturnType<ReturnType<typeof Ariakit.useCollectionStore>["item"]>
+	ReturnType<ReturnType<typeof useCollectionStore>["item"]>
 >;
 
 interface FieldCollectionStoreItem extends CollectionStoreItem {
@@ -71,15 +80,11 @@ interface FieldCollectionStoreItem extends CollectionStoreItem {
  * A collection that tracks labels, controls, and descriptions which provides
  * information about IDs, placement of labels, and control types.
  */
-function FieldCollection(props: Pick<Ariakit.CollectionProps, "render">) {
-	const fieldElementCollection =
-		Ariakit.useCollectionStore<FieldCollectionStoreItem>({
-			defaultItems: [],
-		});
-	const renderedItems = Ariakit.useStoreState(
-		fieldElementCollection,
-		"renderedItems",
-	);
+function FieldCollection(props: Pick<CollectionProps, "render">) {
+	const fieldElementCollection = useCollectionStore<FieldCollectionStoreItem>({
+		defaultItems: [],
+	});
+	const renderedItems = useStoreState(fieldElementCollection, "renderedItems");
 
 	// Collect the control type and index
 	const [controlType, controlIndex] = React.useMemo(() => {
@@ -101,7 +106,7 @@ function FieldCollection(props: Pick<Ariakit.CollectionProps, "render">) {
 	}, [renderedItems, controlIndex]);
 
 	return (
-		<Ariakit.Collection
+		<Collection
 			{...props}
 			store={fieldElementCollection}
 			data-kiwi-label-placement={labelPlacement}
@@ -111,7 +116,7 @@ function FieldCollection(props: Pick<Ariakit.CollectionProps, "render">) {
 }
 
 interface FieldCollectionItemControlProps
-	extends Pick<Ariakit.CollectionItemProps, "render" | "id"> {
+	extends Pick<CollectionItemProps, "render" | "id"> {
 	type: FieldCollectionStoreItem["controlType"];
 }
 
@@ -119,10 +124,10 @@ interface FieldCollectionItemControlProps
  * An element tracked as a control in the `Field`’s collection.
  */
 export function FieldControl(props: FieldCollectionItemControlProps) {
-	const store = Ariakit.useCollectionContext();
+	const store = useCollectionContext();
 	const generatedId = React.useId();
 	const { id = store ? generatedId : undefined, type, ...rest } = props;
-	const renderedItems = Ariakit.useStoreState(store, "renderedItems");
+	const renderedItems = useStoreState(store, "renderedItems");
 	const describedBy = React.useMemo(() => {
 		// Create a space separated list of description IDs
 		const idRefList = renderedItems
@@ -145,10 +150,10 @@ export function FieldControl(props: FieldCollectionItemControlProps) {
 		[type],
 	);
 	return (
-		<Ariakit.CollectionItem
+		<CollectionItem
 			id={id}
 			getItem={getData}
-			render={<Ariakit.Role {...rest} aria-describedby={describedBy} />}
+			render={<Role {...rest} aria-describedby={describedBy} />}
 		/>
 	);
 }
@@ -156,9 +161,9 @@ export function FieldControl(props: FieldCollectionItemControlProps) {
 /**
  * An element tracked as a label in the `Field`’s collection.
  */
-export function FieldLabel(props: Pick<Ariakit.CollectionItemProps, "render">) {
-	const store = Ariakit.useCollectionContext();
-	const renderedItems = Ariakit.useStoreState(store, "renderedItems");
+export function FieldLabel(props: Pick<CollectionItemProps, "render">) {
+	const store = useCollectionContext();
+	const renderedItems = useStoreState(store, "renderedItems");
 	const fieldId = React.useMemo(
 		() =>
 			renderedItems?.find(
@@ -176,9 +181,9 @@ export function FieldLabel(props: Pick<Ariakit.CollectionItemProps, "render">) {
 	);
 
 	return (
-		<Ariakit.CollectionItem
+		<CollectionItem
 			getItem={getData}
-			render={<Ariakit.Role.label {...props} htmlFor={fieldId} />}
+			render={<Role.label {...props} htmlFor={fieldId} />}
 		/>
 	);
 }
@@ -187,7 +192,7 @@ export function FieldLabel(props: Pick<Ariakit.CollectionItemProps, "render">) {
  * An element tracked as a description in the `Field`’s collection.
  */
 export function FieldDescription(
-	props: Pick<Ariakit.CollectionItemProps, "render" | "id">,
+	props: Pick<CollectionItemProps, "render" | "id">,
 ) {
 	const generatedId = React.useId();
 	const { id = generatedId, ...rest } = props;
@@ -198,5 +203,5 @@ export function FieldDescription(
 		}),
 		[],
 	);
-	return <Ariakit.CollectionItem {...rest} id={id} getItem={getData} />;
+	return <CollectionItem {...rest} id={id} getItem={getData} />;
 }

--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface IconProps extends Omit<BaseProps<"svg">, "children"> {
@@ -63,7 +63,7 @@ export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
 	const isDecorative = !alt;
 
 	return (
-		<Ariakit.Role.svg
+		<Role.svg
 			aria-hidden={isDecorative ? "true" : undefined}
 			role={isDecorative ? undefined : "img"}
 			aria-label={isDecorative ? undefined : alt}
@@ -73,7 +73,7 @@ export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
 			ref={forwardedRef}
 		>
 			<use href={`${props.href}#${iconId}`} />
-		</Ariakit.Role.svg>
+		</Role.svg>
 	);
 });
 DEV: Icon.displayName = "Icon";
@@ -110,7 +110,7 @@ export const DisclosureArrow = forwardRef<"svg", DisclosureArrowProps>(
 			<Icon
 				{...rest}
 				render={
-					<Ariakit.Role.svg
+					<Role.svg
 						width="16"
 						height="16"
 						fill="currentColor"
@@ -118,7 +118,7 @@ export const DisclosureArrow = forwardRef<"svg", DisclosureArrowProps>(
 						render={props.render}
 					>
 						{path}
-					</Ariakit.Role.svg>
+					</Role.svg>
 				}
 				className={cx("🥝-disclosure-arrow", props.className)}
 				ref={forwardedRef}
@@ -138,7 +138,7 @@ export const Checkmark = forwardRef<"svg", CheckmarkProps>(
 			<Icon
 				{...props}
 				render={
-					<Ariakit.Role.svg
+					<Role.svg
 						width="16"
 						height="16"
 						fill="currentColor"
@@ -150,7 +150,7 @@ export const Checkmark = forwardRef<"svg", CheckmarkProps>(
 							d="M13.854 4.146a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3-3a.5.5 0 1 1 .708-.708L6.5 10.793l6.646-6.647a.5.5 0 0 1 .708 0Z"
 							clipRule="evenodd"
 						/>
-					</Ariakit.Role.svg>
+					</Role.svg>
 				}
 				ref={forwardedRef}
 			/>
@@ -169,7 +169,7 @@ export const Dismiss = forwardRef<"svg", DismissProps>(
 			<Icon
 				{...props}
 				render={
-					<Ariakit.Role.svg
+					<Role.svg
 						width="16"
 						height="16"
 						viewBox="0 0 16 16"
@@ -177,7 +177,7 @@ export const Dismiss = forwardRef<"svg", DismissProps>(
 						render={props.render}
 					>
 						<path d="M4.853 4.146a.5.5 0 1 0-.707.708L7.293 8l-3.147 3.146a.5.5 0 0 0 .707.708L8 8.707l3.146 3.147a.5.5 0 0 0 .707-.708L8.707 8l3.146-3.146a.5.5 0 1 0-.707-.708L8 7.293 4.853 4.146Z" />
-					</Ariakit.Role.svg>
+					</Role.svg>
 				}
 				ref={forwardedRef}
 			/>

--- a/packages/kiwi-react/src/bricks/IconButton.tsx
+++ b/packages/kiwi-react/src/bricks/IconButton.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { useToolbarContext, ToolbarItem } from "@ariakit/react/toolbar";
 import { Button } from "./Button.js";
 import { VisuallyHidden } from "./VisuallyHidden.js";
 import { Icon } from "./Icon.js";
@@ -98,15 +98,13 @@ export const IconButton = forwardRef<"button", IconButtonProps>(
 	(props, forwardedRef) => {
 		const { label, icon, isActive, labelVariant, ...rest } = props;
 
-		const toolbar = Ariakit.useToolbarContext();
+		const toolbar = useToolbarContext();
 
 		const button = (
 			<Button
 				aria-pressed={isActive}
 				{...rest}
-				render={
-					toolbar ? <Ariakit.ToolbarItem render={props.render} /> : props.render
-				}
+				render={toolbar ? <ToolbarItem render={props.render} /> : props.render}
 				className={cx("🥝-icon-button", props.className)}
 				ref={forwardedRef}
 			>

--- a/packages/kiwi-react/src/bricks/Kbd.tsx
+++ b/packages/kiwi-react/src/bricks/Kbd.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role, type RoleProps } from "@ariakit/react/role";
 import { forwardRef, type BaseProps } from "./~utils.js";
 import { VisuallyHidden } from "./VisuallyHidden.js";
 
@@ -75,15 +75,15 @@ export const Kbd = forwardRef<"kbd", KbdProps>((props, forwardedRef) => {
 	}
 
 	return (
-		<Ariakit.Role
+		<Role
 			{...rest}
 			data-kiwi-variant={variant}
 			className={cx("🥝-kbd", props.className)}
 			render={props.render || <kbd />}
-			ref={forwardedRef as Ariakit.RoleProps["ref"]}
+			ref={forwardedRef as RoleProps["ref"]}
 		>
 			{content}
-		</Ariakit.Role>
+		</Role>
 	);
 });
 DEV: Kbd.displayName = "Kbd";

--- a/packages/kiwi-react/src/bricks/Label.tsx
+++ b/packages/kiwi-react/src/bricks/Label.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import { forwardRef, type BaseProps } from "./~utils.js";
 import { FieldLabel } from "./Field.js";
 
@@ -33,7 +33,7 @@ export const Label = forwardRef<"label", LabelProps>((props, forwardedRef) => {
 	return (
 		<FieldLabel
 			render={
-				<Ariakit.Role.label
+				<Role.label
 					{...props}
 					className={cx("🥝-label", props.className)}
 					ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/ListItem.tsx
+++ b/packages/kiwi-react/src/bricks/ListItem.tsx
@@ -3,18 +3,18 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role, type RoleProps } from "@ariakit/react/role";
 import { forwardRef } from "./~utils.js";
 import { Text } from "./Text.js";
 
 // ----------------------------------------------------------------------------
 
-interface ListItemProps extends Ariakit.RoleProps<"div"> {}
+interface ListItemProps extends RoleProps<"div"> {}
 
 /** @internal */
 const ListItem = forwardRef<"div", ListItemProps>((props, forwardedRef) => {
 	return (
-		<Ariakit.Role.div
+		<Role.div
 			role="listitem"
 			{...props}
 			className={cx("🥝-list-item", props.className)}
@@ -26,7 +26,7 @@ DEV: ListItem.displayName = "ListItem.Root";
 
 // ----------------------------------------------------------------------------
 
-interface ListItemContentProps extends Ariakit.RoleProps<"div"> {}
+interface ListItemContentProps extends RoleProps<"div"> {}
 
 /** @internal */
 const ListItemContent = forwardRef<"div", ListItemContentProps>(
@@ -45,13 +45,13 @@ DEV: ListItemContent.displayName = "ListItem.Content";
 
 // ----------------------------------------------------------------------------
 
-interface ListItemDecorationProps extends Ariakit.RoleProps<"span"> {}
+interface ListItemDecorationProps extends RoleProps<"span"> {}
 
 /** @internal */
 const ListItemDecoration = forwardRef<"span", ListItemDecorationProps>(
 	(props, forwardedRef) => {
 		return (
-			<Ariakit.Role.span
+			<Role.span
 				{...props}
 				className={cx("🥝-list-item-decoration", props.className)}
 				ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/Radio.tsx
+++ b/packages/kiwi-react/src/bricks/Radio.tsx
@@ -3,13 +3,16 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import {
+	Radio as AkRadio,
+	type RadioProps as AkRadioProps,
+} from "@ariakit/react/radio";
 import { FieldControl } from "./Field.js";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 
 type InputBaseProps = Omit<FocusableProps<"input">, "defaultValue" | "value">;
 
-type RadioOwnProps = Pick<Ariakit.RadioProps, "value" | "checked" | "onChange">;
+type RadioOwnProps = Pick<AkRadioProps, "value" | "checked" | "onChange">;
 
 interface RadioProps extends InputBaseProps, RadioOwnProps {}
 
@@ -36,7 +39,7 @@ export const Radio = forwardRef<"input", RadioProps>((props, forwardedRef) => {
 			type="checkable"
 			id={id}
 			render={
-				<Ariakit.Radio
+				<AkRadio
 					accessibleWhenDisabled
 					{...rest}
 					className={cx("🥝-checkbox", "🥝-radio", props.className)}

--- a/packages/kiwi-react/src/bricks/Root.tsx
+++ b/packages/kiwi-react/src/bricks/Root.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import cx from "classnames";
 import foundationsCss from "../foundations/styles.css.js";
 import bricksCss from "./styles.css.js";
@@ -94,7 +94,7 @@ const RootInternal = forwardRef<"div", RootInternalProps>(
 		}, []);
 
 		return (
-			<Ariakit.Role
+			<Role
 				{...rest}
 				className={cx("🥝-root", props.className)}
 				data-kiwi-theme={colorScheme}
@@ -104,7 +104,7 @@ const RootInternal = forwardRef<"div", RootInternalProps>(
 				<RootNodeContext.Provider value={rootNode}>
 					{children}
 				</RootNodeContext.Provider>
-			</Ariakit.Role>
+			</Role>
 		);
 	},
 );

--- a/packages/kiwi-react/src/bricks/Select.tsx
+++ b/packages/kiwi-react/src/bricks/Select.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import {
 	forwardRef,
 	isBrowser,
@@ -46,7 +46,7 @@ const SelectRoot = forwardRef<"div", BaseProps>((props, forwardedRef) => {
 
 	return (
 		<HtmlSelectContext.Provider value={setIsHtmlSelect}>
-			<Ariakit.Role.div
+			<Role.div
 				{...props}
 				className={cx("🥝-select-root", props.className)}
 				data-kiwi-has-select={!supportsHas && isHtmlSelect ? "true" : undefined}
@@ -106,7 +106,7 @@ const HtmlSelect = forwardRef<"select", HtmlSelectProps>(
 					type="textlike"
 					id={id}
 					render={
-						<Ariakit.Role.select
+						<Role.select
 							{...rest}
 							className={cx("🥝-button", "🥝-select", props.className)}
 							data-kiwi-tone="neutral"

--- a/packages/kiwi-react/src/bricks/Spinner.tsx
+++ b/packages/kiwi-react/src/bricks/Spinner.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import cx from "classnames";
 import { VisuallyHidden } from "./VisuallyHidden.js";
 import { forwardRef, type BaseProps } from "./~utils.js";
@@ -48,7 +48,7 @@ export const Spinner = forwardRef<"div", SpinnerProps>(
 		} = props;
 
 		return (
-			<Ariakit.Role
+			<Role
 				{...rest}
 				data-kiwi-size={size}
 				data-kiwi-tone={tone}
@@ -63,7 +63,7 @@ export const Spinner = forwardRef<"div", SpinnerProps>(
 					/>
 				</svg>
 				<VisuallyHidden>{alt}</VisuallyHidden>
-			</Ariakit.Role>
+			</Role>
 		);
 	},
 );

--- a/packages/kiwi-react/src/bricks/Switch.tsx
+++ b/packages/kiwi-react/src/bricks/Switch.tsx
@@ -3,14 +3,17 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import {
+	Checkbox as AkCheckbox,
+	type CheckboxProps as AkCheckboxProps,
+} from "@ariakit/react/checkbox";
 import { FieldControl } from "./Field.js";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 
 type InputBaseProps = Omit<FocusableProps<"input">, "defaultValue" | "value">;
 
 type CheckboxOwnProps = Pick<
-	Ariakit.CheckboxProps,
+	AkCheckboxProps,
 	"value" | "defaultChecked" | "checked" | "onChange"
 >;
 
@@ -45,7 +48,7 @@ export const Switch = forwardRef<"input", SwitchProps>(
 				type="checkable"
 				id={id}
 				render={
-					<Ariakit.Checkbox
+					<AkCheckbox
 						accessibleWhenDisabled
 						{...rest}
 						className={cx("🥝-switch", props.className)}

--- a/packages/kiwi-react/src/bricks/Table.tsx
+++ b/packages/kiwi-react/src/bricks/Table.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import * as React from "react";
 import cx from "classnames";
 import { forwardRef, type BaseProps } from "./~utils.js";
@@ -54,7 +54,7 @@ const Table = forwardRef<"div", TableProps>((props, forwardedRef) => {
 
 	return (
 		<TableContext.Provider value={tableContext}>
-			<Ariakit.Role
+			<Role
 				{...props}
 				className={cx("🥝-table", props.className)}
 				ref={forwardedRef}
@@ -62,7 +62,7 @@ const Table = forwardRef<"div", TableProps>((props, forwardedRef) => {
 				aria-labelledby={captionId}
 			>
 				{props.children}
-			</Ariakit.Role>
+			</Role>
 		</TableContext.Provider>
 	);
 });
@@ -91,14 +91,14 @@ const TableHeader = forwardRef<"div", TableHeaderProps>(
 	(props, forwardedRef) => {
 		return (
 			<TableHeaderContext.Provider value={true}>
-				<Ariakit.Role.div
+				<Role.div
 					{...props}
 					className={cx("🥝-table-header", props.className)}
 					ref={forwardedRef}
 					role="rowgroup"
 				>
 					{props.children}
-				</Ariakit.Role.div>
+				</Role.div>
 			</TableHeaderContext.Provider>
 		);
 	},
@@ -131,13 +131,13 @@ interface TableBodyProps extends BaseProps {}
  */
 const TableBody = forwardRef<"div", TableBodyProps>((props, forwardedRef) => {
 	return (
-		<Ariakit.Role.div
+		<Role.div
 			{...props}
 			className={cx("🥝-table-body", props.className)}
 			ref={forwardedRef}
 		>
 			{props.children}
-		</Ariakit.Role.div>
+		</Role.div>
 	);
 });
 DEV: TableBody.displayName = "Table.Body";
@@ -161,14 +161,14 @@ const TableRow = forwardRef<"div", TableRowProps>((props, forwardedRef) => {
 	const { children, ...rest } = props;
 
 	return (
-		<Ariakit.Role.div
+		<Role.div
 			{...rest}
 			className={cx("🥝-table-row", props.className)}
 			ref={forwardedRef}
 			role="row"
 		>
 			{children}
-		</Ariakit.Role.div>
+		</Role.div>
 	);
 });
 DEV: TableRow.displayName = "Table.Row";
@@ -203,14 +203,14 @@ const TableCaption = forwardRef<"caption", TableCaptionProps>(
 		);
 
 		return (
-			<Ariakit.Role
+			<Role
 				{...rest}
 				id={id}
 				className={cx("🥝-table-caption", props.className)}
 				ref={useMergedRefs(forwardedRef, captionIdRef)}
 			>
 				{children}
-			</Ariakit.Role>
+			</Role>
 		);
 	},
 );
@@ -232,14 +232,14 @@ const TableCell = forwardRef<"span", TableCellProps>((props, forwardedRef) => {
 	const isWithinTableHeader = React.useContext(TableHeaderContext);
 
 	return (
-		<Ariakit.Role.span
+		<Role.span
 			{...props}
 			className={cx("🥝-table-cell", props.className)}
 			ref={forwardedRef}
 			role={isWithinTableHeader ? "columnheader" : "cell"}
 		>
 			{props.children}
-		</Ariakit.Role.span>
+		</Role.span>
 	);
 });
 DEV: TableCell.displayName = "Table.Cell";

--- a/packages/kiwi-react/src/bricks/Tabs.tsx
+++ b/packages/kiwi-react/src/bricks/Tabs.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import * as AkTab from "@ariakit/react/tab";
 import { useControlledState } from "./~hooks.js";
 import { type FocusableProps, type BaseProps, forwardRef } from "./~utils.js";
 
@@ -13,7 +13,7 @@ import { type FocusableProps, type BaseProps, forwardRef } from "./~utils.js";
 
 interface TabsProps
 	extends Pick<
-		Ariakit.TabProviderProps,
+		AkTab.TabProviderProps,
 		| "defaultSelectedId"
 		| "selectedId"
 		| "setSelectedId"
@@ -65,10 +65,10 @@ function Tabs(props: TabsProps) {
 	);
 
 	return (
-		<Ariakit.TabProvider
+		<AkTab.TabProvider
 			selectedId={selectedId}
 			setSelectedId={React.useCallback(
-				(id: Ariakit.TabStoreState["selectedId"]) => {
+				(id: AkTab.TabStoreState["selectedId"]) => {
 					if (document.startViewTransition) {
 						document.startViewTransition(() => {
 							ReactDOM.flushSync(() => {
@@ -84,7 +84,7 @@ function Tabs(props: TabsProps) {
 			selectOnMove={selectOnMove}
 		>
 			{children}
-		</Ariakit.TabProvider>
+		</AkTab.TabProvider>
 	);
 }
 DEV: Tabs.displayName = "Tabs.Root";
@@ -114,7 +114,7 @@ const TabList = forwardRef<"div", TabListProps>((props, forwardedRef) => {
 	const viewTransitionName = `🥝active-stripe-${React.useId().replaceAll(":", "_")}`;
 
 	return (
-		<Ariakit.TabList
+		<AkTab.TabList
 			{...rest}
 			data-kiwi-tone={tone}
 			className={cx("🥝-tab-list", props.className)}
@@ -134,7 +134,7 @@ DEV: TabList.displayName = "Tabs.TabList";
 
 interface TabProps
 	extends FocusableProps<"button">,
-		Pick<Ariakit.TabProps, "id"> {}
+		Pick<AkTab.TabProps, "id"> {}
 
 /**
  * An individual tab button that switches the selected tab panel when clicked.
@@ -149,7 +149,7 @@ interface TabProps
  */
 const Tab = forwardRef<"button", TabProps>((props, forwardedRef) => {
 	return (
-		<Ariakit.Tab
+		<AkTab.Tab
 			accessibleWhenDisabled
 			{...props}
 			className={cx("🥝-tab", props.className)}
@@ -163,7 +163,7 @@ DEV: Tab.displayName = "Tabs.Tab";
 
 interface TabPanelProps
 	extends FocusableProps<"div">,
-		Pick<Ariakit.TabPanelProps, "tabId" | "unmountOnHide" | "focusable"> {}
+		Pick<AkTab.TabPanelProps, "tabId" | "unmountOnHide" | "focusable"> {}
 
 /**
  * The actual content of a tab, shown when the tab is selected. Should be used as a child of `Tabs.Root`.
@@ -176,7 +176,7 @@ interface TabPanelProps
  */
 const TabPanel = forwardRef<"div", TabPanelProps>((props, forwardedRef) => {
 	return (
-		<Ariakit.TabPanel
+		<AkTab.TabPanel
 			{...props}
 			className={cx("🥝-tab-panel", props.className)}
 			ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/Text.tsx
+++ b/packages/kiwi-react/src/bricks/Text.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
 import cx from "classnames";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
@@ -43,7 +43,7 @@ export const Text = forwardRef<"div", TextProps>((props, forwardedRef) => {
 	const { variant, ...rest } = props;
 
 	return (
-		<Ariakit.Role
+		<Role
 			{...rest}
 			className={cx("🥝-text", props.className)}
 			data-kiwi-text-variant={variant}

--- a/packages/kiwi-react/src/bricks/TextBox.tsx
+++ b/packages/kiwi-react/src/bricks/TextBox.tsx
@@ -3,7 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
+import { Focusable } from "@ariakit/react/focusable";
 import cx from "classnames";
 import { FieldControl } from "./Field.js";
 import { Icon } from "./Icon.js";
@@ -65,7 +66,7 @@ const TextBoxInput = forwardRef<"input", TextBoxInputProps>(
 				type="textlike"
 				id={id}
 				render={
-					<Ariakit.Role.input
+					<Role.input
 						readOnly={props.disabled}
 						{...rest}
 						className={cx({ "🥝-text-box": !rootContext }, props.className)}
@@ -75,7 +76,7 @@ const TextBoxInput = forwardRef<"input", TextBoxInputProps>(
 						 */
 						placeholder={props.placeholder ?? " "}
 						render={
-							<Ariakit.Focusable
+							<Focusable
 								accessibleWhenDisabled
 								render={props.render || <input />}
 							/>
@@ -121,7 +122,7 @@ const TextBoxTextarea = forwardRef<"textarea", TextareaProps>(
 				type="textlike"
 				id={id}
 				render={
-					<Ariakit.Role.textarea
+					<Role.textarea
 						readOnly={props.disabled}
 						{...rest}
 						className={cx("🥝-text-box", props.className)}
@@ -131,7 +132,7 @@ const TextBoxTextarea = forwardRef<"textarea", TextareaProps>(
 						 */
 						placeholder={props.placeholder ?? " "}
 						render={
-							<Ariakit.Focusable
+							<Focusable
 								accessibleWhenDisabled
 								render={props.render || <textarea />}
 							/>
@@ -179,7 +180,7 @@ const TextBoxRoot = forwardRef<"div", TextBoxRootProps>(
 			<TextBoxRootContext.Provider
 				value={React.useMemo(() => ({ setDisabled, inputRef }), [])}
 			>
-				<Ariakit.Role.div
+				<Role.div
 					{...props}
 					data-kiwi-disabled={disabled}
 					className={cx("🥝-text-box", props.className)}
@@ -232,7 +233,7 @@ interface TextBoxTextProps extends BaseProps<"span"> {}
 const TextBoxText = forwardRef<"span", TextBoxTextProps>(
 	(props, forwardedRef) => {
 		return (
-			<Ariakit.Role.span
+			<Role.span
 				{...props}
 				className={cx("🥝-text-box-decoration", props.className)}
 				ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import * as AkTooltip from "@ariakit/react/tooltip";
 import { forwardRef, type FocusableProps } from "./~utils.js";
 import { usePopoverApi } from "./~hooks.js";
 
 interface TooltipProps
 	extends Omit<FocusableProps<"div">, "content">,
-		Pick<Ariakit.TooltipProps, "open" | "unmountOnHide">,
-		Pick<Ariakit.TooltipProviderProps, "defaultOpen" | "setOpen"> {
+		Pick<AkTooltip.TooltipProps, "open" | "unmountOnHide">,
+		Pick<AkTooltip.TooltipProviderProps, "defaultOpen" | "setOpen"> {
 	/**
 	 * The content to be displayed inside the tooltip when the trigger element is hovered or focused.
 	 */
@@ -70,23 +70,23 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 			...rest
 		} = props;
 
-		const store = Ariakit.useTooltipStore();
+		const store = AkTooltip.useTooltipStore();
 		const popover = usePopoverApi(store);
 
 		return (
 			<>
-				<Ariakit.TooltipProvider
+				<AkTooltip.TooltipProvider
 					store={store}
 					defaultOpen={defaultOpenProp}
 					open={openProp}
 					setOpen={setOpenProp}
 				>
-					<Ariakit.TooltipAnchor
+					<AkTooltip.TooltipAnchor
 						render={children}
 						{...(type === "description" && { "aria-describedby": id })}
 						{...(type === "label" && { "aria-labelledby": id })}
 					/>
-					<Ariakit.Tooltip
+					<AkTooltip.Tooltip
 						aria-hidden="true"
 						{...rest}
 						unmountOnHide={unmountOnHide}
@@ -101,8 +101,8 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 						portal={popover.portal}
 					>
 						{content}
-					</Ariakit.Tooltip>
-				</Ariakit.TooltipProvider>
+					</AkTooltip.Tooltip>
+				</AkTooltip.TooltipProvider>
 			</>
 		);
 	},

--- a/packages/kiwi-react/src/bricks/Tree.tsx
+++ b/packages/kiwi-react/src/bricks/Tree.tsx
@@ -3,7 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
+import { useCompositeStore, Composite } from "@ariakit/react/composite";
 import { forwardRef, type BaseProps } from "./~utils.js";
 import { Root as TreeItemRoot, Action as TreeItemAction } from "./TreeItem.js";
 
@@ -28,18 +29,18 @@ interface TreeProps extends BaseProps {}
  * ```
  */
 const Tree = forwardRef<"div", TreeProps>((props, forwardedRef) => {
-	const composite = Ariakit.useCompositeStore({ orientation: "vertical" });
+	const composite = useCompositeStore({ orientation: "vertical" });
 
 	return (
-		<Ariakit.Role.div
+		<Role.div
 			role="tree"
 			{...props}
-			render={<Ariakit.Composite store={composite} />}
+			render={<Composite store={composite} />}
 			className={cx("🥝-tree", props.className)}
 			ref={forwardedRef}
 		>
 			{props.children}
-		</Ariakit.Role.div>
+		</Role.div>
 	);
 });
 DEV: Tree.displayName = "Tree.Root";

--- a/packages/kiwi-react/src/bricks/TreeItem.tsx
+++ b/packages/kiwi-react/src/bricks/TreeItem.tsx
@@ -4,7 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import cx from "classnames";
-import * as Ariakit from "@ariakit/react";
+import { Role } from "@ariakit/react/role";
+import {
+	CompositeItem,
+	type CompositeItemProps,
+} from "@ariakit/react/composite";
+import { Toolbar } from "@ariakit/react/toolbar";
 import * as ListItem from "./ListItem.js";
 import { IconButton } from "./IconButton.js";
 import { Icon } from "./Icon.js";
@@ -163,8 +168,8 @@ const TreeItemRoot = forwardRef<"div", TreeItemRootProps>(
 					[level, expanded, selected],
 				)}
 			>
-				<Ariakit.CompositeItem
-					render={<Ariakit.Role {...rest} />}
+				<CompositeItem
+					render={<Role {...rest} />}
 					onClick={
 						useEventHandlers(
 							onClickProp,
@@ -184,7 +189,7 @@ const TreeItemRoot = forwardRef<"div", TreeItemRootProps>(
 					aria-describedby={description ? descriptionId : undefined}
 					aria-level={level}
 					className={cx("🥝-tree-item", props.className)}
-					ref={forwardedRef as Ariakit.CompositeItemProps["ref"]}
+					ref={forwardedRef as CompositeItemProps["ref"]}
 				>
 					<ListItem.Root
 						data-kiwi-expanded={expanded}
@@ -219,7 +224,7 @@ const TreeItemRoot = forwardRef<"div", TreeItemRootProps>(
 							render={<TreeItemActions>{actions}</TreeItemActions>}
 						/>
 					</ListItem.Root>
-				</Ariakit.CompositeItem>
+				</CompositeItem>
 			</TreeItemContext.Provider>
 		);
 	},
@@ -230,14 +235,14 @@ DEV: TreeItemRoot.displayName = "TreeItem.Root";
 
 const TreeItemActions = forwardRef<"div", BaseProps>((props, forwardedRef) => {
 	return (
-		<Ariakit.Toolbar
+		<Toolbar
 			{...props}
 			onClick={useEventHandlers(props.onClick, (e) => e.stopPropagation())}
 			className={cx("🥝-tree-item-actions", props.className)}
 			ref={forwardedRef}
 		>
 			{props.children}
-		</Ariakit.Toolbar>
+		</Toolbar>
 	);
 });
 DEV: TreeItemActions.displayName = "TreeItemActions";
@@ -319,7 +324,7 @@ const TreeChevron = forwardRef<"svg", TreeChevronProps>(
 			<Icon
 				{...props}
 				render={
-					<Ariakit.Role.svg
+					<Role.svg
 						width="16"
 						height="16"
 						fill="currentColor"
@@ -327,7 +332,7 @@ const TreeChevron = forwardRef<"svg", TreeChevronProps>(
 						render={props.render}
 					>
 						<path d="M4.146 6.146a.5.5 0 0 1 .708 0L8 9.293l3.146-3.147a.5.5 0 0 1 .708.708l-3.5 3.5a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 0 1 0-.708Z" />
-					</Ariakit.Role.svg>
+					</Role.svg>
 				}
 				className={cx("🥝-tree-chevron", props.className)}
 				ref={forwardedRef}

--- a/packages/kiwi-react/src/bricks/VisuallyHidden.tsx
+++ b/packages/kiwi-react/src/bricks/VisuallyHidden.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import * as Ariakit from "@ariakit/react";
+import { VisuallyHidden as AkVisuallyHidden } from "@ariakit/react/visually-hidden";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface VisuallyHiddenProps extends BaseProps<"span"> {}
@@ -22,7 +22,7 @@ interface VisuallyHiddenProps extends BaseProps<"span"> {}
  */
 export const VisuallyHidden = forwardRef<"span", VisuallyHiddenProps>(
 	(props, forwardedRef) => {
-		return <Ariakit.VisuallyHidden {...props} ref={forwardedRef} />;
+		return <AkVisuallyHidden {...props} ref={forwardedRef} />;
 	},
 );
 DEV: VisuallyHidden.displayName = "VisuallyHidden";

--- a/packages/kiwi-react/src/bricks/~hooks.ts
+++ b/packages/kiwi-react/src/bricks/~hooks.ts
@@ -3,8 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
-import * as Ariakit from "@ariakit/react";
+import { useStoreState } from "@ariakit/react/store";
 import { supportsPopover } from "./~utils.js";
+import type { PopoverStore } from "@ariakit/react/popover";
 
 /**
  * Wrapper over `useState` that always gives preference to the
@@ -165,14 +166,9 @@ export function useSafeContext<C>(context: React.Context<C>) {
  *
  * @private
  */
-export function usePopoverApi(
-	store: Parameters<typeof Ariakit.useStoreState>[0],
-) {
-	const open = Ariakit.useStoreState(store, (state) => state?.open);
-	const popover = Ariakit.useStoreState(
-		store,
-		(state) => state?.popoverElement,
-	);
+export function usePopoverApi(store: PopoverStore | undefined) {
+	const open = useStoreState(store, (state) => state?.open);
+	const popover = useStoreState(store, (state) => state?.popoverElement);
 
 	React.useEffect(
 		function syncPopoverWithOpenState() {

--- a/packages/kiwi-react/src/bricks/~utils.tsx
+++ b/packages/kiwi-react/src/bricks/~utils.tsx
@@ -3,7 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
-import type * as Ariakit from "@ariakit/react";
+import type { RoleProps } from "@ariakit/react/role";
+import type { FocusableProps as AkFocusableProps } from "@ariakit/react/focusable";
 
 export const isBrowser = typeof document !== "undefined";
 
@@ -54,12 +55,9 @@ type MergeProps<
 
 /** Base component props with custom props. */
 export type BaseProps<ElementType extends React.ElementType = "div"> =
-	MergeProps<ElementType, Pick<Ariakit.RoleProps, "render">>;
+	MergeProps<ElementType, Pick<RoleProps, "render">>;
 
 /** Focusable component props with custom props. */
 export type FocusableProps<ElementType extends React.ElementType = "div"> =
 	BaseProps<ElementType> &
-		Pick<
-			Ariakit.FocusableProps,
-			"disabled" | "accessibleWhenDisabled" | "autoFocus"
-		>;
+		Pick<AkFocusableProps, "disabled" | "accessibleWhenDisabled" | "autoFocus">;


### PR DESCRIPTION
As discussed in https://github.com/iTwin/design-system/discussions/405#discussioncomment-12373238, this replaces all `"@ariakit/react"` barrel imports with direct imports from the relevant entrypoints.

Most of the changes were simple (e.g. importing `Role` from `"@ariakit/react/role"`), but some of them required renaming upon import or using namespace imports (to avoid naming collisions).