### PR TITLE
Update `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
--       @iTwin/design-system-developers
+*       @iTwin/design-system-developers


### PR DESCRIPTION
Updated `CODEOWNERS` to reference [the Design System developers GitHub team](https://github.com/orgs/iTwin/teams/design-system-developers) instead of [the parent Codename Kiwi GitHub team](https://github.com/orgs/iTwin/teams/codename-kiwi) which is being renamed after this.