### PR TITLE
`DropdownMenu.Item`: recognize symbols in `shortcuts`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
 		"package.json": "package-lock.json, pnpm-lock.yaml, pnpm-workspace.yaml, .npmrc",
 		"tsconfig.json": "tsconfig.*.json",
 		"README.md": "*.md",
-		"*.tsx": "${capture}.ts, ${capture}.css, ${capture}.module.css, ${capture}.spec.ts, ${capture}.spec.ts-snapshot.*",
+		"*.tsx": "${capture}.ts, ${capture}.css, ${capture}.module.css, ${capture}.spec.ts, ${capture}.spec.ts-snapshot.*, ${capture}.internal.*",
 		"*.ts": "${capture}.js, ${capture}.css",
 		"*.jsx": "${capture}.js, ${capture}.css",
 		"*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts, ${capture}.css",

--- a/apps/test-app/app/tests/dropdown-menu/index.spec.ts
+++ b/apps/test-app/app/tests/dropdown-menu/index.spec.ts
@@ -100,12 +100,12 @@ test("shortcuts", async ({ page }) => {
 
 	const add = page.getByRole("menuitem", { name: "Add" });
 	const addingShortcut = add.locator("kbd");
-	await expect(addingShortcut.nth(0)).toHaveText("⌘");
+	await expect(addingShortcut.nth(0)).toMatchAriaSnapshot("- text: Command");
 	await expect(addingShortcut.nth(1)).toHaveText("A");
 
 	const edit = page.getByRole("menuitem", { name: "Edit" });
 	const editShortcut = edit.locator("kbd");
-	await expect(editShortcut.nth(0)).toHaveText("⇧");
+	await expect(editShortcut.nth(0)).toMatchAriaSnapshot("- text: Shift");
 	await expect(editShortcut.nth(1)).toHaveText("E");
 });
 

--- a/apps/test-app/app/tests/dropdown-menu/index.tsx
+++ b/apps/test-app/app/tests/dropdown-menu/index.tsx
@@ -17,8 +17,8 @@ export default definePage(
 					</DropdownMenu.Button>
 
 					<DropdownMenu.Content>
-						<DropdownMenu.Item shortcuts="⌘+A">Add</DropdownMenu.Item>
-						<DropdownMenu.Item shortcuts="⇧+E">Edit</DropdownMenu.Item>
+						<DropdownMenu.Item shortcuts="Command+A">Add</DropdownMenu.Item>
+						<DropdownMenu.Item shortcuts="Shift+E">Edit</DropdownMenu.Item>
 						<DropdownMenu.Item disabled>Delete</DropdownMenu.Item>
 						<DropdownMenu.Item>Disable</DropdownMenu.Item>
 					</DropdownMenu.Content>

--- a/packages/kiwi-react/src/bricks/Kbd.internal.ts
+++ b/packages/kiwi-react/src/bricks/Kbd.internal.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+export type PredefinedSymbol = keyof typeof predefinedSymbols;
+
+export const predefinedSymbols = {
+	Backspace: "\u232b",
+	Command: "\u2318",
+	Control: "Ctrl",
+	Down: "\u2193",
+	Eject: "\u23cf",
+	Enter: "\u21b5",
+	Escape: "Esc",
+	Left: "\u2190",
+	Option: "\u2325",
+	Right: "\u2192",
+	Shift: "\u21e7",
+	Space: "\u2423",
+	Tab: "Tab",
+	Up: "\u2191",
+} as const;

--- a/packages/kiwi-react/src/bricks/Kbd.tsx
+++ b/packages/kiwi-react/src/bricks/Kbd.tsx
@@ -6,23 +6,7 @@ import cx from "classnames";
 import { Role, type RoleProps } from "@ariakit/react/role";
 import { forwardRef, type BaseProps } from "./~utils.js";
 import { VisuallyHidden } from "./VisuallyHidden.js";
-
-const predefinedSymbols = {
-	Backspace: "\u232b",
-	Command: "\u2318",
-	Control: "Ctrl",
-	Down: "\u2193",
-	Eject: "\u23cf",
-	Enter: "\u21b5",
-	Escape: "Esc",
-	Left: "\u2190",
-	Option: "\u2325",
-	Right: "\u2192",
-	Shift: "\u21e7",
-	Space: "\u2423",
-	Tab: "Tab",
-	Up: "\u2191",
-} as const;
+import { predefinedSymbols, type PredefinedSymbol } from "./Kbd.internal.js";
 
 interface KbdProps extends BaseProps<"kbd"> {
 	/** @default "solid" */
@@ -37,7 +21,7 @@ interface KbdProps extends BaseProps<"kbd"> {
 	 * <Kbd symbol="Control" />
 	 * ```
 	 */
-	symbol?: keyof typeof predefinedSymbols;
+	symbol?: PredefinedSymbol;
 }
 
 /**

--- a/packages/kiwi-react/src/bricks/~utils.tsx
+++ b/packages/kiwi-react/src/bricks/~utils.tsx
@@ -61,3 +61,8 @@ export type BaseProps<ElementType extends React.ElementType = "div"> =
 export type FocusableProps<ElementType extends React.ElementType = "div"> =
 	BaseProps<ElementType> &
 		Pick<AkFocusableProps, "disabled" | "accessibleWhenDisabled" | "autoFocus">;
+
+// ----------------------------------------------------------------------------
+
+/** See https://github.com/Microsoft/TypeScript/issues/29729 */
+export type AnyString = string & {};


### PR DESCRIPTION
This updates the `shortcuts` prop of `<DropdownMenu.Item>` to recognize the predefined symbols added in #173. If a symbol is recognized, it will be fed into `<Kbd>`'s `symbol` prop (instead of `children`).

### Usage (for consumers)

```diff
- <DropdownMenu.Item shortcuts="⇧+E">
+ <DropdownMenu.Item shortcuts="Shift+E">
```

### Notes
- I've moved some code around to keep things organized. `predefinedSymbols` is exported from `Kbd.internal.tsx` to avoid polluting the main component file's exports.
- I've attempted to provide useful information in the types for `shortcuts`. It's not perfect (there is no autocomplete), but I'm not sure if we can do any better with this API.

### Future considerations

- Make it case-insensitive? https://github.com/iTwin/design-system/pull/416#discussion_r1980606415