### PR TITLE
portal `DropdownMenu` and `Tooltip` by default

### DIFF
--- a/apps/test-app/app/tests/dropdown-menu/index.spec.ts
+++ b/apps/test-app/app/tests/dropdown-menu/index.spec.ts
@@ -204,7 +204,10 @@ test.describe("DropdownMenu.CheckboxItem", () => {
 			await expect(item3).toHaveAttribute("aria-checked", "true");
 
 			const axe = new AxeBuilder({ page });
-			const accessibilityScan = await axe.analyze();
+			const accessibilityScan = await axe
+				.disableRules(["region"])
+				.exclude("[data-focus-trap]")
+				.analyze();
 			expect(accessibilityScan.violations).toEqual([]);
 		});
 	});

--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -93,7 +93,7 @@ const DropdownMenuContent = forwardRef<"div", DropdownMenuContentProps>(
 
 		return (
 			<Menu
-				portal={popover.portal}
+				portal
 				unmountOnHide
 				{...props}
 				gutter={4}

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -91,6 +91,7 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 					/>
 					<AkTooltip.Tooltip
 						aria-hidden="true"
+						portal
 						{...rest}
 						unmountOnHide={unmountOnHide}
 						className={cx("🥝-tooltip", props.className)}
@@ -101,7 +102,6 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 							...props.style,
 						}}
 						wrapperProps={popover.wrapperProps}
-						portal={popover.portal}
 					>
 						{content}
 					</AkTooltip.Tooltip>


### PR DESCRIPTION
`DropdownMenu` and `Tooltip` will now be portaled into the portal container from #425. This avoids issues with nested markup and selectors.

For example, TreeItem actions are all buttons inside a ["toolbar"](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/). If we don't portal the menu or tooltip that's associated with the button, then:
- The menu ends up inside the toolbar (can affect screen-reader experience, even if the events are handled correctly in JS).
- Hovering/pressing the menu or tooltip results in the `:hover`/`:active` selectors of the parent tree-item being matched (this was noted in https://github.com/iTwin/design-system/pull/430#discussion_r1985608403).

Portaling avoids both of these issues. And the overflow actions still behave correctly, because it now relies on the `[data-has-popover-open]` selector from #431 (instead of `:focus-within`).

---

Portaling can cause its own issues, so we need to be careful with it. `DropdownMenu` and `Tooltip` are relatively safe because these are "temporary" elements (i.e. they auto-dismiss when you stop interacting with them). Still, I'm not exposing the `portal` prop to consumers _yet_.

It's worth noting that Ariakit tries to make portals more accessible for screen-reader users by adding "focus traps" which create an "ARIA portal" (using `aria-owns`).

Ariakit's focus traps, combined with the fact that the portal container lives outside any landmarks, required disabling some Axe rules to make the accessibility test pass.