### PR TITLE
skip flaky tests

### DIFF
--- a/apps/test-app/app/tests/field/index.spec.ts
+++ b/apps/test-app/app/tests/field/index.spec.ts
@@ -15,7 +15,9 @@ const controlsToRole: Record<string, Parameters<Page["getByRole"]>[0]> = {
 };
 
 test.describe("default", () => {
-	test("wrapping input and label", async ({ page }) => {
+	test("wrapping input and label", async ({ page, browserName }) => {
+		test.fixme(browserName === "firefox", "This test is flaky in Firefox");
+
 		await page.goto("/tests/field?control=input");
 		await expect(page.getByRole("textbox")).toHaveAccessibleName(
 			"input example",

--- a/apps/test-app/app/tests/tree/index.spec.ts
+++ b/apps/test-app/app/tests/tree/index.spec.ts
@@ -168,11 +168,8 @@ test.describe("keyboard", () => {
 		await expect(item1).toHaveAttribute("aria-selected", "false");
 	});
 
-	test("actions", async ({ page, browserName }) => {
-		test.fixme(
-			browserName === "firefox",
-			"This fails here but works in Firefox (manual)",
-		);
+	test("actions", async ({ page }) => {
+		test.fixme();
 
 		await page.goto("/tests/tree");
 


### PR DESCRIPTION
This skips two tests that are very flaky in CI:
- `field` → "default" → "wrapping input and label" (see [comment 1](https://github.com/iTwin/design-system/pull/343#discussion_r1949474814) and [comment 2](https://github.com/iTwin/design-system/pull/381#discussion_r1966298852)).
- `tree` → "keyboard" → "actions" (see [comment 1](https://github.com/iTwin/design-system/pull/430#issuecomment-2711422098) and [comment 2](https://github.com/iTwin/design-system/pull/437#discussion_r1987856308)).