### PR TITLE
make `TreeItemExpander` completely unfocusable

### DIFF
--- a/packages/kiwi-react/src/bricks/TreeItem.tsx
+++ b/packages/kiwi-react/src/bricks/TreeItem.tsx
@@ -15,7 +15,7 @@ import { IconButton } from "./IconButton.js";
 import { Icon } from "./Icon.js";
 import { forwardRef, type BaseProps } from "./~utils.js";
 import { useEventHandlers } from "./~hooks.js";
-import { GhostAligner } from "./~utils.GhostAligner.js";
+import { GhostAligner, useGhostAlignment } from "./~utils.GhostAligner.js";
 
 // ----------------------------------------------------------------------------
 
@@ -330,24 +330,28 @@ DEV: TreeItemAction.displayName = "TreeItem.Action";
 
 // ----------------------------------------------------------------------------
 
-interface TreeItemExpanderProps
-	extends Omit<IconButtonProps, "variant" | "label" | "icon"> {}
+interface TreeItemExpanderProps extends Omit<BaseProps<"span">, "children"> {}
 
 const TreeItemExpander = forwardRef<"button", TreeItemExpanderProps>(
 	(props, forwardedRef) => {
 		return (
-			<IconButton
-				tabIndex={-1}
+			<Role.span
 				aria-hidden="true"
-				icon={<TreeChevron />}
-				label="Toggle"
 				{...props}
 				onClick={useEventHandlers(props.onClick, (e) => e.stopPropagation())}
-				className={cx("🥝-tree-item-expander", props.className)}
-				variant="ghost"
-				labelVariant="visually-hidden"
+				className={cx(
+					"🥝-button",
+					"🥝-icon-button",
+					"🥝-ghost-aligner",
+					"🥝-tree-item-expander",
+					props.className,
+				)}
+				data-kiwi-variant="ghost"
+				data-kiwi-ghost-align={useGhostAlignment()}
 				ref={forwardedRef}
-			/>
+			>
+				<TreeChevron />
+			</Role.span>
 		);
 	},
 );


### PR DESCRIPTION
Previously, the `TreeItemExpander` was being rendered as `<button tabindex="-1" aria-hidden="true">`. This prevents the button from being tabbable or otherwise accessible to assistive technology, but it still gets focused when clicking with a mouse. Not a problem in practice, but it led to this error in the browser console: ["Blocked aria-hidden on an element because its descendant retained focus"](https://github.com/iTwin/design-system/pull/442#discussion_r1989087794).

This PR makes the `TreeItemExpander` a `<span>` that is completely unfocusable, thus avoiding the error. It required a small amount of code duplication.