### PR TITLE
exploration: generate inline spritesheet for icons

### DIFF
--- a/packages/kiwi-icons/package.json
+++ b/packages/kiwi-icons/package.json
@@ -5,9 +5,11 @@
 	"license": "MIT",
 	"exports": {
 		"./*.svg": "./icons/*.svg",
-		"./icons-list.json": "./icons-list.json"
+		"./icons-list.json": "./icons-list.json",
+		"./SpriteSheet": "./dist/SpriteSheet.js",
+		"./package.json": "./package.json"
 	},
-	"files": ["icons/*.svg", "icons-list.json", "LICENSE.md"],
+	"files": ["dist", "icons/*.svg", "icons-list.json", "LICENSE.md"],
 	"description": "A standalone SVG icon library for the iTwinUI design system",
 	"author": "Bentley Systems",
 	"homepage": "https://github.com/iTwin/design-system",
@@ -18,6 +20,17 @@
 	},
 	"keywords": ["itwinui", "svg", "icons"],
 	"scripts": {
-		"build": "tsx scripts/icons-list.cts"
+		"build": "npm run build:icons-list && npm run build:spritesheet",
+		"build:icons-list": "tsx scripts/icons-list.cts",
+		"build:spritesheet": "esbuild src/SpriteSheet.tsx --outdir=dist"
+	},
+	"devDependencies": {
+		"esbuild": "catalog:",
+		"react": "catalog:",
+		"react-dom": "catalog:"
+	},
+	"peerDependencies": {
+		"react": ">=18.0.0",
+		"react-dom": ">=18.0.0"
 	}
 }

--- a/packages/kiwi-icons/src/SpriteSheet.tsx
+++ b/packages/kiwi-icons/src/SpriteSheet.tsx
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as fs from "node:fs";
+import { join } from "node:path";
+import type * as esbuild from "esbuild";
+
+const packageName = "@itwin/itwinui-icons";
+// import { name as packageName } from "../package.json" with { type: "json" };
+
+/**
+ * Component that generates an inline sprite sheet of all SVG symbols in the package.
+ * Should be used on the server to inject the sprite sheet into the initial HTML.
+ *
+ * ```jsx
+ * import { renderToString } from "react-dom/server";
+ * const html = renderToString(<SpriteSheet />);
+ * ```
+ */
+export function SpriteSheet() {
+	if (typeof window !== "undefined")
+		throw new Error("SpriteSheet should only be rendered on the server.");
+
+	const symbols = new SpriteSheetGenerator().spriteSheetContents;
+
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" style={{ display: "none" }}>
+			{/* biome-ignore lint/security/noDangerouslySetInnerHtml: This will run on server only. */}
+			<defs dangerouslySetInnerHTML={{ __html: symbols }} />
+		</svg>
+	);
+}
+
+// ----------------------------------------------------------------------------
+
+/**
+ * Esbuild plugin that replaces SVG imports with string variables containing the SVG symbol id.
+ *
+ * Must be used when the `<SpriteSheet>` component is rendered in the initial HTML.
+ */
+export function replaceSvgImports() {
+	return {
+		name: "replace-svg-imports",
+		setup(build) {
+			build.onResolve({ filter: /\.svg$/ }, (args) => {
+				if (args.kind !== "import-statement") return;
+				if (!args.path.startsWith(packageName)) return;
+				return {
+					path: join(args.resolveDir, args.path),
+					namespace: "🥝:replace-svg-import",
+				};
+			});
+			build.onLoad(
+				{ filter: /.*/, namespace: "🥝:replace-svg-import" },
+				(args) => {
+					const filename = args.path.split("/").pop();
+					if (!filename) throw new Error("Filename not found");
+					const contents = `export default "${getHref(filename)}"`;
+					return { contents, loader: "js" };
+				},
+			);
+		},
+	} satisfies esbuild.Plugin;
+}
+
+// ----------------------------------------------------------------------------
+
+/**
+ * Get a unique href for an icon.
+ * This is used to reference the symbol from the SpriteSheet and should be used
+ * with the `<Icon>` component.
+ *
+ * ```jsx
+ * const closeIconHref = getHref("close.svg");
+ *
+ * <Icon href={closeIconHref} />
+ * ```
+ */
+export function getHref(filename: string) {
+	return `#🥝${filename}`;
+}
+
+// ----------------------------------------------------------------------------
+
+const iconsDir = new URL("../icons", import.meta.url);
+
+class SpriteSheetGenerator {
+	#icons: Array<{ name: string; content: string }> = [];
+	#spriteSheetContents = "";
+
+	constructor() {
+		this.#init();
+	}
+
+	#init() {
+		this.#icons = fs.readdirSync(iconsDir).map((filename) => {
+			const { pathname } = new URL(`../icons/${filename}`, import.meta.url);
+			const iconContents = fs.readFileSync(pathname, "utf-8");
+			return { name: filename, content: iconContents };
+		});
+		this.#generateSpriteSheet();
+	}
+
+	#generateSpriteSheet() {
+		const symbols = this.#icons
+			.map((icon) => {
+				return icon.content
+					.match(/<symbol.*?<\/symbol>/gs)
+					?.join("\n")
+					.replaceAll(`id="`, `id="🥝${icon.name}--`); // make ids globally unique
+			})
+			.join("\n");
+		this.#spriteSheetContents = `${symbols}`;
+	}
+
+	get spriteSheetContents() {
+		return this.#spriteSheetContents;
+	}
+}

--- a/packages/kiwi-react/src/bricks/Icon.tsx
+++ b/packages/kiwi-react/src/bricks/Icon.tsx
@@ -59,7 +59,6 @@ interface IconProps extends Omit<BaseProps<"svg">, "children"> {
 export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
 	const { href, size, alt, ...rest } = props;
 
-	const iconId = toIconId(size);
 	const isDecorative = !alt;
 
 	return (
@@ -72,11 +71,17 @@ export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
 			className={cx("🥝-icon", props.className)}
 			ref={forwardedRef}
 		>
-			<use href={`${props.href}#${iconId}`} />
+			{href ? <use href={toIconHref(href, size)} /> : null}
 		</Role.svg>
 	);
 });
 DEV: Icon.displayName = "Icon";
+
+function toIconHref(href: string, size: IconProps["size"]) {
+	const separator = href.includes("#") ? "--" : "#";
+	const suffix = toIconId(size);
+	return `${href}${separator}${suffix}`;
+}
 
 function toIconId(size: IconProps["size"]) {
 	if (size === "large") return "icon-large";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,7 +145,17 @@ importers:
         specifier: "catalog:"
         version: 1.29.2
 
-  packages/kiwi-icons: {}
+  packages/kiwi-icons:
+    devDependencies:
+      esbuild:
+        specifier: "catalog:"
+        version: 0.25.1
+      react:
+        specifier: "catalog:"
+        version: 19.0.0
+      react-dom:
+        specifier: "catalog:"
+        version: 19.0.0(react@19.0.0)
 
   packages/kiwi-react:
     dependencies:


### PR DESCRIPTION
> [!NOTE]
> This was an alternative to #455 for fixing #472.

This adds a new `/SpriteSheet` entrypoint to `@itwin/itwinui-icons` which exposes a `<SpriteSheet>` component and a `replaceSvgImports` esbuild plugin.

The `<SpriteSheet>` component is meant to be rendered on the server to generate an inline spritesheet containing every icon in the package. The `replaceSvgImports` will replace `.svg` imports with fragment urls (`#`) referencing symbol ids from the spritesheet.

The `<Icon>` component has been adjusted to allow for these new urls.

Sandbox: https://stackblitz.com/edit/node-7zm16jf6?file=src%2Fserver.js,build.js