### PR TITLE
Fix `<Button variant="solid" tone="accent">` icon fill on pressed state

### DIFF
--- a/packages/kiwi-react/src/bricks/Button.css
+++ b/packages/kiwi-react/src/bricks/Button.css
@@ -167,8 +167,8 @@
 
 				--🥝button-color: var(--ids-color-text-neutral-emphasis);
 				--🥝icon-color: var(--🌀button-state--default, var(--ids-color-icon-neutral-emphasis))
-					var(--🌀button-state--hover, var(--ids-color-icon-strong-hover))
-					var(--🌀button-state--pressed, var(--ids-color-icon-neutral-hover))
+					var(--🌀button-state--hover, var(--ids-color-icon-neutral-emphasis))
+					var(--🌀button-state--pressed, var(--ids-color-icon-neutral-emphasis))
 					var(--🌀button-state--disabled, var(--ids-color-icon-neutral-disabled));
 
 				@media (forced-colors: active) {


### PR DESCRIPTION
Was only apparent in light theme.

| Before | After |
| --- | --- |
| ![btn-bad](https://github.com/user-attachments/assets/a28d753d-5735-4e74-8c8e-2567d2a383df) | ![btn-good](https://github.com/user-attachments/assets/219ed46f-d642-4ac8-ac26-6107bd0f6ab7) |

Also updated hover value as it appears to have changed in Figma.