### PR TITLE
Fix underline styling of `<Anchor>` button

### DIFF
--- a/apps/test-app/app/tests/anchor/index.tsx
+++ b/apps/test-app/app/tests/anchor/index.tsx
@@ -8,10 +8,11 @@ import { Anchor } from "@itwin/itwinui-react/bricks";
 export const handle = { title: "Anchor" };
 
 export default definePage(
-	function Page({ disabled }) {
+	function Page({ disabled, render: renderParam }) {
+		const render = renderParam ? <button /> : undefined;
 		return (
 			<>
-				<Anchor href="#main" disabled={!!disabled}>
+				<Anchor href="#main" disabled={!!disabled} render={render}>
 					Hello
 				</Anchor>
 

--- a/packages/kiwi-react/src/bricks/Anchor.css
+++ b/packages/kiwi-react/src/bricks/Anchor.css
@@ -36,6 +36,7 @@
 			var(--🌀anchor-state--pressed, 3px);
 		text-decoration-color: var(--🌀anchor-state--default, currentColor)
 			var(--🌀anchor-state--hover, currentColor) var(--🌀anchor-state--pressed, transparent);
+		text-decoration-line: underline;
 
 		border-radius: 4px;
 
@@ -47,7 +48,6 @@
 		&:where(button) {
 			border: none;
 			background: transparent;
-			text-decoration: underline;
 		}
 	}
 

--- a/packages/kiwi-react/src/bricks/Anchor.css
+++ b/packages/kiwi-react/src/bricks/Anchor.css
@@ -47,6 +47,7 @@
 		&:where(button) {
 			border: none;
 			background: transparent;
+			text-decoration: underline;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes underline styling of `<Anchor>` component when it is rendered as a button.
Try it out by visiting: `/tests/anchor?render`