### PR TITLE
exploration: add `zustand` and internal wrapper hooks

### DIFF
--- a/packages/kiwi-react/package.json
+++ b/packages/kiwi-react/package.json
@@ -41,7 +41,8 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.15",
-		"classnames": "^2.5.1"
+		"classnames": "^2.5.1",
+		"zustand": "^5.0.3"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",

--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -14,7 +14,7 @@ import {
 	type BaseProps,
 	type FocusableProps,
 } from "./~utils.js";
-import { usePopoverApi } from "./~hooks.js";
+import { usePopoverApi, useStoreState } from "./~hooks.js";
 import {
 	MenuProvider,
 	useMenuContext,
@@ -25,7 +25,6 @@ import {
 	type MenuItemCheckboxProps,
 	type MenuProviderProps,
 } from "@ariakit/react/menu";
-import { useStoreState } from "@ariakit/react/store";
 import { predefinedSymbols, type PredefinedSymbol } from "./Kbd.internal.js";
 
 // ----------------------------------------------------------------------------

--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -13,8 +13,8 @@ import {
 	type CollectionProps,
 	type CollectionItemProps,
 } from "@ariakit/react/collection";
-import { useStoreState } from "@ariakit/react/store";
 import { forwardRef, type BaseProps } from "./~utils.js";
+import { useStoreState } from "./~hooks.js";
 
 // ----------------------------------------------------------------------------
 
@@ -84,7 +84,10 @@ function FieldCollection(props: Pick<CollectionProps, "render">) {
 	const fieldElementCollection = useCollectionStore<FieldCollectionStoreItem>({
 		defaultItems: [],
 	});
-	const renderedItems = useStoreState(fieldElementCollection, "renderedItems");
+	const renderedItems = useStoreState(
+		fieldElementCollection,
+		(state) => state.renderedItems,
+	);
 
 	// Collect the control type and index
 	const [controlType, controlIndex] = React.useMemo(() => {
@@ -127,7 +130,7 @@ export function FieldControl(props: FieldCollectionItemControlProps) {
 	const store = useCollectionContext();
 	const generatedId = React.useId();
 	const { id = store ? generatedId : undefined, type, ...rest } = props;
-	const renderedItems = useStoreState(store, "renderedItems");
+	const renderedItems = useStoreState(store, (state) => state?.renderedItems);
 	const describedBy = React.useMemo(() => {
 		// Create a space separated list of description IDs
 		const idRefList = renderedItems
@@ -163,7 +166,7 @@ export function FieldControl(props: FieldCollectionItemControlProps) {
  */
 export function FieldLabel(props: Pick<CollectionItemProps, "render">) {
 	const store = useCollectionContext();
-	const renderedItems = useStoreState(store, "renderedItems");
+	const renderedItems = useStoreState(store, (state) => state?.renderedItems);
 	const fieldId = React.useMemo(
 		() =>
 			renderedItems?.find(

--- a/packages/kiwi-react/src/bricks/Tooltip.tsx
+++ b/packages/kiwi-react/src/bricks/Tooltip.tsx
@@ -5,9 +5,8 @@
 import * as React from "react";
 import cx from "classnames";
 import * as AkTooltip from "@ariakit/react/tooltip";
-import { useStoreState } from "@ariakit/react/store";
 import { forwardRef, type FocusableProps } from "./~utils.js";
-import { usePopoverApi } from "./~hooks.js";
+import { usePopoverApi, useStoreState } from "./~hooks.js";
 
 interface TooltipProps
 	extends Omit<FocusableProps<"div">, "content">,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      zustand:
+        specifier: ^5.0.3
+        version: 5.0.3(@types/react@19.0.10)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
     devDependencies:
       "@types/node":
         specifier: "catalog:"
@@ -2397,6 +2400,27 @@ packages:
     engines: { node: ">= 14" }
     hasBin: true
 
+  zustand@5.0.3:
+    resolution:
+      {
+        integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==,
+      }
+    engines: { node: ">=12.20.0" }
+    peerDependencies:
+      "@types/react": ">=18.0.0"
+      immer: ">=9.0.6"
+      react: ">=18.0.0"
+      use-sync-external-store: ">=1.2.0"
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
   "@ampproject/remapping@2.3.0":
     dependencies:
@@ -3627,3 +3651,9 @@ snapshots:
 
   yaml@2.6.1:
     optional: true
+
+  zustand@5.0.3(@types/react@19.0.10)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0)):
+    optionalDependencies:
+      "@types/react": 19.0.10
+      react: 19.0.0
+      use-sync-external-store: 1.4.0(react@19.0.0)


### PR DESCRIPTION
This PR adds [`zustand`](https://zustand.docs.pmnd.rs/getting-started/introduction) as a dependency and introduces two very simple internal hooks:
- `useCreateStore`: This wraps [Zustand's `createStore`](https://zustand.docs.pmnd.rs/apis/create-store) for the purpose of making it local to a component tree.
- `useStoreState`: This provides a unified interface for [Ariakit's `useStoreState`](https://ariakit.org/reference/use-store-state) _and_ [Zustand's `useStore`](https://zustand.docs.pmnd.rs/hooks/use-store).
  - All instances of Ariakit `useStoreState` updated to use this wrapper hook.

---

- [ ] TODO: Fix `useStoreState` types so that return value for `undefined` store is inferred.

---

### Example

```tsx
type CountStore = { count: 0; increment: () => void; decrement: () => void; };
const CountStoreContext = React.createContext<Store<CountStore>>();
```

```tsx
function CounterRoot() {
  const countStore = useCreateStore<CountStore>((set) => ({
    count: 0,
    increment: () => set((state) => ({ count: state.count + 1 })),
    decrement: () => set((state) => ({ count: state.count - 1 })),
  }));
  const increment = useStoreState(countStore, (state) => state.increment);
  const decrement = useStoreState(countStore, (state) => state.decrement);

  return (
    <CountStoreContext.Provider value={countStore}>
      <button onClick={increment}>Increment</button>
      <Count />
      <button onClick={decrement}>Decrement</button>
    </CountStoreContext.Provider>
  );
}
```

```tsx
function Count() {
  const countStore = useSafeContext(CountStoreContext);
  const count = useStoreState(countStore, (state) => state.count);

  return <output>{count}</count>;
}
```