### PR TITLE
`DropdownMenu`: render menuitems as `<button>`

### DIFF
--- a/packages/kiwi-react/src/bricks/DropdownMenu.tsx
+++ b/packages/kiwi-react/src/bricks/DropdownMenu.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import cx from "classnames";
 import * as ListItem from "./~utils.ListItem.js";
 import { Button } from "./Button.js";
+import { Button as ButtonAk } from "@ariakit/react/button";
 import { Kbd } from "./Kbd.js";
 import { Checkmark, DisclosureArrow, Icon } from "./Icon.js";
 import {
@@ -156,7 +157,7 @@ DEV: DropdownMenuButton.displayName = "DropdownMenu.Button";
 // ----------------------------------------------------------------------------
 
 interface DropdownMenuItemProps
-	extends Omit<FocusableProps, "children">,
+	extends Omit<FocusableProps<"button">, "children">,
 		Partial<
 			Pick<DropdownMenuItemShortcutsProps, "shortcuts"> &
 				Pick<DropdownMenuIconProps, "icon">
@@ -174,20 +175,28 @@ interface DropdownMenuItemProps
  * <DropdownMenu.Item label="Edit" />
  * ```
  */
-const DropdownMenuItem = forwardRef<"div", DropdownMenuItemProps>(
+const DropdownMenuItem = forwardRef<"button", DropdownMenuItemProps>(
 	(props, forwardedRef) => {
 		const { label, shortcuts, icon, ...rest } = props;
 
 		return (
 			<MenuItem
 				accessibleWhenDisabled
-				{...rest}
-				render={<ListItem.Root render={props.render} />}
-				className={cx("🥝-dropdown-menu-item", props.className)}
-				ref={forwardedRef}
+				render={
+					<ListItem.Root
+						render={
+							<ButtonAk
+								accessibleWhenDisabled
+								{...rest}
+								className={cx("🥝-dropdown-menu-item", props.className)}
+								ref={forwardedRef}
+							/>
+						}
+					/>
+				}
 			>
 				{icon ? <DropdownMenuIcon icon={icon} /> : null}
-				<ListItem.Content>{label}</ListItem.Content>
+				<ListItem.Content render={<span />}>{label}</ListItem.Content>
 				{shortcuts ? <DropdownMenuItemShortcuts shortcuts={shortcuts} /> : null}
 			</MenuItem>
 		);
@@ -197,7 +206,8 @@ DEV: DropdownMenuItem.displayName = "DropdownMenu.Item";
 
 // ----------------------------------------------------------------------------
 
-interface DropdownMenuItemShortcutsProps extends BaseProps {
+interface DropdownMenuItemShortcutsProps
+	extends Omit<BaseProps<"span">, "children"> {
 	/**
 	 * A string defining the keyboard shortcut(s) associated with the menu item.
 	 *
@@ -216,7 +226,7 @@ interface DropdownMenuItemShortcutsProps extends BaseProps {
 }
 
 const DropdownMenuItemShortcuts = forwardRef<
-	"div",
+	"span",
 	DropdownMenuItemShortcutsProps
 >((props, forwardedRef) => {
 	const { shortcuts, ...rest } = props;
@@ -230,6 +240,7 @@ const DropdownMenuItemShortcuts = forwardRef<
 
 	return (
 		<ListItem.Decoration
+			render={<span />}
 			{...rest}
 			className={cx("🥝-dropdown-menu-item-shortcuts", props.className)}
 			ref={forwardedRef}
@@ -258,7 +269,7 @@ DEV: DropdownMenuItemShortcuts.displayName = "DropdownMenuItemShortcuts";
 
 // ----------------------------------------------------------------------------
 
-interface DropdownMenuIconProps extends BaseProps {
+interface DropdownMenuIconProps extends BaseProps<"svg"> {
 	/**
 	 * An optional icon displayed before the menu-item label.
 	 *
@@ -268,7 +279,7 @@ interface DropdownMenuIconProps extends BaseProps {
 	icon?: string | React.JSX.Element;
 }
 
-const DropdownMenuIcon = forwardRef<"div", DropdownMenuIconProps>(
+const DropdownMenuIcon = forwardRef<"svg", DropdownMenuIconProps>(
 	(props, forwardedRef) => {
 		const { icon, ...rest } = props;
 
@@ -278,10 +289,10 @@ const DropdownMenuIcon = forwardRef<"div", DropdownMenuIconProps>(
 					<Icon
 						href={typeof icon === "string" ? icon : undefined}
 						render={React.isValidElement(icon) ? icon : undefined}
+						{...rest}
+						ref={forwardedRef}
 					/>
 				}
-				{...rest}
-				ref={forwardedRef}
 			/>
 		);
 	},
@@ -291,8 +302,11 @@ DEV: DropdownMenuIcon.displayName = "DropdownMenuIcon";
 // ----------------------------------------------------------------------------
 
 interface DropdownMenuCheckboxItemProps
-	extends Omit<FocusableProps, "onChange" | "children">,
-		Pick<MenuItemCheckboxProps, "checked" | "onChange" | "name" | "value">,
+	extends Omit<FocusableProps<"button">, "onChange" | "children" | "name">,
+		Pick<
+			MenuItemCheckboxProps,
+			"defaultChecked" | "checked" | "onChange" | "name" | "value"
+		>,
 		Pick<DropdownMenuItemProps, "label" | "icon"> {}
 
 /**
@@ -305,22 +319,43 @@ interface DropdownMenuCheckboxItemProps
  * ```
  */
 const DropdownMenuCheckboxItem = forwardRef<
-	"div",
+	"button",
 	DropdownMenuCheckboxItemProps
 >((props, forwardedRef) => {
-	const { label, icon, ...rest } = props;
+	const {
+		label,
+		icon,
+		defaultChecked,
+		checked,
+		onChange,
+		name,
+		value = defaultChecked ? "on" : undefined, // For defaultChecked to work
+		...rest
+	} = props;
 
 	return (
 		<MenuItemCheckbox
 			accessibleWhenDisabled
-			value={props.defaultChecked ? "on" : undefined} // For defaultChecked to work
-			{...rest}
-			render={<ListItem.Root render={props.render} />}
-			className={cx("🥝-dropdown-menu-item", props.className)}
-			ref={forwardedRef}
+			defaultChecked={defaultChecked}
+			checked={checked}
+			name={name}
+			value={value}
+			onChange={onChange}
+			render={
+				<ListItem.Root
+					render={
+						<ButtonAk
+							accessibleWhenDisabled
+							{...rest}
+							className={cx("🥝-dropdown-menu-item", props.className)}
+							ref={forwardedRef}
+						/>
+					}
+				/>
+			}
 		>
 			{icon ? <DropdownMenuIcon icon={icon} /> : null}
-			<ListItem.Content>{label}</ListItem.Content>
+			<ListItem.Content render={<span />}>{label}</ListItem.Content>
 			<ListItem.Decoration
 				render={<Checkmark className="🥝-dropdown-menu-checkmark" />}
 			/>


### PR DESCRIPTION
_Stacked against #489_

This PR changes the underlying element of `DropdownMenu.Item` and `DropdownMenu.CheckboxItem` from `<div>` to `<button>`, and the underlying element of their descendants to `<span>` (to ensure valid markup).

This change is made for two reasons:
- MenuItems are interactive elements, so `<button>` is the more appropriate element.
- In #404, I'm internally rendering `<Tree.ItemAction>` as `<IconButton>` or `<DropdownMenu.Item>`, so having the consistency is nice (otherwise the typescript part becomes tricky).