### PR TITLE
add theme switcher to test pages

### DIFF
--- a/apps/test-app/app/tests/tests.module.css
+++ b/apps/test-app/app/tests/tests.module.css
@@ -6,3 +6,7 @@
 	display: grid;
 	grid-template-columns: 1fr auto;
 }
+
+.pushRight {
+	margin-inline-start: auto;
+}

--- a/apps/test-app/app/tests/tests.tsx
+++ b/apps/test-app/app/tests/tests.tsx
@@ -19,6 +19,7 @@ import {
 } from "react-router";
 import {
 	RightSidebar,
+	ThemeSwitcher,
 	useLocalStorage,
 	VariantsListContext,
 } from "~/~utils.tsx";
@@ -70,6 +71,8 @@ export default function Page() {
 							/>
 
 							<Text variant="body-md">{title}</Text>
+
+							<ThemeSwitcher className={styles.pushRight} />
 						</>
 					}
 				>


### PR DESCRIPTION
This extends the right sidebar from #394 to add a simple icon-button for toggling between light and dark color schemes.

Also:
- Updated `RightSidebar` to render an `<aside>` landmark because it is outside `<main>`.
- ~~Introduced a new `atomic` convention for sharing utility classes in the test-app.~~ [Removed](https://github.com/iTwin/design-system/compare/c723d53bc243303db511dffdc485db2fae731df3..5dce0eb386a35d428948f353c28b167da427a9b4).

---

Preview any of the pages at https://itwin.github.io/design-system/501/

<details>
<summary>Video</summary>

https://github.com/user-attachments/assets/9137779a-4163-44cd-b00e-6fa27395805c

</details>