### PR TITLE
Fixing Select component overflow

### DIFF
--- a/packages/kiwi-react/src/bricks/Select.css
+++ b/packages/kiwi-react/src/bricks/Select.css
@@ -19,10 +19,11 @@
 .🥝-select:is(.🥝-button) {
 	--✨padding-inline-start: 8px;
 	--✨padding-inline-end: calc(4px + 16px + 4px); /* (gap) + (arrow size) + (padding-inline - disclosure arrow offset) */
-	min-inline-size: calc(var(--✨padding-inline-start) + 1ch + var(--✨padding-inline-end));
-	text-overflow: ellipsis;
 
 	@layer base {
+		min-inline-size: calc(var(--✨padding-inline-start) + 1ch + var(--✨padding-inline-end));
+		text-overflow: ellipsis;
+
 		&:where(select:not([multiple])) {
 			appearance: none;
 			--🥝button-padding-inline: var(--✨padding-inline-start) var(--✨padding-inline-end);


### PR DESCRIPTION
Fixing `Select` component overflow

Before:
![image](https://github.com/user-attachments/assets/576349e8-fda4-4f8c-8eec-6a64dd96221c)

After:
![image](https://github.com/user-attachments/assets/665adbb9-fbee-44a6-a29f-cc66b880ba20)

Minimum size set to padding + 1 character

`Select` component with one letter options:
![image](https://github.com/user-attachments/assets/33c3a804-c0aa-460b-8bfa-9d02a9a54cba)

With empty values:
![image](https://github.com/user-attachments/assets/f0e7839c-e116-4737-a8a4-c862af2de3a6)
