### PR TITLE
Use `@layer`s and `:where` instead of `:is` in `<Divider>`

### DIFF
--- a/packages/kiwi-react/src/bricks/Divider.css
+++ b/packages/kiwi-react/src/bricks/Divider.css
@@ -8,24 +8,26 @@
 		align-self: stretch;
 		background-color: var(--ids-color-border-neutral-muted);
 
-		@media (forced-colors: active) {
-			background-color: CanvasText;
-		}
-
-		&:is(hr) {
+		&:where(hr) {
 			border: none;
 			margin: 0;
 		}
 	}
 
 	@layer modifiers {
-		&:not([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
+		&:where(:not([aria-orientation="vertical"], [data-kiwi-orientation="vertical"])) {
 			block-size: 1px;
 		}
 
-		&:is([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
+		&:where([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
 			inline-size: 1px;
 			min-block-size: 100%;
 		}
+	}
+}
+
+@media (forced-colors: active) {
+	.🥝-divider {
+		background-color: CanvasText;
 	}
 }

--- a/packages/kiwi-react/src/bricks/Divider.css
+++ b/packages/kiwi-react/src/bricks/Divider.css
@@ -3,25 +3,29 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .🥝-divider {
-	flex: 0 0 auto;
-	align-self: stretch;
-	background-color: var(--ids-color-border-neutral-muted);
+	@layer base {
+		flex: 0 0 auto;
+		align-self: stretch;
+		background-color: var(--ids-color-border-neutral-muted);
 
-	@media (forced-colors: active) {
-		background-color: CanvasText;
+		@media (forced-colors: active) {
+			background-color: CanvasText;
+		}
+
+		&:is(hr) {
+			border: none;
+			margin: 0;
+		}
 	}
 
-	&:is(hr) {
-		border: none;
-		margin: 0;
-	}
+	@layer modifiers {
+		&:not([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
+			block-size: 1px;
+		}
 
-	&:not([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
-		block-size: 1px;
-	}
-
-	&:is([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
-		inline-size: 1px;
-		min-block-size: 100%;
+		&:is([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
+			inline-size: 1px;
+			min-block-size: 100%;
+		}
 	}
 }


### PR DESCRIPTION
- All components should use `@layer`s, but `<Divider>` was missing these.
- Swap `:is` with `:where`.
- `forced-colors` goes to the bottom of the CSS file.