### PR TITLE
Fix `forced-colors` for `<Button>` as anchor

### DIFF
--- a/packages/kiwi-react/src/bricks/Anchor.css
+++ b/packages/kiwi-react/src/bricks/Anchor.css
@@ -95,3 +95,9 @@
 		--🌀anchor-state--pressed: var(--🌀anchor-state,);
 	}
 }
+
+@media (forced-colors: active) {
+	.🥝-anchor:where(button) {
+		color: LinkText;
+	}
+}

--- a/packages/kiwi-react/src/bricks/Anchor.css
+++ b/packages/kiwi-react/src/bricks/Anchor.css
@@ -44,11 +44,6 @@
 
 		transition: all 150ms ease-out;
 		transition-property: color, text-decoration-color, text-underline-offset;
-
-		&:where(button) {
-			border: none;
-			background: transparent;
-		}
 	}
 
 	@layer modifiers {


### PR DESCRIPTION
- Remove duplicate CSS addressed in #489.
- Fix `color` applied to `<Button>` as anchor. Issue found in #454.

| Before | After |
| --- | --- |
| <img width="332" alt="Screenshot 2025-03-26 at 4 15 45 PM" src="https://github.com/user-attachments/assets/173b91a9-74cc-4cd0-908e-ded1b09ad64c" /> | <img width="332" alt="Screenshot 2025-03-26 at 4 16 16 PM" src="https://github.com/user-attachments/assets/e8e8eba3-f034-41c9-a6de-92d812d07783" /> |