### PR TITLE
CI: add another shard

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I've noticed that CI has become slower after recent changes (I believe it was #465 which had the biggest impact).

This PR splits tests into five shards instead of four, to help speed it up a little.

| Before | After |
| --- | --- |
| 156 tests per shard | 122 tests per shard |
| 5-6 mins total | ~5 mins total |
| <img src="https://github.com/user-attachments/assets/50859aca-b052-4a74-89a5-2dc2d1b98f5c" alt="max 4m30s per shard" width="250"> | <img src="https://github.com/user-attachments/assets/844ed754-0317-4778-a9b4-a62a1ddeef84" alt="max 4 mins per shard" width="250"> |

The current impact of this additional shard is smaller than I expected, but it should still help keep our CI times more manageable as our test suite will only keep growing in size.

Will update the required CI checks before merging.