### PR TITLE
remove implicit `ToolbarItem` from `<IconButton>`

### DIFF
--- a/packages/kiwi-react/src/bricks/IconButton.tsx
+++ b/packages/kiwi-react/src/bricks/IconButton.tsx
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import cx from "classnames";
-import { useToolbarContext, ToolbarItem } from "@ariakit/react/toolbar";
 import { Button } from "./Button.js";
 import { VisuallyHidden } from "./VisuallyHidden.js";
 import { Icon } from "./Icon.js";
@@ -119,15 +118,12 @@ export const IconButton = forwardRef<"button", IconButtonProps>(
 		const labelId = `${baseId}-label`;
 		const dotId = `${baseId}-dot`;
 
-		const toolbar = useToolbarContext();
-
 		const button = (
 			<Button
 				aria-pressed={isActive}
 				aria-labelledby={labelId}
 				aria-describedby={dot ? dotId : undefined}
 				{...rest}
-				render={toolbar ? <ToolbarItem render={props.render} /> : props.render}
 				className={cx("🥝-icon-button", props.className)}
 				ref={forwardedRef}
 			>

--- a/packages/kiwi-react/src/bricks/TreeItem.tsx
+++ b/packages/kiwi-react/src/bricks/TreeItem.tsx
@@ -10,7 +10,7 @@ import {
 	CompositeItem,
 	type CompositeItemProps,
 } from "@ariakit/react/composite";
-import { Toolbar } from "@ariakit/react/toolbar";
+import { Toolbar, ToolbarItem } from "@ariakit/react/toolbar";
 import * as ListItem from "./~utils.ListItem.js";
 import { IconButton } from "./IconButton.js";
 import * as DropdownMenu from "./DropdownMenu.js";
@@ -483,16 +483,20 @@ const TreeItemAction = forwardRef<"button", TreeItemActionProps>(
 		}
 
 		return (
-			<IconButton
-				label={label}
-				icon={icon}
-				inert={visible === false ? true : undefined}
-				{...rest}
-				dot={dot}
-				variant="ghost"
-				className={cx("🥝-tree-item-action", props.className)}
-				data-kiwi-visible={visible}
-				ref={forwardedRef}
+			<ToolbarItem
+				render={
+					<IconButton
+						label={label}
+						icon={icon}
+						inert={visible === false ? true : undefined}
+						{...rest}
+						dot={dot}
+						variant="ghost"
+						className={cx("🥝-tree-item-action", props.className)}
+						data-kiwi-visible={visible}
+						ref={forwardedRef}
+					/>
+				}
 			/>
 		);
 	},


### PR DESCRIPTION
This undoes part of #233. Previously it was necessary for `<IconButton>` to magically become a toolbar item, but once `<Tree.ItemAction>` was added in #355, we have a place where we can explicitly wrap `<IconButton>` with `<ToolbarItem>`.

As a result, `<IconButton>` has become simpler and more flexible.