### PR TITLE
update some jsdocs

### DIFF
--- a/packages/kiwi-react/src/bricks/Field.tsx
+++ b/packages/kiwi-react/src/bricks/Field.tsx
@@ -146,6 +146,12 @@ interface FieldCollectionItemControlProps
 /**
  * The control component for the field.
  *
+ * Use the `render` prop to render the control component.
+ *
+ * ```tsx
+ * <Field.Control render={<TextBox.Input />} />
+ * ```
+ *
  * If the rendered component uses a compositional API, then use a function
  * within `render` to apply the `controlProps` to the correct sub-component:
  *

--- a/packages/kiwi-react/src/bricks/ProgressBar.tsx
+++ b/packages/kiwi-react/src/bricks/ProgressBar.tsx
@@ -6,9 +6,13 @@ import { Role } from "@ariakit/react/role";
 import cx from "classnames";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
-interface ProgressBarProps
-	extends Omit<BaseProps, "aria-labelledby">,
-		Required<Pick<BaseProps, "aria-labelledby">> {
+interface ProgressBarProps extends Omit<BaseProps, "aria-labelledby"> {
+	/**
+	 * Label for the progress bar.
+	 *
+	 * This prop is required because `role="progressbar"` requires an accessible name.
+	 */
+	"aria-labelledby": string;
 	/**
 	 * The size of the progress bar.
 	 * @default "medium"


### PR DESCRIPTION
This expands on some JSDocs to add missing information.
- `ProgressBar` explains that `aria-labelledby` is required.
- `Field.Control` explains basic usage of `render` prop first, before showing the more involved example.