### PR TITLE
fix `ErrorRegion` markup

### DIFF
--- a/packages/kiwi-react/src/bricks/ErrorRegion.tsx
+++ b/packages/kiwi-react/src/bricks/ErrorRegion.tsx
@@ -98,6 +98,7 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 							>
 								<StatusWarning className="🥝-error-region-icon" />
 								<Text
+									render={<span />}
 									id={labelId}
 									className="🥝-error-region-label"
 									variant="body-sm"


### PR DESCRIPTION
This fixes a small issue where a `<div>` is rendered inside the `ErrorRegion` disclosure (`<button>`) element.

`<div>` is invalid inside `<button>` (only [phrasing content](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content) is allowed), so changed to `<span>`.