### PR TITLE
fix `tsconfig`

### DIFF
--- a/packages/kiwi-react/tsconfig.json
+++ b/packages/kiwi-react/tsconfig.json
@@ -4,6 +4,8 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"baseUrl": ".",
+		"module": "ES2022",
+		"moduleResolution": "Bundler",
 		"noEmit": false,
 		"declaration": true,
 		"emitDeclarationOnly": true,


### PR DESCRIPTION
Follow-up to #532. I needed to override `module` and `moduleResolution` for one reason: VSCode will auto import from `.tsx` extensions when using `module: "preserve"`.

`.tsx` imports are fine in an application, but a package should only use `.js` imports because that's what gets delivered to npm.