### PR TITLE
add custom styling for `<VisuallyHidden>`

### DIFF
--- a/packages/kiwi-react/src/bricks/VisuallyHidden.css
+++ b/packages/kiwi-react/src/bricks/VisuallyHidden.css
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+.🥝-visually-hidden {
+	@layer base {
+		&:where(:not(:active, :focus-within)) {
+			clip-path: inset(50%) !important;
+			overflow: hidden !important;
+			position: absolute !important;
+			white-space: nowrap !important;
+			block-size: 1px !important;
+			inline-size: 1px !important;
+			user-select: none !important;
+		}
+	}
+}

--- a/packages/kiwi-react/src/bricks/VisuallyHidden.tsx
+++ b/packages/kiwi-react/src/bricks/VisuallyHidden.tsx
@@ -2,7 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { VisuallyHidden as AkVisuallyHidden } from "@ariakit/react/visually-hidden";
+import cx from "classnames";
+import { Role } from "@ariakit/react/role";
 import { forwardRef, type BaseProps } from "./~utils.js";
 
 interface VisuallyHiddenProps extends BaseProps<"span"> {}
@@ -22,7 +23,13 @@ interface VisuallyHiddenProps extends BaseProps<"span"> {}
  */
 export const VisuallyHidden = forwardRef<"span", VisuallyHiddenProps>(
 	(props, forwardedRef) => {
-		return <AkVisuallyHidden {...props} ref={forwardedRef} />;
+		return (
+			<Role.span
+				{...props}
+				className={cx("🥝-visually-hidden", props.className)}
+				ref={forwardedRef}
+			/>
+		);
 	},
 );
 DEV: VisuallyHidden.displayName = "VisuallyHidden";

--- a/packages/kiwi-react/src/bricks/styles.css
+++ b/packages/kiwi-react/src/bricks/styles.css
@@ -5,6 +5,7 @@
 @import "./sublayers.css" layer(itwinui.components);
 
 @import "./Icon.css" layer(itwinui.components);
+@import "./VisuallyHidden.css" layer(itwinui.components);
 @import "./~utils.Dot.css" layer(itwinui.components);
 @import "./~utils.GhostAligner.css" layer(itwinui.components);
 @import "./~utils.ListItem.css" layer(itwinui.components);


### PR DESCRIPTION
This PR adds our own CSS for the `<VisuallyHidden>` component instead of relying on Ariakit's version. Two reasons:

1. Focused items should not be hidden, so the selector automatically handles focused items, based on https://www.tpgi.com/the-anatomy-of-visually-hidden/ and https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
2. Hidden text should not be selectable, it includes `user-select: none`. (I know @FlyersPh9 will like that one)

`!important` helps enforce this utility class, because it should never be overridden.