### PR TITLE
fix undefined check for `ownerWindow.document.fonts`

### DIFF
--- a/packages/kiwi-react/src/bricks/Root.tsx
+++ b/packages/kiwi-react/src/bricks/Root.tsx
@@ -352,7 +352,7 @@ function loadFonts(rootNode: Document | ShadowRoot) {
 	const ownerWindow = getWindow(rootNode);
 
 	if (
-		!ownerWindow ||
+		!ownerWindow?.document?.fonts ||
 		Array.from(ownerWindow.document.fonts).some(
 			(font) => font.family === "InterVariable",
 		)


### PR DESCRIPTION
Apparently `document.fonts` can be `undefined` in some cases (e.g. `JSDOM` environment).