### PR TITLE
Override iOS Safari UA height style for Switch

### DIFF
--- a/packages/kiwi-react/src/bricks/Switch.css
+++ b/packages/kiwi-react/src/bricks/Switch.css
@@ -44,6 +44,7 @@
 		position: relative;
 		border-radius: 9999px;
 		inline-size: var(--✨width);
+		block-size: auto; /* Necessary to override iOS Safari UA styles */
 
 		background-color: var(--🌀switch-state--default, var(--✨bg--default))
 			var(--🌀switch-state--hover, var(--✨bg--hover))


### PR DESCRIPTION
Resolves #559 

iOS Safari has the following UA styles for checkboxes:

```css
input[type="checkbox"] {
  width: 16px;
  height: 16px;
}
```

We assume the `height`/`block-size` is `auto` for other browsers, so this just makes that explicit (and adds a note about why — since it could be easy to assume we don’t need it).
