### PR TITLE
Fix `<Tabs.Tab>` active stripe on viewport resize

### DIFF
--- a/packages/kiwi-react/src/bricks/Tabs.css
+++ b/packages/kiwi-react/src/bricks/Tabs.css
@@ -20,14 +20,14 @@
 				position: absolute;
 				/* biome-ignore lint/correctness/noUnknownProperty: `position-anchor` is within `@supports` and offers a fallback. */
 				position-anchor: --🥝active-tab;
-				inset-inline: calc(anchor(start) + var(--🥝tab-padding-inline))
-					calc(anchor(end) + var(--🥝tab-padding-inline));
+				inset-inline-start: calc(anchor(start) + var(--🥝tab-padding-inline));
 				inset-block-end: calc(anchor(end) - var(--🥝tab-active-stripe-gap));
+				inline-size: calc(anchor-size(inline) - 2 * var(--🥝tab-padding-inline));
 				block-size: var(--🥝tab-active-stripe-size);
 				background-color: var(--🥝tab-active-stripe-color);
 
 				@media (prefers-reduced-motion: no-preference) {
-					transition: inset-inline 150ms ease-in-out;
+					transition: inset-inline-start 150ms ease-in-out, inline-size 150ms ease-in-out;
 				}
 			}
 		}


### PR DESCRIPTION
Previously, when you would resize the browser window or the dev tools, the active stripe would scale on X axis before snapping back to the correct size.  This was because the container's width is changing & the active stripe's position & width were set using `inset-inline`.

![tabs-before](https://github.com/user-attachments/assets/862a73c2-03b0-42b0-af74-0c24bc550bad)

Rather than relying on `inset-inline` to set the width & positioning, I am now setting the width using `inline-size`.

I then tried using `transform: translateX` to position the stripe but for some reason I couldn't get it to work as expected.
```css
&::after {
	content: "";
	position: absolute;
	position-anchor: --🥝active-tab;
	inset-block-end: calc(anchor(end) - var(--🥝tab-active-stripe-gap));
	inline-size: calc(anchor-size(inline) - 2 * var(--🥝tab-padding-inline));
	left: 0;

	transform: translateX(calc(anchor(start) + var(--🥝tab-padding-inline)));
	will-change: transform;

	@media (prefers-reduced-motion: no-preference) {
		transition: transform 150ms ease-in-out;
	}
}
```

So instead I am positioning the stripe using `inset-inline-start` instead of `inset-inline`.  This requires `transition`ing both `inset-inline-start` & `inline-size`.

![tabs-after](https://github.com/user-attachments/assets/a2974926-5d60-4431-87a4-77d27b0afcb0)

Closes #556.