### PR TITLE
Turn off unknown property lint rule for CSS

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -22,6 +22,7 @@
 	"linter": {
 		"rules": {
 			"correctness": {
+				"noUnknownProperty": "off",
 				"noUnusedImports": "info",
 				"noUnusedLabels": "off"
 			},

--- a/packages/kiwi-react/src/bricks/Tabs.css
+++ b/packages/kiwi-react/src/bricks/Tabs.css
@@ -13,12 +13,10 @@
 		gap: 8px;
 		position: relative;
 
-		/* biome-ignore lint/correctness/noUnknownProperty: `position-anchor` is within `@supports` and offers a fallback. */
 		@supports (position-anchor: --foo) {
 			&::after {
 				content: "";
 				position: absolute;
-				/* biome-ignore lint/correctness/noUnknownProperty: `position-anchor` is within `@supports` and offers a fallback. */
 				position-anchor: --🥝active-tab;
 				inset-inline-start: calc(anchor(start) + var(--🥝tab-padding-inline));
 				inset-block-end: calc(anchor(end) - var(--🥝tab-active-stripe-gap));


### PR DESCRIPTION
Biome can’t keep up with CSS and CSS ignores properties it doesn’t know (like ones that only work in some browsers), so this is just slowing us down.