### PR TITLE
Avoid overriding of `TreeItemRoot` props when spreading

### DIFF
--- a/packages/kiwi-react/src/bricks/TreeItem.tsx
+++ b/packages/kiwi-react/src/bricks/TreeItem.tsx
@@ -17,7 +17,6 @@ import { useEventHandlers } from "./~hooks.js";
 import * as ListItem from "./~utils.ListItem.js";
 import { forwardRef } from "./~utils.js";
 
-import type { CompositeItemProps } from "@ariakit/react/composite";
 import type { BaseProps } from "./~utils.js";
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Addresses a https://github.com/iTwin/design-system/pull/554#discussion_r2042327455 to avoid unintentional prop overrides when spreading the props.

I'm passing the props directly to `Role`, although https://ariakit.org/guide/composition#explicit-render-function could have been used as well.