### PR TITLE
test-app: fix hooks error

### DIFF
--- a/apps/test-app/app/root.tsx
+++ b/apps/test-app/app/root.tsx
@@ -43,9 +43,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 function LayoutInner({ children }: { children: React.ReactNode }) {
+	const preferredColorScheme = useColorScheme();
+
 	// Normally we want the return value of `useColorScheme` which adapts to the system preference,
 	// However, we want to set a static value when testing the `/tests/root/` route.
-	const colorScheme = useIsRootTest() ? "dark light" : useColorScheme();
+	const colorScheme = useIsRootTest() ? "dark light" : preferredColorScheme;
 
 	return (
 		<html lang="en" data-color-scheme={colorScheme}>


### PR DESCRIPTION
This fixes the runtime error that was noticeable when visiting the test-app home page (`/`) and navigating to the `/tests/root` route.

The issue was that `useColorScheme` was being called conditionally. This was fine in the past because it was simply returning the context value (`use` is allowed to be called conditionally), but #501 made the hook stateful which is what broke it. The solution is to always execute the hook.

### Testing

Visit [deploy preview](https://supreme-barnacle-pl8jn8m.pages.github.io/598/) then click on "Root". There should be no "Application Error", unlike in `main` branch.