### PR TITLE
improve `useIsClient` hook

### DIFF
--- a/packages/bricks/src/~hooks.ts
+++ b/packages/bricks/src/~hooks.ts
@@ -204,7 +204,7 @@ export function usePopoverApi(store: PopoverStore | undefined) {
 }
 
 /**
- * Hook that returns false initially, then returns true after the first client render.
+ * Hook that returns true for the first "full" client render.
  * Useful to guard against using client APIs during SSR.
  *
  * Note: This will return `false` during hydration.
@@ -212,11 +212,9 @@ export function usePopoverApi(store: PopoverStore | undefined) {
  * @private
  */
 export function useIsClient() {
-	const [isClient, setIsClient] = React.useState(false);
-
-	React.useEffect(() => {
-		setIsClient(true);
-	}, []);
-
-	return isClient;
+	return React.useSyncExternalStore(
+		React.useCallback(() => () => {}, []),
+		() => true,
+		() => false,
+	);
 }


### PR DESCRIPTION
This is a small improvement to the `useIsClient` hook. It uses [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) which is an SSR-safe way to differentiate server vs client (without causing hydration errors). As a result, we can skip some re-renders when rendering purely on the client.

Return value:
- With SSR: `false` on the server (and during hydration on the client), then `true` for every subsequent render.
- Without SSR: always `true`. 