### PR TITLE
remove `[disabled]` selectors

### DIFF
--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -75,7 +75,7 @@
 			--🥝focus-outline-offset: 2px;
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			--🥝anchor-color: var(--✨color--disabled);
 			cursor: not-allowed;
 			text-decoration: none;

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -218,7 +218,7 @@
 			}
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			--🌀button-state: var(--🌀button-state--disabled);
 			color: var(--ids-color-text-neutral-disabled);
 			cursor: not-allowed;

--- a/packages/bricks/src/Checkbox.css
+++ b/packages/bricks/src/Checkbox.css
@@ -114,7 +114,7 @@
 			--🌀checkbox-aria-state: var(--🌀checkbox-aria-state--indeterminate);
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			--🌀checkbox-visual-state: var(--🌀checkbox-visual-state--disabled);
 			--🥝checkbox-color-svg: var(--ids-color-icon-neutral-disabled);
 			cursor: not-allowed;
@@ -156,7 +156,7 @@
 			}
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			background-color: Canvas;
 			border-color: GrayText;
 

--- a/packages/bricks/src/Label.css
+++ b/packages/bricks/src/Label.css
@@ -14,7 +14,7 @@
 	}
 
 	@layer states {
-		&:has(+ :where(:disabled, [disabled], [aria-disabled="true"])) {
+		&:has(+ :where(:disabled, [aria-disabled="true"])) {
 			color: var(--ids-color-text-neutral-disabled);
 
 			&:is(label) {

--- a/packages/bricks/src/Switch.css
+++ b/packages/bricks/src/Switch.css
@@ -121,7 +121,7 @@
 			--🥝switch-thumb-aspect-ratio: 1.75;
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			--🌀switch-state: var(--🌀switch-state--disabled);
 			--🥝switch-thumb-color: var(--ids-color-icon-neutral-disabled);
 			cursor: not-allowed;
@@ -154,7 +154,7 @@
 			--🥝switch-thumb-color: SelectedItemText;
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			background-color: Canvas;
 			border-color: GrayText;
 			--🥝switch-thumb-color: GrayText;

--- a/packages/bricks/src/Tabs.css
+++ b/packages/bricks/src/Tabs.css
@@ -135,7 +135,7 @@
 			}
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			--🌀tab-state: var(--🌀tab-state--disabled);
 			--🥝tab-active-stripe-color: var(--ids-color-border-neutral-disabled);
 			cursor: not-allowed;
@@ -178,7 +178,7 @@
 			--🥝tab-color: SelectedItemText;
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			--🥝tab-color: GrayText;
 		}
 	}

--- a/packages/bricks/src/TextBox.css
+++ b/packages/bricks/src/TextBox.css
@@ -128,7 +128,6 @@
 		}
 
 		&:where(
-				[disabled],
 				:disabled,
 				[aria-disabled="true"],
 				[data-kiwi-disabled="true"],
@@ -163,7 +162,6 @@
 		color: FieldText;
 
 		&:where(
-				[disabled],
 				:disabled,
 				[aria-disabled="true"],
 				[data-kiwi-disabled="true"],

--- a/packages/bricks/src/~utils.ListItem.css
+++ b/packages/bricks/src/~utils.ListItem.css
@@ -69,7 +69,7 @@
 			--🌀list-item-state: var(--🌀list-item-state--pressed);
 		}
 
-		&:where([disabled], :disabled, [aria-disabled="true"]) {
+		&:where(:disabled, [aria-disabled="true"]) {
 			--🌀list-item-state: var(--🌀list-item-state--disabled);
 			cursor: not-allowed;
 		}
@@ -120,7 +120,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-list-item:where([disabled], :disabled, [aria-disabled="true"]) {
+	.🥝-list-item:where(:disabled, [aria-disabled="true"]) {
 		color: GrayText;
 	}
 }


### PR DESCRIPTION
Removes `[disabled]` from all places.

I believe it was originally added because the `disabled` attribute might be used on an element that doesn't support it and would therefore not match `:disabled`; however, this scenario should never happen, and it should be considered a mistake. We should instead use an aria attribute or a data attribute for elements that don't support the `disabled` attribute.