### PR TITLE
setup `examples` workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,10 @@ Apps:
 
 - [`test-app`](./apps/test-app): A [React Router](https://reactrouter.com/) app for automated and manual testing.
 
+Examples:
+
+- [`examples`](./examples): A private package for storing examples of StrataKit in action.
+
 Also, there’s [an internal package](./internal) which is used for configuration files and common variables for the workspace at large.
 
 ### Development environment

--- a/examples/bricks/Button.jsx
+++ b/examples/bricks/Button.jsx
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Button } from "@stratakit/bricks";
+
+export const Basic = () => {
+	return <Button>Click me</Button>;
+};

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "examples",
+	"private": true,
+	"type": "module",
+	"version": "0.0.1",
+	"exports": {
+		"./*": "./*"
+	},
+	"dependencies": {
+		"@stratakit/icons": "workspace:*",
+		"@stratakit/bricks": "workspace:*"
+	}
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "internal/tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,15 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@6.3.3(@types/node@22.14.1)(lightningcss@1.29.3)(tsx@4.19.3)(yaml@2.6.1))
 
+  examples:
+    dependencies:
+      "@stratakit/bricks":
+        specifier: workspace:*
+        version: link:../packages/bricks
+      "@stratakit/icons":
+        specifier: workspace:*
+        version: link:../packages/icons
+
   internal:
     dependencies:
       colorjs.io:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/*
   - apps/*
   - internal
+  - examples
 
 catalog:
   react: ^19.1.0


### PR DESCRIPTION
Introduces a new `examples` workspace in the monorepo. This is a place where we can create and store polished, consumer-facing examples of every component.

The convention I've chosen is:
- one named export per example.
- one file per component containing all examples for that component.
- separate subdirectories for different packages.

```
examples/
  bricks/
    Button.jsx
  structures/
    …
```