### PR TITLE
Fix error region layout

### DIFF
--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -95,7 +95,6 @@
 	@layer base {
 		text-decoration: none;
 		line-height: 1.2;
-		white-space: nowrap;
 		user-select: none;
 		cursor: pointer;
 		font-size: var(--ids-font-size-12);

--- a/packages/bricks/src/ErrorRegion.css
+++ b/packages/bricks/src/ErrorRegion.css
@@ -62,6 +62,7 @@
 	--✨border-radius: calc(var(--✨container-border-radius) - var(--✨container-border-width));
 
 	@layer base {
+		white-space: normal;
 		min-block-size: 2rem;
 		padding-inline-start: 8px;
 		padding-inline-end: 4px;

--- a/packages/bricks/src/ErrorRegion.css
+++ b/packages/bricks/src/ErrorRegion.css
@@ -85,6 +85,8 @@
 	@layer base {
 		flex: 1;
 		text-align: start;
+		max-inline-size: 100%;
+		overflow-wrap: break-word;
 	}
 }
 

--- a/packages/bricks/src/ErrorRegion.css
+++ b/packages/bricks/src/ErrorRegion.css
@@ -63,7 +63,6 @@
 
 	@layer base {
 		flex-wrap: wrap;
-		white-space: normal;
 		min-block-size: 2rem;
 		padding-inline-start: 8px;
 		padding-inline-end: 4px;

--- a/packages/bricks/src/ErrorRegion.css
+++ b/packages/bricks/src/ErrorRegion.css
@@ -62,6 +62,7 @@
 	--✨border-radius: calc(var(--✨container-border-radius) - var(--✨container-border-width));
 
 	@layer base {
+		flex-wrap: wrap;
 		white-space: normal;
 		min-block-size: 2rem;
 		padding-inline-start: 8px;


### PR DESCRIPTION
This PR closes #560 by using suggestions from https://github.com/iTwin/design-system/issues/560#issuecomment-2828602984 and applying additional improvements

- `Button` component text will now wrap by default (used in error region expander)
- Error region expander will wrap flex items (icon, label and expander) to avoid rendering of icon/expander outside of the error region container
- Error region label now uses `break-word` to avoid text bleeding outside of the container when long words are used in a label

Consumers of the `ErrorRegion` are still expected to ensure that enough space is dedicated to the component.