### PR TITLE
fix changesets workflow

### DIFF
--- a/.github/workflows/changeset-release.yaml
+++ b/.github/workflows/changeset-release.yaml
@@ -5,17 +5,12 @@ on:
     branches:
       - main
 
-env:
-  NPM_CONFIG_PROVENANCE: true
-
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
     name: Release
     if: github.repository == 'iTwin/design-system'
-    permissions:
-      id-token: write
     runs-on: ubuntu-latest
 
     steps:
@@ -39,12 +34,12 @@ jobs:
       - name: Create release PR or publish to npm
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
-          version: pnpm changeset version && pnpm format --write
-          publish: pnpm run build && pnpm changeset publish
+          version: pnpm run changeset:version
+          publish: pnpm run changeset:publish
           title: Release packages
           commit: Release packages
         env:
-          # GITHUB_TOKEN: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
 		"lint:copyright": "tsx internal/copyright-linter.ts",
 		"prettier": "prettier . '!**/*.{js,jsx,ts,tsx,cjs,cts,mjs,mts,css,json,jsonc}' --check",
 		"test": "pnpm --filter=@stratakit/test-app test --",
-		"changeset": "pnpx @changesets/cli@2.29.2"
+		"changeset": "pnpx @changesets/cli@2.29.2",
+		"changeset:version": "pnpm run changeset version && pnpm format --write",
+		"changeset:publish": "pnpm run build && pnpm run changeset publish"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",


### PR DESCRIPTION
Follow-up to #653. This fixes some issues:
- Removed npm provenance and `permissions: id-token: write`, because it was leading to an [error](https://github.com/iTwin/design-system/actions/runs/14783263168/job/41506627376) during the checkout step. Enabling provenance might require the repo to be public.
- Explicitly passed the default `GITHUB_TOKEN` to `changesets/action` (it is required).
  - In the future, we'll want to use `IMJS_ADMIN_GH_TOKEN`. Related: https://github.com/iTwin/design-system/pull/653#discussion_r2070786709
- Moved `version` and `publish` scripts to `package.json` because `changesets/action` does not seem to allow chaining multiple commands inline.

Tested it by running the workflow against this branch first (which generated #655). After merging this PR, #656 was generated.