### PR TITLE
create `Text` compat component

### DIFF
--- a/apps/test-app/app/compat/text.tsx
+++ b/apps/test-app/app/compat/text.tsx
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Text } from "@stratakit/react";
+import { definePage } from "~/~utils.tsx";
+
+export const handle = { title: "Text" };
+
+export default definePage(function Page() {
+	return (
+		<div style={{ display: "grid", gap: 4 }}>
+			<Text variant="headline">This is a headline</Text>
+			<Text variant="title">This is a title</Text>
+			<Text variant="subheading">This is a subheading</Text>
+			<Text variant="leading">This is a leading</Text>
+			<Text>This is a body</Text>
+			<Text variant="small">This is a small text</Text>
+		</div>
+	);
+});

--- a/apps/test-app/app/components.ts
+++ b/apps/test-app/app/components.ts
@@ -34,4 +34,4 @@ export const components = [
 	"Tree",
 ];
 
-export const compatComponents = ["Anchor"];
+export const compatComponents = ["Anchor", "Text"];

--- a/packages/compat/src/Text.tsx
+++ b/packages/compat/src/Text.tsx
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Text as SkText } from "@stratakit/bricks";
+import * as React from "react";
+import { useCompatProps } from "./~utils.tsx";
+
+import type { Text as IuiText } from "@itwin/itwinui-react";
+import type { PolymorphicForwardRefComponent } from "./~utils.tsx";
+
+type IuiTextProps = React.ComponentProps<typeof IuiText>;
+
+interface TextProps
+	extends Pick<IuiTextProps, "variant" | "isMuted" | "isSkeleton"> {
+	/** NOT IMPLEMENTED. */
+	isMuted?: IuiTextProps["isMuted"];
+	/** NOT IMPLEMENTED. */
+	isSkeleton?: IuiTextProps["isSkeleton"];
+}
+
+export const Text = React.forwardRef((props, forwardedRef) => {
+	const {
+		variant: variantProp,
+		isMuted, // NOT IMPLEMENTED
+		isSkeleton, // NOT IMPLEMENTED
+		...rest
+	} = useCompatProps(props);
+
+	const variant = React.useMemo(() => {
+		switch (variantProp) {
+			case "headline":
+				return "display-md";
+			case "title":
+				return "headline-lg";
+			case "subheading":
+				return "headline-md";
+			case "leading":
+				return "headline-sm";
+			case "body":
+				return "body-sm";
+			case "small":
+				return "caption-lg";
+			default:
+				return "body-md";
+		}
+	}, [variantProp]);
+
+	return <SkText {...rest} variant={variant} ref={forwardedRef} />;
+}) as PolymorphicForwardRefComponent<"div", TextProps>;
+DEV: Text.displayName = "Text";

--- a/packages/compat/src/Text.tsx
+++ b/packages/compat/src/Text.tsx
@@ -10,6 +10,7 @@ import { useCompatProps } from "./~utils.tsx";
 import type { Text as IuiText } from "@itwin/itwinui-react";
 import type { PolymorphicForwardRefComponent } from "./~utils.tsx";
 
+type SkTextProps = React.ComponentProps<typeof SkText>;
 type IuiTextProps = React.ComponentProps<typeof IuiText>;
 
 interface TextProps
@@ -28,7 +29,7 @@ export const Text = React.forwardRef((props, forwardedRef) => {
 		...rest
 	} = useCompatProps(props);
 
-	const variant = React.useMemo(() => {
+	const variant: SkTextProps["variant"] = React.useMemo(() => {
 		switch (variantProp) {
 			case "headline":
 				return "display-md";

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -5,3 +5,4 @@
 "use client";
 
 export { Anchor } from "./Anchor.js";
+export { Text } from "./Text.js";


### PR DESCRIPTION
Adds a `<Text>` to `@stratakit/react` (equivalent to [iTwinUI `<Text>`](https://itwinui.bentley.com/docs/text)). Resolves #588.

✅ Implemented `variant` prop.
❌ Not implemented `isMuted` and `isSkeleton` props.

### Screenshot comparison

| iTwinUI v3 | StrataKit compat |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/8a9e127c-061f-45c8-a717-24ae0ed454dc) | ![image](https://github.com/user-attachments/assets/517b46b7-3b9d-4008-a0e8-c3bdc7513693) |