### PR TITLE
optimize dependabot workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,8 +7,14 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
+    groups:
+      npm-dependencies:
+        applies-to: version-updates
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-dependencies:
+        applies-to: version-updates

--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -48,10 +48,12 @@ jobs:
   fix-formatting:
     name: Fix formatting
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: contains(github.ref_name, 'dependabot/')
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
This is a followup to #664 to tackle https://github.com/iTwin/design-system/pull/664#issuecomment-2854690496.

- `dependabot.yaml`: Now using [`groups`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates) syntax to group multiple updates into a single PR.
- `PR.yaml`: Updated the `fix-formatting` job to:
  - explicitly checkout the branch (`with.ref`).
  - use a more reliable `if` condition that should work for initial PR and also for subsequent pushes.