### PR TITLE
create `Tooltip` compat component

### DIFF
--- a/apps/test-app/app/compat/tooltip.tsx
+++ b/apps/test-app/app/compat/tooltip.tsx
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Button } from "@stratakit/bricks";
+import { Tooltip } from "@stratakit/react";
+import { definePage } from "~/~utils.tsx";
+
+export const handle = { title: "Tooltip" };
+
+export default definePage(function Page() {
+	return (
+		<Tooltip content="Here's your tooltip. Was it worth it?">
+			<Button>Please, hover/focus me!</Button>
+		</Tooltip>
+	);
+});

--- a/apps/test-app/app/components.ts
+++ b/apps/test-app/app/components.ts
@@ -40,5 +40,6 @@ export const components = {
 		"Divider",
 		"Kbd",
 		"Text",
+		"Tooltip",
 	],
 };

--- a/packages/compat/src/Tooltip.tsx
+++ b/packages/compat/src/Tooltip.tsx
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Tooltip as SkTooltip } from "@stratakit/bricks";
+import * as React from "react";
+import { useCompatProps } from "./~utils.tsx";
+
+import type { Tooltip as IuiTooltip } from "@itwin/itwinui-react";
+import type { PolymorphicForwardRefComponent } from "./~utils.tsx";
+
+type SkTooltipProps = React.ComponentProps<typeof SkTooltip>;
+type IuiTooltipProps = React.ComponentProps<typeof IuiTooltip>;
+
+interface TooltipProps
+	extends Pick<
+		IuiTooltipProps,
+		| "content"
+		| "children"
+		| "placement"
+		| "visible"
+		| "onVisibleChange"
+		| "autoUpdateOptions"
+		| "middleware"
+		| "reference"
+		| "ariaStrategy"
+	> {
+	/** The element that will trigger the tooltip when hovered or focused. */
+	children: SkTooltipProps["children"];
+	/** NOT IMPLEMENTED. */
+	autoUpdateOptions?: IuiTooltipProps["autoUpdateOptions"];
+	/** NOT IMPLEMENTED. */
+	middleware?: IuiTooltipProps["middleware"];
+	/** NOT IMPLEMENTED. */
+	reference?: IuiTooltipProps["reference"];
+}
+
+/** @see https://itwinui.bentley.com/docs/tooltip */
+export const Tooltip = React.forwardRef((props, forwardedRef) => {
+	const {
+		content,
+		children,
+		visible,
+		onVisibleChange,
+		ariaStrategy = "description",
+		placement,
+		autoUpdateOptions, // NOT IMPLEMENTED
+		middleware, // NOT IMPLEMENTED
+		reference, // NOT IMPLEMENTED
+		...rest
+	} = useCompatProps(props);
+
+	return (
+		<SkTooltip
+			{...rest}
+			placement={placement}
+			content={content}
+			open={visible}
+			setOpen={onVisibleChange}
+			type={ariaStrategy}
+			ref={forwardedRef}
+		>
+			{children}
+		</SkTooltip>
+	);
+}) as PolymorphicForwardRefComponent<"div", TooltipProps>;
+DEV: Tooltip.displayName = "Tooltip";

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -8,3 +8,4 @@ export { Anchor } from "./Anchor.js";
 export { Divider } from "./Divider.js";
 export { Kbd, KbdKeys } from "./Kbd.js";
 export { Text } from "./Text.js";
+export { Tooltip } from "./Tooltip.js";


### PR DESCRIPTION
Adds a `<Tooltip>` to `@stratakit/react`. Equivalent to [iTwinUI `<Tooltip>`](https://itwinui.bentley.com/docs/tooltip). Resolves #590.

✅ Implemented props: `content`, `children`, `visible`, `onVisibleChange`, `ariaStrategy`, `placement`.
❌ Not implemented props: `autoUpdateOptions`, `middleware`, `reference`.

### Screenshot 

![Screenshot of a tooltip showing below a button. The button text reads "Please hover/focus me" and the tooltip text reads "Here's your tooltip. Was it worth it?"](https://github.com/user-attachments/assets/da3187dc-409f-4544-b6d4-a75388cd9af7)
