### PR TITLE
add `placement` prop to `Tooltip`

### DIFF
--- a/.changeset/many-pianos-lick.md
+++ b/.changeset/many-pianos-lick.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Added `placement` prop to `Tooltip`.

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -15,7 +15,10 @@ import type { FocusableProps } from "@stratakit/foundations/secret-internals";
 interface TooltipProps
 	extends Omit<FocusableProps<"div">, "content">,
 		Pick<AkTooltip.TooltipProps, "open" | "unmountOnHide">,
-		Pick<AkTooltip.TooltipProviderProps, "defaultOpen" | "setOpen"> {
+		Pick<
+			AkTooltip.TooltipProviderProps,
+			"defaultOpen" | "setOpen" | "placement"
+		> {
 	/**
 	 * The content to be displayed inside the tooltip when the trigger element is hovered or focused.
 	 */
@@ -41,6 +44,14 @@ interface TooltipProps
 	 * @default "description"
 	 */
 	type?: "description" | "label" | "none";
+
+	/**
+	 * The placement of the tooltip.
+	 *
+	 * When not enough space is available to satisfy the specified placement, the tooltip will
+	 * automatically flip to the opposite side.
+	 */
+	placement?: AkTooltip.TooltipProviderProps["placement"];
 }
 
 /**
@@ -71,6 +82,7 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 			open: openProp,
 			setOpen: setOpenProp,
 			unmountOnHide = type === "none",
+			placement,
 			...rest
 		} = props;
 
@@ -85,6 +97,7 @@ export const Tooltip = forwardRef<"div", TooltipProps>(
 					defaultOpen={defaultOpenProp}
 					open={openProp}
 					setOpen={setOpenProp}
+					placement={placement}
 				>
 					<AkTooltip.TooltipAnchor
 						render={children}


### PR DESCRIPTION
This is exposed as-is from [Ariakit](https://ariakit.org/reference/tooltip-provider#placement).

While I don't foresee many use cases where the consumer needs to set this prop, this is mainly required for #672.

I also expect we'll need to set it internally in at least two places (both of which need `placement="right"`):
- vertical toolbar
- platformBar

