### PR TITLE
[experiment] implement `isSkeleton` prop in `Text` compat

### DIFF
--- a/apps/test-app/app/compat/text.tsx
+++ b/apps/test-app/app/compat/text.tsx
@@ -17,6 +17,8 @@ export default definePage(function Page() {
 			<Text variant="leading">This is a leading</Text>
 			<Text>This is a body</Text>
 			<Text variant="small">This is a small text</Text>
+
+			<Text isSkeleton>This is some skeleton text</Text>
 		</div>
 	);
 });

--- a/packages/compat/src/Text.tsx
+++ b/packages/compat/src/Text.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { Text as SkText } from "@stratakit/bricks";
+import { Skeleton as SkSkeleton, Text as SkText } from "@stratakit/bricks";
 import * as React from "react";
 import { useCompatProps } from "./~utils.tsx";
 
@@ -17,15 +17,13 @@ interface TextProps
 	extends Pick<IuiTextProps, "variant" | "isMuted" | "isSkeleton"> {
 	/** NOT IMPLEMENTED. */
 	isMuted?: IuiTextProps["isMuted"];
-	/** NOT IMPLEMENTED. */
-	isSkeleton?: IuiTextProps["isSkeleton"];
 }
 
 export const Text = React.forwardRef((props, forwardedRef) => {
 	const {
 		variant: variantProp,
 		isMuted, // NOT IMPLEMENTED
-		isSkeleton, // NOT IMPLEMENTED
+		isSkeleton,
 		...rest
 	} = useCompatProps(props);
 
@@ -48,6 +46,47 @@ export const Text = React.forwardRef((props, forwardedRef) => {
 		}
 	}, [variantProp]);
 
+	if (isSkeleton) {
+		return <SkeletonText {...rest} variant={variantProp} ref={forwardedRef} />;
+	}
+
 	return <SkText {...rest} variant={variant} ref={forwardedRef} />;
 }) as PolymorphicForwardRefComponent<"div", TextProps>;
 DEV: Text.displayName = "Text";
+
+// ----------------------------------------------------------------------------
+
+const SkeletonText = React.forwardRef((props, forwardedRef) => {
+	const { variant, ...rest } = props;
+
+	const size = React.useMemo(() => {
+		switch (variant) {
+			case "headline":
+				return "xlarge";
+			case "title":
+				return "large";
+			case "subheading":
+				return "medium";
+			case "leading":
+				return "medium";
+			case "body":
+				return "medium";
+			case "small":
+				return "small";
+			default:
+				return "medium";
+		}
+	}, [variant]);
+
+	return (
+		<SkSkeleton
+			aria-hidden="true"
+			inert
+			{...rest}
+			size={size}
+			style={{ width: "fit-content", color: "transparent", ...props.style }}
+			ref={forwardedRef}
+		/>
+	);
+}) as PolymorphicForwardRefComponent<"div", Pick<IuiTextProps, "variant">>;
+DEV: SkeletonText.displayName = "SkeletonText";


### PR DESCRIPTION
Follow-up to #660.

This is an experiment to see what it would take to implement the `isSkeleton` prop.
- renders `<Skeleton>` component
- approximately maps the `variant` to `size`
- adds `color: transparent`, `aria-hidden="true"` and `inert` to hide the text.
- adds `width: fit-content` to constrain the skeleton to the width of the text.

Screenshot:

![It's just a grey rectangle](https://github.com/user-attachments/assets/a15a5c13-bba8-45b9-a7f7-4c0756ba563c)
