### PR TITLE
Add `Label` compatibility component

### DIFF
--- a/apps/test-app/app/compat/label.tsx
+++ b/apps/test-app/app/compat/label.tsx
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Label } from "@stratakit/react";
+import { definePage } from "~/~utils.tsx";
+
+export const handle = { title: "Label" };
+
+export default definePage(function Page() {
+	return (
+		<div style={{ display: "grid", gap: 4 }}>
+			<Label>Label</Label>
+			<Label htmlFor="control">Label (associated with a control)</Label>
+			<input id="control" />
+		</div>
+	);
+});

--- a/apps/test-app/app/components.ts
+++ b/apps/test-app/app/components.ts
@@ -35,10 +35,11 @@ export const components = {
 		"Tree",
 	],
 	compat: [
+		// force newline to improve mergability (remove when unnecessary)
 		"Anchor",
-
 		"Divider",
 		"Kbd",
+		"Label",
 		"Text",
 		"Tooltip",
 	],

--- a/packages/compat/src/Label.tsx
+++ b/packages/compat/src/Label.tsx
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Label as SkLabel } from "@stratakit/bricks";
+import * as React from "react";
+import { useCompatProps } from "./~utils.tsx";
+
+import type { Label as IuiLabel } from "@itwin/itwinui-react";
+import type { PolymorphicForwardRefComponent } from "./~utils.tsx";
+
+type IuiLabelProps = React.ComponentProps<typeof IuiLabel>;
+
+interface LabelProps
+	extends Pick<IuiLabelProps, "displayStyle" | "disabled" | "required"> {
+	/** NOT IMPLEMENTED. */
+	displayStyle?: IuiLabelProps["displayStyle"];
+	/** NOT IMPLEMENTED. */
+	disabled?: IuiLabelProps["disabled"];
+	/** NOT IMPLEMENTED. */
+	required?: IuiLabelProps["required"];
+}
+
+/** @see https://itwinui.bentley.com/docs/label */
+export const Label = React.forwardRef((props, forwardedRef) => {
+	const {
+		displayStyle, // NOT IMPLEMENTED
+		disabled, // NOT IMPLEMENTED
+		required, // NOT IMPLEMENTED
+		...rest
+	} = useCompatProps(props);
+	return <SkLabel {...rest} ref={forwardedRef} />;
+}) as PolymorphicForwardRefComponent<"label", LabelProps>;
+DEV: Label.displayName = "Label";

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -7,5 +7,6 @@
 export { Anchor } from "./Anchor.js";
 export { Divider } from "./Divider.js";
 export { Kbd, KbdKeys } from "./Kbd.js";
+export { Label } from "./Label.js";
 export { Text } from "./Text.js";
 export { Tooltip } from "./Tooltip.js";


### PR DESCRIPTION
Adds a `Label` compatibility component with the following props:

- `required` not implemented because we don’t any implemented styles for this in StrataKit.
- `disabled` not implemented because we don’t any implemented styles for this in StrataKit.
- `displayStyle` not implemented because this is a concern of StrataKit’s `Field` component.
