### PR TITLE
update `test-app` with `AccordionItem` component from library

### DIFF
--- a/apps/test-app/app/tokens.css
+++ b/apps/test-app/app/tokens.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-:root {
+html {
 	scrollbar-gutter: stable;
 }
 
@@ -13,8 +13,4 @@ body {
 
 h2 {
 	margin-block-start: 1rem;
-}
-
-.🥝-accordion-item-content {
-	grid-column-start: marker-before-start;
 }

--- a/apps/test-app/app/tokens.module.css
+++ b/apps/test-app/app/tokens.module.css
@@ -42,3 +42,7 @@
 		box-shadow: var(--_swatch-shadow, var(--stratakit-shadow-surface-xs));
 	}
 }
+
+.accordionItemContent {
+	grid-column: 1 / -1;
+}

--- a/apps/test-app/app/tokens.tsx
+++ b/apps/test-app/app/tokens.tsx
@@ -86,7 +86,7 @@ export default function Page() {
 							</AccordionItem.Button>
 						</AccordionItem.Header>
 
-						<AccordionItem.Content>
+						<AccordionItem.Content className={styles.accordionItemContent}>
 							<Tokens tokens={relevantTokens} kind="color" />
 						</AccordionItem.Content>
 					</AccordionItem.Root>
@@ -105,7 +105,7 @@ export default function Page() {
 					</AccordionItem.Button>
 				</AccordionItem.Header>
 
-				<AccordionItem.Content>
+				<AccordionItem.Content className={styles.accordionItemContent}>
 					<Tokens tokens={[...shadowTokens.keys()]} kind="shadow" />
 				</AccordionItem.Content>
 			</AccordionItem.Root>
@@ -122,7 +122,7 @@ export default function Page() {
 					</AccordionItem.Button>
 				</AccordionItem.Header>
 
-				<AccordionItem.Content>
+				<AccordionItem.Content className={styles.accordionItemContent}>
 					<TypographyVariants variants={typographyVariants} />
 				</AccordionItem.Content>
 			</AccordionItem.Root>


### PR DESCRIPTION
Currently, the `test-app` uses `Disclosure` from `@ariakit/react/disclosure` with custom CSS. This PR aims to replace these with the `AccordionItem` component from `@stratakit/structures`.