### PR TITLE
create `MenuItem` compat component

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -34,7 +34,8 @@
 	"scripts": {},
 	"dependencies": {
 		"@itwin/itwinui-react": "^3.18.2",
-		"@stratakit/bricks": "^0.2.0"
+		"@stratakit/bricks": "^0.2.0",
+		"@stratakit/structures": "^0.1.1"
 	},
 	"devDependencies": {
 		"@stratakit/foundations": "workspace:*",

--- a/packages/compat/src/MenuItem.tsx
+++ b/packages/compat/src/MenuItem.tsx
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Icon as SkIcon } from "@stratakit/foundations";
+import { DropdownMenu as SkDropdownMenu } from "@stratakit/structures";
+import * as React from "react";
+import { useCompatProps } from "./~utils.tsx";
+
+import type { MenuItem as IuiMenuItem } from "@itwin/itwinui-react";
+import type { PolymorphicForwardRefComponent } from "./~utils.tsx";
+
+// ----------------------------------------------------------------------------
+
+type IuiMenuItemProps = React.ComponentProps<typeof IuiMenuItem>;
+
+interface MenuItemProps
+	extends Pick<
+		IuiMenuItemProps,
+		| "isSelected"
+		| "disabled"
+		| "value"
+		| "size"
+		| "sublabel"
+		| "startIcon"
+		| "icon"
+		| "endIcon"
+		| "badge"
+		| "subMenuItems"
+		| "focused"
+	> {
+	/** NOT IMPLEMENTED. */
+	endIcon?: IuiMenuItemProps["endIcon"];
+	/** NOT IMPLEMENTED. */
+	value?: IuiMenuItemProps["value"];
+	/** NOT IMPLEMENTED. */
+	sublabel?: IuiMenuItemProps["sublabel"];
+	/** NOT IMPLEMENTED. */
+	isSelected?: IuiMenuItemProps["isSelected"];
+	/** NOT IMPLEMENTED. */
+	focused?: IuiMenuItemProps["focused"];
+	/** NOT IMPLEMENTED. */
+	subMenuItems?: IuiMenuItemProps["subMenuItems"];
+	/** NOT IMPLEMENTED. */
+	size?: IuiMenuItemProps["size"];
+	/** @deprecated NOT IMPLEMENTED. */
+	badge?: IuiMenuItemProps["badge"];
+}
+
+// ----------------------------------------------------------------------------
+
+/** @see https://itwinui.bentley.com/docs/dropdownmenu */
+export const MenuItem = React.forwardRef((props, forwardedRef) => {
+	const {
+		children,
+		icon,
+		startIcon = icon,
+		disabled,
+		endIcon, // NOT IMPLEMENTED
+		value, // NOT IMPLEMENTED
+		sublabel, // NOT IMPLEMENTED
+		isSelected, // NOT IMPLEMENTED
+		focused, // NOT IMPLEMENTED
+		subMenuItems, // NOT IMPLEMENTED
+		size, // NOT IMPLEMENTED
+		badge, // NOT IMPLEMENTED
+		...rest
+	} = useCompatProps(props);
+
+	return (
+		<SkDropdownMenu.Item
+			{...rest}
+			label={children}
+			icon={startIcon ? <SkIcon render={startIcon} /> : undefined}
+			disabled={disabled}
+			ref={forwardedRef}
+		/>
+	);
+}) as PolymorphicForwardRefComponent<"button", MenuItemProps>;
+DEV: MenuItem.displayName = "MenuItem";

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -8,6 +8,7 @@ export { Anchor } from "./Anchor.js";
 export { Divider } from "./Divider.js";
 export { Kbd, KbdKeys } from "./Kbd.js";
 export { Label } from "./Label.js";
+export { MenuItem } from "./MenuItem.js";
 export { ProgressLinear } from "./ProgressLinear.js";
 export { Text } from "./Text.js";
 export { Tooltip } from "./Tooltip.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       "@stratakit/bricks":
         specifier: ^0.2.0
         version: link:../bricks
+      "@stratakit/structures":
+        specifier: ^0.1.1
+        version: link:../structures
     devDependencies:
       "@stratakit/foundations":
         specifier: workspace:*


### PR DESCRIPTION
Adds `<MenuItem>` to `@stratakit/react`. Equivalent to [iTwinUI `<MenuItem>`](https://itwinui.bentley.com/docs/dropdownmenu). Part of #596.

### Changes

- `MenuItem` maps to StrataKit's `DropdownMenu.Item`.
  - Most of the props are not implemented, except for `children`, `startIcon` and `disabled`.
  - The `onClick` prop behaves a bit differently: it does not get called with the `value` (see below).
- `@stratakit/compat` now depends on `@stratakit/structures`.

### Preview

No demo added in this PR because `MenuItem` does not make sense by itself.

See follow-up PR #713.

---

### Background

In StrataKit, there is only a `DropdownMenu` component which includes a `DropdownMenu.Item` subcomponent.

In iTwinUI v3, there is a "standalone" `MenuItem`, however this component is improperly designed (e.g. it has a confusing [`value`+`onClick` mechanism](https://github.com/iTwin/iTwinUI/blob/04619737aac75e0a07d4c53569ab7406f42d0b48/packages/itwinui-react/src/core/Menu/MenuItem.tsx#L156) which hides the actual click event, and also it can be passed into components like `ComboBox` and `Select`, where it doesn't belong).

### Updates needed in iTwinUI

<details>
<summary><s>Original proposed changes</s></summary>

- The `MenuItem` component needs to be deprecated?
- New `DropdownMenu.Item`, `Select.Option` and `ComboBox.Menu` components need to be added to replace `MenuItem`.

</details>

**Update**: See https://github.com/iTwin/design-system/pull/691#discussion_r2100948837.