### PR TITLE
remove deprecated `Root` and `Icon` from `@stratakit/bricks`

### DIFF
--- a/.changeset/young-bugs-wear.md
+++ b/.changeset/young-bugs-wear.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": minor
+---
+
+The previously-deprecated `Root` and `Icon` components have been removed from `@stratakit/bricks`, since they were moved to `@stratakit/foundations`.

--- a/packages/bricks/src/index.ts
+++ b/packages/bricks/src/index.ts
@@ -25,12 +25,3 @@ export { Text } from "./Text.js";
 export * as TextBox from "./TextBox.js";
 export { Tooltip } from "./Tooltip.js";
 export { VisuallyHidden } from "./VisuallyHidden.js";
-
-import { Icon, Root } from "@stratakit/foundations";
-
-/** @deprecated Please import `Root` from `"@stratakit/foundations"` instead. */
-const RootDeprecated = Root as typeof Root;
-/** @deprecated Please import `Icon` from `"@stratakit/foundations"` instead. */
-const IconDeprecated = Icon as typeof Icon;
-
-export { RootDeprecated as Root, IconDeprecated as Icon };


### PR DESCRIPTION
In #640, `Root` and `Icon` were moved into `@stratakit/foundations`. They were re-exported from `@stratakit/bricks` (but marked as deprecated).

This PR removes the deprecated exports, resulting in a breaking change (grouped for release together with the breaking change from #704).