### PR TITLE
Add component specific `::selection` styling

### DIFF
--- a/.changeset/plenty-grapes-dig.md
+++ b/.changeset/plenty-grapes-dig.md
@@ -1,0 +1,6 @@
+---
+"@stratakit/structures": patch
+"@stratakit/bricks": patch
+---
+
+Added component specific `::selection` styling.

--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -59,6 +59,7 @@
 			--🥝anchor-color: var(--🌀anchor-state--default, var(--✨color--critical))
 				var(--🌀anchor-state--hover, var(--✨color--critical-hover))
 				var(--🌀anchor-state--pressed, var(--✨color--critical-pressed));
+			--🥝selection-color-bg: var(--ids-color-bg-critical-base);
 			-webkit-tap-highlight-color: var(--ids-color-bg-glow-on-surface-critical-pressed);
 		}
 	}

--- a/packages/bricks/src/Badge.css
+++ b/packages/bricks/src/Badge.css
@@ -28,29 +28,36 @@
 		&:where([data-kiwi-variant="solid"]) {
 			--🥝badge-border-color: var(--ids-color-border-glow-strong-default);
 			--🥝badge-text-color: var(--ids-color-text-neutral-emphasis);
+			--🥝selection-color-text: var(--ids-color-text-neutral-primary);
 
 			&:where([data-kiwi-tone="neutral"]) {
 				--🥝badge-background-color: var(--ids-color-bg-mono-base);
+				--🥝selection-color-bg: var(--ids-color-bg-mono-muted);
 			}
 
 			&:where([data-kiwi-tone="info"]) {
 				--🥝badge-background-color: var(--ids-color-bg-info-base);
+				--🥝selection-color-bg: var(--ids-color-bg-info-muted);
 			}
 
 			&:where([data-kiwi-tone="positive"]) {
 				--🥝badge-background-color: var(--ids-color-bg-positive-base);
+				--🥝selection-color-bg: var(--ids-color-bg-positive-muted);
 			}
 
 			&:where([data-kiwi-tone="attention"]) {
 				--🥝badge-background-color: var(--ids-color-bg-attention-base);
+				--🥝selection-color-bg: var(--ids-color-bg-attention-muted);
 			}
 
 			&:where([data-kiwi-tone="critical"]) {
 				--🥝badge-background-color: var(--ids-color-bg-critical-base);
+				--🥝selection-color-bg: var(--ids-color-bg-critical-muted);
 			}
 
 			&:where([data-kiwi-tone="accent"]) {
 				--🥝badge-background-color: var(--ids-color-bg-accent-base);
+				--🥝selection-color-bg: var(--ids-color-bg-accent-muted);
 			}
 		}
 
@@ -123,6 +130,28 @@
 			&:where([data-kiwi-tone="accent"]) {
 				--🥝badge-text-color: var(--ids-color-text-accent-base);
 				--🥝badge-border-color: var(--ids-color-border-accent-base);
+			}
+		}
+
+		&:where([data-kiwi-variant="muted"], [data-kiwi-variant="outline"]) {
+			&:where([data-kiwi-tone="neutral"]) {
+				--🥝selection-color-bg: var(--ids-color-bg-mono-base);
+			}
+
+			&:where([data-kiwi-tone="info"]) {
+				--🥝selection-color-bg: var(--ids-color-bg-info-base);
+			}
+
+			&:where([data-kiwi-tone="positive"]) {
+				--🥝selection-color-bg: var(--ids-color-bg-positive-base);
+			}
+
+			&:where([data-kiwi-tone="attention"]) {
+				--🥝selection-color-bg: var(--ids-color-bg-attention-base);
+			}
+
+			&:where([data-kiwi-tone="critical"]) {
+				--🥝selection-color-bg: var(--ids-color-bg-critical-base);
 			}
 		}
 	}

--- a/packages/bricks/src/Description.css
+++ b/packages/bricks/src/Description.css
@@ -9,6 +9,7 @@
 		}
 
 		&:where([data-kiwi-tone="critical"]) {
+			--🥝selection-color-bg: var(--ids-color-bg-critical-base);
 			color: var(--ids-color-text-critical-base);
 		}
 	}

--- a/packages/structures/src/Banner.css
+++ b/packages/structures/src/Banner.css
@@ -21,27 +21,32 @@
 
 			&:where([data-kiwi-tone="neutral"]) {
 				--🥝banner-color-border: var(--ids-color-border-neutral-base);
+				--🥝selection-color-bg: var(--ids-color-bg-mono-base);
 			}
 		}
 
 		&:where([data-kiwi-tone="info"]) {
 			--🥝banner-color-border: var(--ids-color-border-info-base);
 			--🥝icon-color: var(--ids-color-icon-info-base);
+			--🥝selection-color-bg: var(--ids-color-bg-info-base);
 		}
 
 		&:where([data-kiwi-tone="positive"]) {
 			--🥝banner-color-border: var(--ids-color-border-positive-base);
 			--🥝icon-color: var(--ids-color-icon-positive-base);
+			--🥝selection-color-bg: var(--ids-color-bg-positive-base);
 		}
 
 		&:where([data-kiwi-tone="attention"]) {
 			--🥝banner-color-border: var(--ids-color-border-attention-base);
 			--🥝icon-color: var(--ids-color-icon-attention-base);
+			--🥝selection-color-bg: var(--ids-color-bg-attention-base);
 		}
 
 		&:where([data-kiwi-tone="critical"]) {
 			--🥝banner-color-border: var(--ids-color-border-critical-base);
 			--🥝icon-color: var(--ids-color-icon-critical-base);
+			--🥝selection-color-bg: var(--ids-color-bg-critical-base);
 		}
 	}
 }

--- a/packages/structures/src/ErrorRegion.css
+++ b/packages/structures/src/ErrorRegion.css
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝-error-region {
 	--✨padding: 4px;
+	--🥝selection-color-bg: var(--ids-color-bg-attention-base);
 
 	@layer base {
 		position: relative;

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -60,6 +60,7 @@
 		&:where([data-kiwi-error="true"]) {
 			--🥝icon-color: var(--ids-color-icon-attention-base);
 			--🥝tree-item-color: var(--ids-color-text-attention-base);
+			--🥝selection-color-bg: var(--ids-color-bg-attention-base);
 		}
 	}
 


### PR DESCRIPTION
Follow up to #650. Within individual components:
- For UI components that allow text selection, match the `::selection` to the `tone`.
- `<Badge variant="solid">` has unique `::selection` styling to help with color contrast.  [See demo page.](https://supreme-barnacle-pl8jn8m.pages.github.io/715/tests/badge?visual)