### PR TITLE
test-app: improve landmark usage in sandbox

### DIFF
--- a/apps/test-app/app/sandbox/index.tsx
+++ b/apps/test-app/app/sandbox/index.tsx
@@ -95,23 +95,25 @@ export const meta: MetaFunction = () => {
 export default function Page() {
 	return (
 		<div className={styles.appLayout}>
-			<Header />
 			<PlatformBar />
+			<Header />
 			<PanelGroup
 				direction="horizontal"
 				className={styles.content}
 				keyboardResizeBy={2.5}
 			>
-				<Panel
-					defaultSize={20}
-					minSize={15}
-					maxSize={35}
-					className={styles.leftPanel}
-				>
-					<LeftPanel />
-				</Panel>
-				<PanelSplitter />
-				<Panel className={styles.canvasWrapper}>
+				<nav aria-label="Left panel" style={{ display: "contents" }}>
+					<Panel
+						defaultSize={20}
+						minSize={15}
+						maxSize={35}
+						className={styles.leftPanel}
+					>
+						<LeftPanel />
+					</Panel>
+					<PanelSplitter />
+				</nav>
+				<Panel className={styles.canvasWrapper} tagName="main">
 					<Canvas />
 				</Panel>
 			</PanelGroup>
@@ -136,13 +138,13 @@ function Header() {
 
 function PlatformBar() {
 	return (
-		<div className={styles.platformBar}>
+		<nav className={styles.platformBar}>
 			<div className={styles.tools}>
 				<Icon href={placeholderIcon} size="large" />
 				<Icon href={placeholderIcon} size="large" />
 				<Icon href={placeholderIcon} size="large" />
 			</div>
-		</div>
+		</nav>
 	);
 }
 


### PR DESCRIPTION
_Follow-up to #722_.

This PR sets up [landmarks](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/) in the `/sandbox` page.

Previously, `<header>` was the only landmark being used, whereas _now_ the following landmarks are used:

1. PlatformBar: unnamed `<nav>`
2. Header: `<header>`
3. Left panel: `<nav>` labeled as "Left panel"
   - The "resizer" is also inside this nav.
4. Canvas: `<main>`

Also, the PlatformBar was moved before Header to better represent DOM order. This is somewhat debatable, but I consider the "logo" to be located within the PlatformBar, preceding the Header content.

### Preview

See [732 deploy preview](http://itwin.github.io/design-system/732/sandbox).

<details>
<summary>Screenshot</summary>

![Screenshot of the sandbox showing all the landmarks visually annotated using Accessibility Insights](https://github.com/user-attachments/assets/1a1a6311-f265-4c1a-9783-857466a94a99)

</details>
