### PR TITLE
Update `label` prop type

### DIFF
--- a/.changeset/five-chairs-grow.md
+++ b/.changeset/five-chairs-grow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": minor
+---
+
+Updated the `label` prop type in the `<Chip />` component from `string` to `ReactNode`.

--- a/.changeset/five-chairs-grow.md
+++ b/.changeset/five-chairs-grow.md
@@ -1,5 +1,5 @@
 ---
-"@stratakit/structures": minor
+"@stratakit/structures": patch
 ---
 
 Updated the `label` prop type in the `<Chip />` component from `string` to `ReactNode`.

--- a/.changeset/vast-times-smell.md
+++ b/.changeset/vast-times-smell.md
@@ -1,5 +1,5 @@
 ---
-"@stratakit/bricks": minor
+"@stratakit/bricks": patch
 ---
 
 Updated the `label` prop type in the `<Badge />` component from `string` to `ReactNode`.

--- a/.changeset/vast-times-smell.md
+++ b/.changeset/vast-times-smell.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": minor
+---
+
+Updated the `label` prop type in the `<Badge />` component from `string` to `ReactNode`.

--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -13,7 +13,7 @@ interface BadgeProps extends Omit<BaseProps<"span">, "children"> {
 	/**
 	 * The label displayed inside the badge.
 	 */
-	label: string;
+	label: React.ReactNode;
 
 	/**
 	 * The tone of the badge.

--- a/packages/structures/src/Chip.tsx
+++ b/packages/structures/src/Chip.tsx
@@ -16,7 +16,7 @@ interface ChipProps extends Omit<BaseProps<"div">, "children"> {
 	/**
 	 * The label displayed inside the chip.
 	 */
-	label: string;
+	label: React.ReactNode;
 
 	/**
 	 * The variant style of the Chip.


### PR DESCRIPTION
This PR updates `label` prop type from `string` to `ReactNode` of `<Badge />` and `<Chip />` components. This is not a breaking change, since the type is extended (`string` is a subset of `ReactNode`). Based on suggestion from: https://github.com/iTwin/design-system/pull/718#discussion_r2107706125