### PR TITLE
fix `Tree.Item` console warnings

### DIFF
--- a/.changeset/shaky-plums-wonder.md
+++ b/.changeset/shaky-plums-wonder.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fixed console warnings raised from `<Tree.Item>` component.

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -188,15 +188,17 @@ interface TreeItemProps extends Omit<BaseProps, "content" | "children"> {
  */
 const TreeItem = React.memo(
 	forwardRef<"div", TreeItemProps>((props, forwardedRef) => {
-		const { expanded, selected } = props;
 		const {
+			selected,
 			onSelectedChange,
+			expanded,
 			onExpandedChange,
 			icon,
 			unstable_decorations,
 			label,
 			description,
 			actions,
+			error: _,
 			onClick: onClickProp,
 			onKeyDown: onKeyDownProp,
 			...rest
@@ -232,6 +234,8 @@ const TreeItem = React.memo(
 			<TreeItemRootProvider {...props}>
 				<TreeItemRoot
 					{...rest}
+					expanded={expanded}
+					selected={selected}
 					onClick={useEventHandlers(onClickProp, handleClick)}
 					onKeyDown={useEventHandlers(onKeyDownProp, handleKeyDown)}
 					ref={forwardedRef}
@@ -581,23 +585,22 @@ const TreeItemActionsOverflowMenuContext = React.createContext(false);
  */
 function TreeItemActionsOverflowMenu() {
 	const overflow = React.useContext(TreeItemHasOverflowActionsContext);
-	const [open, setOpen] = React.useState(false);
+	const [open, _setOpen] = React.useState(false);
 	const isArrowKeyPressed = React.useRef(false);
+
+	const setOpen = React.useCallback((value: boolean) => {
+		// Do not open the menu using arrow keys because it conflicts with the toolbar's arrow key navigation
+		if (value && !isArrowKeyPressed.current) {
+			_setOpen(true);
+		} else {
+			_setOpen(false);
+		}
+	}, []);
 
 	if (!overflow) return null;
 	return (
 		<PopoverProvider placement="right-start">
-			<DropdownMenu.Root
-				open={open}
-				setOpen={React.useCallback((value: boolean) => {
-					// Do not open the menu using arrow keys because it conflicts with the toolbar's arrow key navigation
-					if (value && !isArrowKeyPressed.current) {
-						setOpen(true);
-					} else {
-						setOpen(false);
-					}
-				}, [])}
-			>
+			<DropdownMenu.Root open={open} setOpen={setOpen}>
 				<DropdownMenu.Button
 					onKeyDown={(e) => {
 						if (arrowKeys.includes(e.key)) {

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -731,7 +731,8 @@ const TreeItemAction = React.memo(
 					<IconButton
 						label={label}
 						icon={icon}
-						inert={visible === false ? true : undefined}
+						// @ts-expect-error: Using string value as a workaround for React 18
+						inert={visible === false ? "true" : undefined}
 						{...rest}
 						dot={dot}
 						variant="ghost"


### PR DESCRIPTION
Fixes #735.
- `useCallback` called unconditionally.
- `error` destructured so it's excluded from `rest`.
- `inert` attribute set to string value (`"true"`) to support React 18.