### PR TITLE
Fix `ref` type of `Field.Label` component

### DIFF
--- a/.changeset/tasty-states-stay.md
+++ b/.changeset/tasty-states-stay.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Fixed a `ref` type of `Field.Label` component to use the `HTMLLabelElement` instead of `HTMLDivElement`.

--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -79,7 +79,7 @@ DEV: FieldRoot.displayName = "Field";
  * A label for the field’s control element. This is automatically associated
  * with the control’s `id`.
  */
-const FieldLabel = forwardRef<"div", BaseProps<"label">>(
+const FieldLabel = forwardRef<"label", BaseProps<"label">>(
 	(props, forwardedRef) => {
 		const store = useCollectionContext();
 		const renderedItems = useStoreState(
@@ -103,7 +103,7 @@ const FieldLabel = forwardRef<"div", BaseProps<"label">>(
 			<CollectionItem
 				getItem={getData}
 				render={<Label {...props} htmlFor={fieldId} />}
-				ref={forwardedRef}
+				ref={forwardedRef as CollectionItemProps["ref"]}
 			/>
 		);
 	},


### PR DESCRIPTION
This PR fixes `ref` type of `Field.Label` component based on https://github.com/iTwin/design-system/pull/688#discussion_r2112548763.

This is non-breaking change for consumers, since `HTMLLabelElement` is a subclass of `HTMLDivElement`.