### PR TITLE
handle `render={undefined}` in `DropdownMenu.Button`

### DIFF
--- a/.changeset/fifty-turtles-train.md
+++ b/.changeset/fifty-turtles-train.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+`DropdownMenu.Button` will now ignore `render={undefined}`.

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -151,13 +151,15 @@ const DropdownMenuButton = forwardRef<"button", DropdownMenuButtonProps>(
 		return (
 			<MenuButton
 				accessibleWhenDisabled
-				render={
-					<Button accessibleWhenDisabled={accessibleWhenDisabled}>
-						{children}
-						<DisclosureArrow />
-					</Button>
-				}
 				{...rest}
+				render={
+					props.render ?? (
+						<Button accessibleWhenDisabled={accessibleWhenDisabled}>
+							{children}
+							<DisclosureArrow />
+						</Button>
+					)
+				}
 				className={cx("🥝-dropdown-menu-button", props.className)}
 				data-has-popover-open={open || undefined}
 				ref={forwardedRef}


### PR DESCRIPTION
Pulled out of https://github.com/iTwin/design-system/pull/713#discussion_r2126659790.

This PR makes `DropdownMenu.Button` ignore `render={undefined}` instead of it overriding the default/fallback value. (Sometimes, as is the case with [`useCompatProps`](https://github.com/iTwin/design-system/blob/8cf943ae1ea0b2fb3b5f701324d85e2983d0afe6/packages/compat/src/~utils.tsx#L73), the value of `render` is explicitly set to `undefined` instead of _not_ passing the prop).

Before this PR, `<Dropdown.Button render={undefined}>` would render nothing, whereas now it behaves the same as if `render` was not passed.