### PR TITLE
create `Button` compat component

### DIFF
--- a/apps/test-app/app/compat/button.tsx
+++ b/apps/test-app/app/compat/button.tsx
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Button } from "@stratakit/react";
+import { definePage } from "~/~utils.tsx";
+
+import placeholderIcon from "@stratakit/icons/placeholder.svg";
+
+export const handle = { title: "Button" };
+
+export default definePage(function Page() {
+	return (
+		<div style={{ display: "grid", gap: 4, justifyItems: "start" }}>
+			{(["default", "high-visibility", "cta", "borderless"] as const).map(
+				(styleType) => {
+					return (
+						<div key={styleType} style={{ display: "flex", gap: 4 }}>
+							<Button styleType={styleType}>Click me</Button>
+
+							<Button
+								styleType={styleType}
+								startIcon={
+									<svg>
+										<use href={`${placeholderIcon}#icon`} />
+									</svg>
+								}
+								endIcon={
+									<svg>
+										<use href={`${placeholderIcon}#icon`} />
+									</svg>
+								}
+							>
+								Click me
+							</Button>
+
+							<Button styleType={styleType} disabled>
+								Click me
+							</Button>
+
+							<Button styleType={styleType} as="a" href="#">
+								Click me
+							</Button>
+						</div>
+					);
+				},
+			)}
+
+			<Button htmlDisabled>Click me</Button>
+
+			<Button
+				startIcon={
+					<svg>
+						<use href={`${placeholderIcon}#icon`} />
+					</svg>
+				}
+				startIconProps={{ style: { outline: "1px solid DeepPink" } }}
+				endIcon={
+					<svg>
+						<use href={`${placeholderIcon}#icon`} />
+					</svg>
+				}
+				endIconProps={{ style: { outline: "1px solid DeepPink" } }}
+			>
+				Click me
+			</Button>
+
+			<hr style={{ justifySelf: "stretch" }} />
+
+			{/* NOT IMPLEMENTED */}
+			<Button size="small">Click me</Button>
+			<Button size="large">Click me</Button>
+			<Button stretched>Click me</Button>
+			<Button loading>Click me</Button>
+		</div>
+	);
+});

--- a/apps/test-app/app/~meta.ts
+++ b/apps/test-app/app/~meta.ts
@@ -39,6 +39,7 @@ export const components = {
 	compat: [
 		"Anchor",
 		"Avatar",
+		"Button",
 		"Checkbox",
 		"Divider",
 		"Input",

--- a/packages/compat/src/Button.tsx
+++ b/packages/compat/src/Button.tsx
@@ -59,18 +59,18 @@ export const Button = React.forwardRef((props, forwardedRef) => {
 		...rest
 	} = useCompatProps(props);
 
-	const variantAndTone = React.useMemo<
-		Pick<SkButtonProps, "variant" | "tone">
-	>(() => {
+	const variantAndTone = React.useMemo(() => {
 		switch (styleType) {
 			case "borderless":
-				return { variant: "ghost", tone: "neutral" };
+				return { variant: "ghost" satisfies SkButtonProps["variant"] } as const;
 			case "high-visibility":
 			case "cta":
-				return { variant: "solid", tone: "accent" };
-			case "default":
-				return { variant: "outline", tone: "neutral" };
+				return {
+					variant: "solid" satisfies SkButtonProps["variant"],
+					tone: "accent" satisfies SkButtonProps["tone"],
+				} as const;
 		}
+		return { variant: "outline" satisfies SkButtonProps["variant"] } as const;
 	}, [styleType]);
 
 	// When `htmlDisabled` is set, we don't want to use `aria-disabled`.
@@ -82,8 +82,7 @@ export const Button = React.forwardRef((props, forwardedRef) => {
 			accessibleWhenDisabled={accessibleWhenDisabled}
 			disabled={props.disabled || htmlDisabled}
 			ref={forwardedRef}
-			// biome-ignore lint/suspicious/noExplicitAny: thisisfine.jpg
-			{...(variantAndTone as any)}
+			{...variantAndTone}
 		>
 			{startIcon ? (
 				<Icon

--- a/packages/compat/src/Button.tsx
+++ b/packages/compat/src/Button.tsx
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Button as SkButton } from "@stratakit/bricks";
+import * as React from "react";
+import { useCompatProps } from "./~utils.tsx";
+
+import type { Button as IuiButton } from "@itwin/itwinui-react";
+import type { PolymorphicForwardRefComponent } from "./~utils.tsx";
+import { Icon } from "@stratakit/foundations";
+
+// ----------------------------------------------------------------------------
+
+type IuiButtonProps = React.ComponentProps<typeof IuiButton>;
+type SkButtonProps = React.ComponentProps<typeof SkButton>;
+
+interface ButtonProps
+	extends Pick<
+		IuiButtonProps,
+		| "size"
+		| "styleType"
+		| "startIcon"
+		| "endIcon"
+		| "labelProps"
+		| "startIconProps"
+		| "endIconProps"
+		| "stretched"
+		| "loading"
+		| "htmlDisabled"
+	> {
+	/** NOT IMPLEMENTED. */
+	size?: IuiButtonProps["size"];
+	/** NOT IMPLEMENTED. */
+	labelProps?: IuiButtonProps["labelProps"];
+	/** NOT IMPLEMENTED. */
+	stretched?: IuiButtonProps["stretched"];
+	/** NOT IMPLEMENTED. */
+	loading?: IuiButtonProps["loading"];
+}
+
+// ----------------------------------------------------------------------------
+
+/** @see https://itwinui.bentley.com/docs/button */
+export const Button = React.forwardRef((props, forwardedRef) => {
+	const {
+		children,
+		styleType = "default",
+		startIcon,
+		endIcon,
+		startIconProps,
+		endIconProps,
+		htmlDisabled,
+		size, // NOT IMPLEMENTED
+		labelProps, // NOT IMPLEMENTED
+		stretched, // NOT IMPLEMENTED
+		loading, // NOT IMPLEMENTED
+		...rest
+	} = useCompatProps(props);
+
+	const variantAndTone = React.useMemo<
+		Pick<SkButtonProps, "variant" | "tone">
+	>(() => {
+		switch (styleType) {
+			case "borderless":
+				return { variant: "ghost", tone: "neutral" };
+			case "high-visibility":
+			case "cta":
+				return { variant: "solid", tone: "accent" };
+			case "default":
+				return { variant: "outline", tone: "neutral" };
+		}
+	}, [styleType]);
+
+	// When `htmlDisabled` is set, we don't want to use `aria-disabled`.
+	const accessibleWhenDisabled = !htmlDisabled;
+
+	return (
+		<SkButton
+			{...rest}
+			accessibleWhenDisabled={accessibleWhenDisabled}
+			disabled={props.disabled || htmlDisabled}
+			ref={forwardedRef}
+			// biome-ignore lint/suspicious/noExplicitAny: thisisfine.jpg
+			{...(variantAndTone as any)}
+		>
+			{startIcon ? (
+				<Icon
+					render={startIcon}
+					{...(startIconProps as React.ComponentProps<"svg">)}
+				/>
+			) : null}
+			{children}
+			{endIcon ? (
+				<Icon
+					render={endIcon}
+					{...(endIconProps as React.ComponentProps<"svg">)}
+				/>
+			) : null}
+		</SkButton>
+	);
+}) as PolymorphicForwardRefComponent<"button", ButtonProps>;
+DEV: Button.displayName = "Button";

--- a/packages/compat/src/Button.tsx
+++ b/packages/compat/src/Button.tsx
@@ -70,7 +70,7 @@ export const Button = React.forwardRef((props, forwardedRef) => {
 					tone: "accent" satisfies SkButtonProps["tone"],
 				} as const;
 		}
-		return { variant: "outline" satisfies SkButtonProps["variant"] } as const;
+		return { variant: "solid" satisfies SkButtonProps["variant"] } as const;
 	}, [styleType]);
 
 	// When `htmlDisabled` is set, we don't want to use `aria-disabled`.

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -6,6 +6,7 @@
 
 export { Anchor } from "./Anchor.js";
 export { Avatar } from "./Avatar.js";
+export { Button } from "./Button.js";
 export { Checkbox } from "./Checkbox.js";
 export { Divider } from "./Divider.js";
 export { Input } from "./Input.js";


### PR DESCRIPTION
_Part of #581_

This PR adds a `<Button>` component to `@stratakit/react`, equivalent to [iTwinUI `<Button>`](https://itwinui.bentley.com/docs/button).

**Implemented props**:
- `children`
- `styleType` (weirdly, however)
- `startIcon`/`startIconProps`
- `endIcon`/`endIconProps`.
- `htmlDisabled`

**Not implemented props**:
- `size`
- `labelProps` (there is  no such element)
- `stretched`
- `loading`

### Preview

See [#768 deploy preview](https://itwin.github.io/design-system/768/compat/button).

<img src="https://github.com/user-attachments/assets/18214895-ec69-48ac-bc31-9e19834cd1b8" alt="Screenshot of different permutations of button">
