### PR TITLE
throw against multiple instances of `@stratakit/foundations`

### DIFF
--- a/.changeset/spicy-forks-drop.md
+++ b/.changeset/spicy-forks-drop.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/foundations": patch
+---
+
+An error will now be thrown when multiple instances of `@stratakit/foundations` are detected.

--- a/packages/foundations/scripts/build.js
+++ b/packages/foundations/scripts/build.js
@@ -22,7 +22,7 @@ await esbuild.build({
 	format: "esm",
 	jsx: "automatic",
 	target: "es2021",
-	...(!isDev && { dropLabels: ["DEV"] }),
+	dropLabels: ["DROP", ...(isDev ? ["DEV"] : [])],
 });
 
 // Run esbuild again, only to inline bundled CSS inside `.css.ts` files

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -30,6 +30,9 @@ import type { BaseProps } from "./~utils.js";
 
 const css = foundationsCss + componentsCss;
 
+/** This helps pinpoint the location where this module is imported from. */
+const stack = new Error()?.stack?.split("Error")?.at(-1)?.trim() || "";
+
 // ----------------------------------------------------------------------------
 
 interface RootProps extends BaseProps {
@@ -80,6 +83,8 @@ interface RootProps extends BaseProps {
  * ```
  */
 export const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
+	throwIfNotSingleton();
+
 	const {
 		children,
 		synchronizeColorScheme = false,
@@ -381,6 +386,36 @@ function loadFonts(rootNode: Document | ShadowRoot) {
 			},
 		);
 		ownerWindow.document.fonts.add(font);
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+/**
+ * This function injects the location of this file into `globalThis`, and throws an error
+ * if more than one location is detected.
+ */
+function throwIfNotSingleton() {
+	DROP: return;
+
+	// biome-ignore lint/correctness/noUnreachable: The early return will be removed by build script.
+	const symbol = Symbol.for("@stratakit/foundations");
+
+	const _globalThis = globalThis as typeof globalThis & {
+		[symbol]: { versions?: Set<string> };
+	};
+	_globalThis[symbol] ??= { versions: new Set() };
+
+	if (stack) _globalThis[symbol].versions?.add(stack);
+	if ((_globalThis[symbol].versions?.size || 0) > 1) {
+		console.table(
+			Array.from(_globalThis[symbol].versions || []).map((stack) => ({
+				"@stratakit/foundations location": stack,
+			})),
+		);
+		throw new Error(
+			`Multiple instances of @stratakit/foundations detected. This can lead to unexpected behavior.`,
+		);
 	}
 }
 


### PR DESCRIPTION
This PR updates the `<Root>` component to execute some code (during render) that will `throw`  when it detects multiple instances of the file (and by proxy `@stratakit/foundations`).

Error text: "Multiple instances of @stratakit/foundations detected. This can lead to unexpected behavior."

### Details

**Background**: As `@stratakit/foundations` is intended to be a "singleton" and is [explicitly documented](https://github.com/iTwin/design-system/blob/fda6e15d8428ddeb894ae746a02e1bb43a3d9d34/packages/foundations/README.md?plain=1#L22) to be used as a "peer dependency", we should be strict about it right from the start. I've already started seeing reports of React `Context` not working because multiple disconnected instances of `@stratakit/foundations` were being used.

**Differences when compared to [iTwinUI equivalent](https://github.com/iTwin/iTwinUI/blob/8f01965a288e20d3840b91f5797675f03d7f6682/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx#L492-L530)**:
- Detection logic: This uses [`new Error().stack`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) (instead of "magically" conjured version numbers).
- Result: In addition to a `console.table` listing all instances, a showstopping error is `throw`n (instead of just a `console.warn`).

### Testing

I'm returning early during development (using `esbuild`'s "drop labels" feature to drop the early return in the built package), because every change to `Root.tsx` creates a new version of the file (HMR) which results in the error being thrown.

I did verify (by inspecting) that the information is stored in `globalThis` when using the production build, but I'm not sure what is the best way to actually test that the error works. (We might just have to wait until we release it? Open to feedback.)