### PR TITLE
internal: create `useUnreactiveCallback` hook

### DIFF
--- a/packages/foundations/src/~hooks.ts
+++ b/packages/foundations/src/~hooks.ts
@@ -8,6 +8,7 @@ import * as React from "react";
 import { isBrowser, supportsPopover } from "./~utils.js";
 
 import type { PopoverStore } from "@ariakit/react/popover";
+import type { AnyFunction } from "./~utils.js";
 
 /**
  * SSR-safe wrapper over `React.useLayoutEffect`.
@@ -120,12 +121,26 @@ export function useMergedRefs<T>(
 }
 
 /**
- * Hook that accepts a list of event handlers and returns a single memoized handler
- * that ensures `defaultPrevented` is respected for each handler.
+ * Hook that "memoizes" a function by skipping reactivity, similar to `React.useEffectEvent`.
  *
- * The memoization technique used by this hook ensures that only the "latest" handlers are ever called.
- * The "latest" handlers are stored in a ref and updated on each render in an insertion effect. The result
- * is that the handlers passed to this hook do not always need to be memoized.
+ * The memoization technique used by this hook ensures that only the "latest" callback is ever called,
+ * regardless of its dependencies. The "latest" callback is stored in a ref and updated on each render
+ * in an Effect. The result is that the callback passed to this hook does not need to be memoized.
+ *
+ * @private
+ */
+export function useUnreactiveCallback<T extends AnyFunction>(callback: T) {
+	const latestCallback = useLatestRef(callback);
+
+	return React.useCallback<AnyFunction>(
+		(...args) => latestCallback.current?.(...args),
+		[latestCallback],
+	) as T;
+}
+
+/**
+ * Hook that accepts a list of event handlers and returns a single memoized (unreactive)
+ * handler that ensures `defaultPrevented` is respected for each handler.
  *
  * Example:
  * ```tsx

--- a/packages/foundations/src/~utils.tsx
+++ b/packages/foundations/src/~utils.tsx
@@ -90,6 +90,9 @@ export type FocusableProps<ElementType extends React.ElementType = "div"> =
 /** See https://github.com/Microsoft/TypeScript/issues/29729 */
 export type AnyString = string & {};
 
+// biome-ignore lint/suspicious/noExplicitAny: allow any type of function
+export type AnyFunction = (...args: any) => any;
+
 // ----------------------------------------------------------------------------
 
 /** Returns the value unchanged. */


### PR DESCRIPTION
This is like `useEventHandlers` but for any kind of function. Will be used in #713.

Another way to think of it: it's like `useCallback` but without the dependency array. Instead of reacting to dependencies, it always uses the latest available version.

Moved some of the JSDocs from `useEventHandlers` into this hook's JSDocs, and used the word "unreactive" to refer to this concept.

---

References:
- #256 and #273.
- [`React.useEffectEvent`](https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event) (experimental API) and [`use-effect-event` package](https://github.com/sanity-io/use-effect-event/blob/main/src/useEffectEvent.ts).
- https://github.com/iTwin/design-system/pull/713#discussion_r2140370674.