### PR TITLE
Bump `brace-expansion`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1380,16 +1380,16 @@ packages:
       }
     engines: { node: ">=8" }
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     resolution:
       {
-        integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==,
+        integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
       }
 
-  brace-expansion@4.0.0:
+  brace-expansion@4.0.1:
     resolution:
       {
-        integrity: sha512-l/mOwLWs7BQIgOKrL46dIAbyCKvPV7YJPDspkuc88rHsZRlg3hptUGdU7Trv0VFP4d3xnSGBQrKu5ZvGB7UeIw==,
+        integrity: sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==,
       }
     engines: { node: ">= 18" }
 
@@ -3369,11 +3369,11 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@4.0.0:
+  brace-expansion@4.0.1:
     dependencies:
       balanced-match: 3.0.1
 
@@ -3713,7 +3713,7 @@ snapshots:
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minipass@7.1.2: {}
 
@@ -4054,7 +4054,7 @@ snapshots:
 
   wireit@0.14.12:
     dependencies:
-      brace-expansion: 4.0.0
+      brace-expansion: 4.0.1
       chokidar: 3.6.0
       fast-glob: 3.3.3
       jsonc-parser: 3.3.1


### PR DESCRIPTION
This PR fixes `pnpm audit` failure due to https://github.com/advisories/GHSA-v6h2-p8h4-qcjw