### PR TITLE
test-app: move logo out of header

### DIFF
--- a/apps/test-app/app/sandbox/index.module.css
+++ b/apps/test-app/app/sandbox/index.module.css
@@ -9,20 +9,23 @@
 	block-size: 100dvb;
 	display: grid;
 	grid-template-areas:
-		"header header"
+		"platformBar header"
 		"platformBar content";
 	grid-template-rows: auto 1fr;
 	grid-template-columns: auto 1fr;
 }
 
 .header {
+	--_header-height: 40px;
 	grid-area: header;
 	background-color: var(--stratakit-color-bg-page-base);
 	border-block-end: 1px solid var(--stratakit-color-border-neutral-base);
 
+	min-block-size: var(--_header-height);
 	display: flex;
 	align-items: center;
 	gap: 12px;
+	padding-inline: 12px;
 }
 
 .platformBar {

--- a/apps/test-app/app/sandbox/index.tsx
+++ b/apps/test-app/app/sandbox/index.tsx
@@ -126,9 +126,6 @@ export default function Page() {
 function Header() {
 	return (
 		<header className={styles.header}>
-			<div className={styles.logo}>
-				<Icon href={placeholderIcon} size="large" />
-			</div>
 			<Text render={<h1 />} variant="body-md">
 				{title}
 			</Text>
@@ -139,6 +136,9 @@ function Header() {
 function PlatformBar() {
 	return (
 		<nav className={styles.platformBar}>
+			<div className={styles.logo}>
+				<Icon href={placeholderIcon} size="large" />
+			</div>
 			<div className={styles.tools}>
 				<Icon href={placeholderIcon} size="large" />
 				<Icon href={placeholderIcon} size="large" />


### PR DESCRIPTION
_Follow-up to #732_.

This PR updates the `/sandbox` page layout to move the "logo" out of the `<header>` and into the left `<nav>` (aka "PlatformBar").