### PR TITLE
add control-specific border tokens

### DIFF
--- a/.changeset/twelve-wolves-bow.md
+++ b/.changeset/twelve-wolves-bow.md
@@ -1,0 +1,10 @@
+---
+"@stratakit/foundations": patch
+---
+
+Added new CSS variables:
+
+- `--stratakit-color-border-control-checkbox`
+- `--stratakit-color-border-control-radio`
+- `--stratakit-color-border-control-textbox`
+- `--stratakit-color-border-control-select`

--- a/internal/theme-dark.json
+++ b/internal/theme-dark.json
@@ -705,6 +705,22 @@
 				"switch": {
 					"$type": "color",
 					"$value": "{p-color.gray.700}"
+				},
+				"checkbox": {
+					"$type": "color",
+					"$value": "{p-color.gray.600}"
+				},
+				"radio": {
+					"$type": "color",
+					"$value": "{p-color.gray.600}"
+				},
+				"textbox": {
+					"$type": "color",
+					"$value": "{p-color.gray.600}"
+				},
+				"select": {
+					"$type": "color",
+					"$value": "{p-color.gray.600}"
 				}
 			}
 		},

--- a/internal/theme-light.json
+++ b/internal/theme-light.json
@@ -705,6 +705,22 @@
 				"switch": {
 					"$type": "color",
 					"$value": "{p-color.gray.50}"
+				},
+				"checkbox": {
+					"$type": "color",
+					"$value": "{p-color.gray.100}"
+				},
+				"radio": {
+					"$type": "color",
+					"$value": "{p-color.gray.100}"
+				},
+				"textbox": {
+					"$type": "color",
+					"$value": "{p-color.gray.100}"
+				},
+				"select": {
+					"$type": "color",
+					"$value": "{p-color.gray.100}"
 				}
 			}
 		},


### PR DESCRIPTION
Added new CSS variables based on the latest update to the Figma file:

- `--stratakit-color-border-control-checkbox`
- `--stratakit-color-border-control-radio`
- `--stratakit-color-border-control-textbox`
- `--stratakit-color-border-control-select`

These will be used in the outline variants of these controls (and perhaps also in the solid variants). **This PR doesn't change component CSS.**

The names for these variables might change in the future. All of these variables currently have the same value, which presents an opportunity for consolidation into a single variable.