### PR TITLE
Add drag and drop support to `TreeItem`

### DIFF
--- a/apps/test-app/app/tests/tree/index.tsx
+++ b/apps/test-app/app/tests/tree/index.tsx
@@ -37,6 +37,7 @@ export default definePage(
 		description: descriptionParam,
 		error: errorParam,
 		items: itemsParam,
+		draggable,
 	}) {
 		const [_, startTransition] = React.useTransition();
 		const overflowPostfix = overflow
@@ -118,6 +119,7 @@ export default definePage(
 							expanded={item.expanded}
 							selected={item.selected}
 							error={error}
+							onMove={draggable ? (data) => console.log(data) : undefined}
 							onSelectedChange={() => {
 								setData(
 									produce((prev) => {

--- a/packages/structures/package.json
+++ b/packages/structures/package.json
@@ -106,6 +106,8 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.17",
+		"@atlaskit/pragmatic-drag-and-drop": "^1.7.2",
+		"@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
 		"@stratakit/bricks": "^0.3.0",
 		"classnames": "^2.5.1"
 	},

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -156,6 +156,83 @@
 	}
 }
 
+.🥝-tree-item-drag-preview {
+	@layer base {
+		padding-block: 4px;
+		padding-inline: 6px;
+		border: 1px solid var(--stratakit-color-border-neutral-base);
+		border-radius: 4px;
+		background-color: hsl(from var(--stratakit-color-border-neutral-base) h s l / 0.56); /* Don’t do this */
+		backdrop-filter: blur(2px);
+		color: var(--stratakit-color-text-neutral-primary);
+	}
+}
+
+.🥝-tree-item-drop-indicator {
+	--✨first-level-indent: 24px;
+	--✨subsequent-level-indent: 6px;
+
+	@layer base {
+		position: absolute;
+		pointer-events: none;
+		touch-action: none;
+	}
+
+	@layer modifiers {
+		&:where([data-kiwi-instruction="combine"]) {
+			--indent: calc(
+				var(--✨first-level-indent) +
+				var(--✨subsequent-level-indent) *
+				(var(--🥝tree-item-level) - 1)
+			);
+
+			inset-block: 0;
+			inset-inline-end: 0;
+			inset-inline-start: var(--indent);
+			inline-size: calc(100% - var(--indent));
+			block-size: 100%;
+			border-radius: 6px;
+			border: 1px solid var(--stratakit-color-border-accent-base);
+		}
+
+		&:where([data-kiwi-instruction^="reorder-"]) {
+			--✨first-level-indent: 28px;
+			--✨subsequent-level-indent: 6px;
+
+			--indent: calc(
+				var(--✨first-level-indent) +
+				var(--✨subsequent-level-indent) *
+				(var(--🥝tree-item-level) - 1) +
+				4px
+			);
+
+			inset-inline-start: var(--indent);
+			block-size: 1px;
+			inline-size: calc(100% - var(--indent));
+			background-color: var(--stratakit-color-border-neutral-inverse);
+
+			&::before {
+				content: "";
+				position: absolute;
+				block-size: 4px;
+				aspect-ratio: 1;
+				border: 1px solid var(--stratakit-color-border-neutral-inverse);
+				border-radius: 9999px;
+				inset-inline-start: -4px;
+				inset-block-start: -1.5px;
+			}
+		}
+
+		&:where([data-kiwi-instruction="reorder-before"]) {
+			inset-block-start: -0.5px;
+		}
+
+		&:where([data-kiwi-instruction="reorder-after"]) {
+			inset-block-end: -0.5px;
+		}
+	}
+}
+
 @media (forced-colors: active) {
 	.🥝-tree-item-node:is(.🥝-list-item) {
 		--🥝list-item-background-color: Canvas;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,12 @@ importers:
       "@ariakit/react":
         specifier: ^0.4.17
         version: 0.4.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@atlaskit/pragmatic-drag-and-drop":
+        specifier: ^1.7.2
+        version: 1.7.2
+      "@atlaskit/pragmatic-drag-and-drop-hitbox":
+        specifier: ^1.1.0
+        version: 1.1.0
       "@stratakit/bricks":
         specifier: ^0.3.0
         version: link:../bricks
@@ -368,6 +374,18 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  "@atlaskit/pragmatic-drag-and-drop-hitbox@1.1.0":
+    resolution:
+      {
+        integrity: sha512-JWt6eVp6Br2FPHRM8s0dUIHQk/jFInGP1f3ti5CdtM1Ji5/pt8Akm44wDC063Gv2i5RGseixtbW0z/t6RYtbdg==,
+      }
+
+  "@atlaskit/pragmatic-drag-and-drop@1.7.2":
+    resolution:
+      {
+        integrity: sha512-GFlFVusm+PpzNwpk4ju8+w9a9pWD5NIGi4DoJ9g6CXTUMlQ4BCsivvmUk+azsV31luEKZtf2J0tg1y3vdltrTQ==,
+      }
 
   "@axe-core/playwright@4.10.2":
     resolution:
@@ -570,6 +588,13 @@ packages:
     engines: { node: ">=6.9.0" }
     peerDependencies:
       "@babel/core": ^7.0.0-0
+
+  "@babel/runtime@7.27.6":
+    resolution:
+      {
+        integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==,
+      }
+    engines: { node: ">=6.9.0" }
 
   "@babel/template@7.27.2":
     resolution:
@@ -1492,6 +1517,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  bind-event-listener@3.0.0:
+    resolution:
+      {
+        integrity: sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==,
+      }
+
   brace-expansion@2.0.2:
     resolution:
       {
@@ -2378,6 +2409,12 @@ packages:
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
+  raf-schd@4.0.3:
+    resolution:
+      {
+        integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==,
+      }
+
   react-dom@19.1.0:
     resolution:
       {
@@ -2918,6 +2955,17 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
+  "@atlaskit/pragmatic-drag-and-drop-hitbox@1.1.0":
+    dependencies:
+      "@atlaskit/pragmatic-drag-and-drop": 1.7.2
+      "@babel/runtime": 7.27.6
+
+  "@atlaskit/pragmatic-drag-and-drop@1.7.2":
+    dependencies:
+      "@babel/runtime": 7.27.6
+      bind-event-listener: 3.0.0
+      raf-schd: 4.0.3
+
   "@axe-core/playwright@4.10.2(playwright-core@1.53.0)":
     dependencies:
       axe-core: 4.10.3
@@ -3088,6 +3136,8 @@ snapshots:
       "@babel/plugin-transform-typescript": 7.27.1(@babel/core@7.27.4)
     transitivePeerDependencies:
       - supports-color
+
+  "@babel/runtime@7.27.6": {}
 
   "@babel/template@7.27.2":
     dependencies:
@@ -3596,6 +3646,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bind-event-listener@3.0.0: {}
+
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -4038,6 +4090,8 @@ snapshots:
       signal-exit: 3.0.7
 
   queue-microtask@1.2.3: {}
+
+  raf-schd@4.0.3: {}
 
   react-dom@19.1.0(react@19.1.0):
     dependencies:


### PR DESCRIPTION
Resolves #706

**Work in progress**

This directly integrates Pragmatic drag and drop into the `TreeItem`.

Currently the `TreeItemDragPreview` and `TreeItemDropIndicator` components are used internally and conditionally based on an `onMove` prop. Likely will need to rename this. I wanted to distance it from the `onDrop` event, since that’d have a different expected arguments.

## TODO

Brain dump for when I pick this up tomorrow…

- [ ] Drop indicators probably need to respect nesting design-wise.
- [ ] Maybe add a switch for using a custom native drag preview vs. the custom custom drag preview.
  - The former needs to be rendered differently.
- [ ] Likely use floating UI instead of a popover.

## Testing

Probably will make a dedicated test for this, but for now: `/tests/tree?draggable`.

Need to add the tree reordering function still. See the console for the logged data when dropped. Also, need to figure out an API for IDs. I think maybe it should be different than the `id` prop (for the DOM).