### PR TITLE
Merge `labelProps` and `removeButtonProps` of compat `Tag` component

### DIFF
--- a/apps/test-app/app/compat/tag.tsx
+++ b/apps/test-app/app/compat/tag.tsx
@@ -13,15 +13,31 @@ export default definePage(function Page() {
 		<div style={{ display: "flex", gap: 4 }}>
 			<Tag>Simple tag</Tag>
 			<Tag variant="basic">Basic tag</Tag>
-			<Tag onClick={(e) => console.log("onClick", e)}>With onClick</Tag>
-			<Tag onRemove={(e) => console.log("onRemove", e)}>With onRemove</Tag>
+			<Tag
+				onClick={(e) => console.log("onClick", e)}
+				labelProps={{ onClick: (e) => console.log("labelProps.onClick", e) }}
+			>
+				With onClick
+			</Tag>
+			<Tag
+				onRemove={(e) => console.log("onRemove", e)}
+				removeButtonProps={{
+					onClick: (e) => console.log("removeButtonProps.onClick", e),
+				}}
+			>
+				With onRemove
+			</Tag>
 			<Tag
 				onClick={(e) => console.log("onClick", e)}
 				labelProps={{
 					className: "my-label",
+					onClick: (e) => console.log("labelProps.onClick", e),
 				}}
 				onRemove={(e) => console.log("onRemove", e)}
-				removeButtonProps={{ className: "my-dismiss" }}
+				removeButtonProps={{
+					className: "my-dismiss",
+					onClick: (e) => console.log("removeButtonProps.onClick", e),
+				}}
 			>
 				With onClick and onRemove
 			</Tag>

--- a/packages/compat/src/Tag.tsx
+++ b/packages/compat/src/Tag.tsx
@@ -9,6 +9,7 @@ import { useCompatProps } from "./~utils.tsx";
 
 import type { Tag as IuiTag } from "@itwin/itwinui-react";
 import type { PolymorphicForwardRefComponent } from "./~utils.tsx";
+import { useEventHandlers } from "@stratakit/foundations/secret-internals";
 
 type IuiTagProps = React.ComponentProps<typeof IuiTag>;
 
@@ -39,17 +40,20 @@ export const Tag = React.forwardRef((props, forwardedRef) => {
 		...rest
 	} = useCompatProps(props);
 
+	const onDismissClick = useEventHandlers(removeButtonProps?.onClick, onRemove);
+	const onLabelClick = useEventHandlers(labelProps?.onClick, onClick);
+
 	if (onRemove) {
 		return (
 			<Chip.Root render={<span />} {...rest} ref={forwardedRef}>
 				<Chip.Label
 					render={onClick ? <button /> : undefined}
-					onClick={onClick}
 					{...labelProps}
+					onClick={onLabelClick}
 				>
 					{children}
 				</Chip.Label>
-				<Chip.DismissButton onClick={onRemove} {...removeButtonProps} />
+				<Chip.DismissButton {...removeButtonProps} onClick={onDismissClick} />
 			</Chip.Root>
 		);
 	}


### PR DESCRIPTION
This PR merges `labelProps.onClick` with `onClick` (when label is rendered as a button).
And `removeButtonProps.onClick` with `onRemove`.
Based on iTwinUI changes: https://github.com/iTwin/iTwinUI/pull/2570
Initial discussion: https://github.com/iTwin/design-system/pull/764#discussion_r2158767500