### PR TITLE
prepare compat package for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These are the packages of StrataKit:
 - [`@stratakit/icons`](./packages/icons/): A standalone SVG icon library.
 - [`@stratakit/bricks`](./packages/bricks/): Small, modular components that can be assembled to create larger, more functional experiences.
 - [`@stratakit/structures`](./packages/structures): Medium-sized component structures built on top of `@stratakit/bricks`.
-- [`@stratakit/react`](./packages/compat/): A React compatibility layer for using iTwinUI v3 APIs. (🚧 Not published)
+- [`@stratakit/react`](./packages/compat/): A React compatibility layer for using iTwinUI v3 APIs.
 
 > [!NOTE]
 > StrataKit packages are currently published as `0.X` versions. StrataKit follows [semantic versioning](https://semver.org/), and breaking changes will only be published in _minor_ version bumps. It is therefore safe to use the `^` syntax to specify version ranges in your `package.json`.

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -51,7 +51,8 @@
 				"../../packages/foundations:build",
 				"../../packages/bricks:build",
 				"../../packages/structures:build",
-				"../../packages/icons:build"
+				"../../packages/icons:build",
+				"../../packages/compat:build"
 			],
 			"files": [
 				"app",
@@ -72,7 +73,8 @@
 				"../../packages/icons:build",
 				"../../packages/foundations:dev",
 				"../../packages/bricks:dev",
-				"../../packages/structures:dev"
+				"../../packages/structures:dev",
+				"../../packages/compat:dev"
 			],
 			"service": true
 		},

--- a/packages/compat/CHANGELOG.md
+++ b/packages/compat/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+Initial release 🥳

--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -1,10 +1,34 @@
 # @stratakit/react
 
-A React compatibility layer for using iTwinUI v3 APIs.
+A React compatibility layer for StrataKit, matching [`@itwin/itwinui-react`](https://npmjs.com/package/@itwin/itwinui-react) v3 APIs.
+
+## Installation
+
+Using your package manager of choice, install the latest version of [`@stratakit/react`](https://www.npmjs.com/package/@stratakit/react?activeTab=versions).
 
 ```console
 npm add @stratakit/react
 ```
 
+## Usage
+
+`@stratakit/react` requires setting up the [`@stratakit/foundations` package](https://www.npmjs.com/package/@stratakit/foundations), either by itself or using the [theme bridge](https://github.com/iTwin/iTwinUI/wiki/StrataKit-theme-bridge). Once that's done, you can import and use any components from `@stratakit/react`.
+
+```jsx
+import { Button } from "@stratakit/react";
+
+function App() {
+	return <Button>Hello</Button>;
+}
+```
+
+For more details on using specific features, refer to the inline documentation available on every component and prop. Also see [iTwinUI documentation](https://itwinui.bentley.com/).
+
 > [!IMPORTANT]
-> 🚧 This package is in active development and has not been published yet.
+> `@stratakit/react` is a work-in-progress. Many iTwinUI features and APIs are currently missing.
+
+## Contributing
+
+Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/design-system/issues).
+
+If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/design-system/blob/main/CONTRIBUTING.md) for more information.

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,15 +1,21 @@
 {
 	"name": "@stratakit/react",
-	"private": true,
 	"type": "module",
-	"version": "0.1.0",
+	"version": "0.0.1",
 	"license": "MIT",
 	"sideEffects": false,
+	"types": "./dist/index.d.ts",
 	"exports": {
-		".": "./src/index.ts",
-		"./*": "./*"
+		".": {
+			"@stratakit/source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"development": "./dist/DEV/index.js",
+			"default": "./dist/index.js"
+		},
+		"./package.json": "./package.json"
 	},
 	"files": [
+		"dist",
 		"CHANGELOG.md",
 		"LICENSE.md"
 	],
@@ -34,7 +40,10 @@
 		"react",
 		"ui"
 	],
-	"scripts": {},
+	"scripts": {
+		"build": "wireit",
+		"dev": "wireit"
+	},
 	"dependencies": {
 		"@itwin/itwinui-react": "^3.18.3",
 		"@stratakit/bricks": "^0.3.0",
@@ -46,6 +55,7 @@
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",
+		"esbuild": "catalog:",
 		"react": "catalog:",
 		"react-dom": "catalog:",
 		"typescript": "catalog:"
@@ -54,5 +64,64 @@
 		"@stratakit/foundations": "^0.1.6",
 		"react": ">=18.0.0",
 		"react-dom": ">=18.0.0"
+	},
+	"wireit": {
+		"build": {
+			"dependencies": [
+				"../foundations:build",
+				"../bricks:build",
+				"../structures:build",
+				"build:js",
+				"build:DEV",
+				"build:types"
+			]
+		},
+		"build:js": {
+			"command": "node scripts/build.js",
+			"files": [
+				"src",
+				"scripts",
+				"../../internal"
+			],
+			"output": [
+				"dist/**/*.js",
+				"!dist/DEV"
+			]
+		},
+		"build:DEV": {
+			"command": "node scripts/build.js",
+			"files": [
+				"src",
+				"scripts",
+				"../../internal"
+			],
+			"output": [
+				"dist/DEV/**/*.js"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			}
+		},
+		"build:types": {
+			"command": "tsc --outDir dist",
+			"files": [
+				"src"
+			],
+			"output": [
+				"dist/**/*.d.ts"
+			],
+			"dependencies": [
+				"../foundations:build:types",
+				"../bricks:build:types",
+				"../structures:build:types"
+			]
+		},
+		"dev": {
+			"command": "tsc --watch --outDir dist",
+			"files": [
+				"src"
+			],
+			"service": true
+		}
 	}
 }

--- a/packages/compat/scripts/build.js
+++ b/packages/compat/scripts/build.js
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as esbuild from "esbuild";
+import fg from "fast-glob";
+
+const isDev = process.env.NODE_ENV === "development";
+
+const entryPoints = await fg("src/**/*.{ts,tsx}", {
+	onlyFiles: true,
+	ignore: ["**/*.d.ts"],
+});
+
+await esbuild.build({
+	entryPoints,
+	entryNames: "[dir]/[name]",
+	outbase: "src",
+	outdir: isDev ? "dist/DEV" : "dist",
+	bundle: false,
+	format: "esm",
+	jsx: "automatic",
+	target: "es2021",
+	...(!isDev && { dropLabels: ["DEV"] }),
+});

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -1,11 +1,10 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
-	"extends": "internal/tsconfig.json",
+	"extends": "internal/tsconfig.library.json",
 	"compilerOptions": {
-		"allowImportingTsExtensions": false,
 		"rootDir": "src",
 		"baseUrl": "."
 	},
 	"include": ["src"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "dist/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       "@types/react-dom":
         specifier: "catalog:"
         version: 19.1.6(@types/react@19.1.8)
+      esbuild:
+        specifier: "catalog:"
+        version: 0.25.5
       react:
         specifier: "catalog:"
         version: 19.1.0


### PR DESCRIPTION
Prepares the `@stratakit/react` package for publishing to npm.
- Added `build.js` script and updated `tsconfig.json` similar to other packages.
  - Note: This package does not have CSS so it does not need the `inlineCssPlugin`.
- Updated `package.json` fields, including `files`, `exports` and `wireit`.
  - Note: `"private": true` was removed.
- Updated `README.md` with basic documentation.

**Manual test**: Run `pnpm run build` and inspect the `dist` directory inside `packages/compat/`.

As soon as this PR is merged, ~~I believe `changesets` will automatically publish the package to npm.~~ I had to create another PR #813 to manually publish [`@stratakit/react@0.0.1`](https://www.npmjs.com/package/@stratakit/react). This is because `changesets` already has an open PR #776 which is blocking auto-publish.