### PR TITLE
move component styles into `@layer stratakit`

### DIFF
--- a/packages/bricks/src/styles.css
+++ b/packages/bricks/src/styles.css
@@ -3,28 +3,28 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-@import "./VisuallyHidden.css" layer(itwinui.components);
-@import "./~utils.Dot.css" layer(itwinui.components);
-@import "./~utils.GhostAligner.css" layer(itwinui.components);
+@import "./VisuallyHidden.css" layer(stratakit.components);
+@import "./~utils.Dot.css" layer(stratakit.components);
+@import "./~utils.GhostAligner.css" layer(stratakit.components);
 
-@import "./Anchor.css" layer(itwinui.components);
-@import "./Avatar.css" layer(itwinui.components);
-@import "./Badge.css" layer(itwinui.components);
-@import "./Button.css" layer(itwinui.components);
-@import "./Checkbox.css" layer(itwinui.components);
-@import "./Description.css" layer(itwinui.components);
-@import "./Divider.css" layer(itwinui.components);
-@import "./IconButton.css" layer(itwinui.components);
-@import "./Kbd.css" layer(itwinui.components);
-@import "./Label.css" layer(itwinui.components);
-@import "./Progress.css" layer(itwinui.components);
-@import "./Radio.css" layer(itwinui.components);
-@import "./Spinner.css" layer(itwinui.components);
-@import "./Select.css" layer(itwinui.components);
-@import "./Skeleton.css" layer(itwinui.components);
-@import "./Switch.css" layer(itwinui.components);
-@import "./Text.css" layer(itwinui.components);
-@import "./TextBox.css" layer(itwinui.components);
-@import "./Tooltip.css" layer(itwinui.components);
+@import "./Anchor.css" layer(stratakit.components);
+@import "./Avatar.css" layer(stratakit.components);
+@import "./Badge.css" layer(stratakit.components);
+@import "./Button.css" layer(stratakit.components);
+@import "./Checkbox.css" layer(stratakit.components);
+@import "./Description.css" layer(stratakit.components);
+@import "./Divider.css" layer(stratakit.components);
+@import "./IconButton.css" layer(stratakit.components);
+@import "./Kbd.css" layer(stratakit.components);
+@import "./Label.css" layer(stratakit.components);
+@import "./Progress.css" layer(stratakit.components);
+@import "./Radio.css" layer(stratakit.components);
+@import "./Spinner.css" layer(stratakit.components);
+@import "./Select.css" layer(stratakit.components);
+@import "./Skeleton.css" layer(stratakit.components);
+@import "./Switch.css" layer(stratakit.components);
+@import "./Text.css" layer(stratakit.components);
+@import "./TextBox.css" layer(stratakit.components);
+@import "./Tooltip.css" layer(stratakit.components);
 
-@import "./Field.css" layer(itwinui.components);
+@import "./Field.css" layer(stratakit.components);

--- a/packages/foundations/src/styles.css
+++ b/packages/foundations/src/styles.css
@@ -9,5 +9,5 @@
 @import "./~typography.css" layer(itwinui.foundations);
 @import "./~global.css" layer(itwinui.foundations);
 
-@import "./~sublayers.css" layer(itwinui.components);
-@import "./Icon.css" layer(itwinui.components);
+@import "./~sublayers.css" layer(stratakit.components);
+@import "./Icon.css" layer(stratakit.components);

--- a/packages/structures/src/styles.css
+++ b/packages/structures/src/styles.css
@@ -3,15 +3,15 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-@import "./~utils.ListItem.css" layer(itwinui.components);
+@import "./~utils.ListItem.css" layer(stratakit.components);
 
-@import "./AccordionItem.css" layer(itwinui.components);
-@import "./Banner.css" layer(itwinui.components);
-@import "./Chip.css" layer(itwinui.components);
-@import "./DropdownMenu.css" layer(itwinui.components);
-@import "./ErrorRegion.css" layer(itwinui.components);
-@import "./Table.css" layer(itwinui.components);
-@import "./Tabs.css" layer(itwinui.components);
-@import "./Toolbar.css" layer(itwinui.components);
-@import "./Tree.css" layer(itwinui.components);
-@import "./TreeItem.css" layer(itwinui.components);
+@import "./AccordionItem.css" layer(stratakit.components);
+@import "./Banner.css" layer(stratakit.components);
+@import "./Chip.css" layer(stratakit.components);
+@import "./DropdownMenu.css" layer(stratakit.components);
+@import "./ErrorRegion.css" layer(stratakit.components);
+@import "./Table.css" layer(stratakit.components);
+@import "./Tabs.css" layer(stratakit.components);
+@import "./Toolbar.css" layer(stratakit.components);
+@import "./Tree.css" layer(stratakit.components);
+@import "./TreeItem.css" layer(stratakit.components);


### PR DESCRIPTION
Follow-up to #375.

This PR moves all component styles into a new `@layer stratakit.components`, but the foundations remain in `@layer itwinui.foundations`.