### PR TITLE
fix Context usage for React 18

### DIFF
--- a/.changeset/real-ties-go.md
+++ b/.changeset/real-ties-go.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fixed an issue where Toolbar was using Context as a component which doesn't work in React 18.

--- a/packages/structures/src/Toolbar.tsx
+++ b/packages/structures/src/Toolbar.tsx
@@ -34,13 +34,15 @@ interface ToolbarProps extends BaseProps {
  */
 const ToolbarGroup = forwardRef<"div", ToolbarProps>((props, forwardedRef) => {
 	return (
-		<IconButtonContext value={React.useMemo(() => ({ iconSize: "large" }), [])}>
+		<IconButtonContext.Provider
+			value={React.useMemo(() => ({ iconSize: "large" }), [])}
+		>
 			<Toolbar.Toolbar
 				{...props}
 				className={cx("🥝-toolbar", props.className)}
 				ref={forwardedRef}
 			/>
-		</IconButtonContext>
+		</IconButtonContext.Provider>
 	);
 });
 DEV: ToolbarGroup.displayName = "Toolbar.Group";


### PR DESCRIPTION
This fixes Toolbar component not working in React 18.

Before this change, this (incorrect) warning is logged:

> Warning: Rendering <Context> directly is not supported and will be removed in a future major release. Did you mean to render <Context.Consumer> instead?

The actual issue is that `<Context>` support was only recently added in [React 19](https://react.dev/blog/2024/12/05/react-19#context-as-a-provider). For React 18, we need to use `<Context.Provider>`.