### PR TITLE
Github Actions: Update default milestone

### DIFF
--- a/.github/workflows/pr-milestone.js
+++ b/.github/workflows/pr-milestone.js
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 const MILESTONES = {
-	DEFAULT: "2025 Q2",
+	DEFAULT: "2025 Q3",
 	API_BRIDGE: "API bridge",
 };
 


### PR DESCRIPTION
This PR updates the Github Actions so that when automatically assigning milestones, the default milestone is now "2025 Q3" instead of "2025 Q2".

### Possible considerations:
- For automatically assigning labels in `pr-labels.js`, `compat/src/Button.tsx` is missing from the paths for `LABELS.BUTTON`