### PR TITLE
Fix "Running bespoke commands" docs in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ pnpm --filter=@stratakit/test-app run test -- button
 cd apps/test-app
 
 # run this from inside apps/test-app for the same result
-pnpm run test -- -- button
+pnpm run test -- button
 ```
 
 ---


### PR DESCRIPTION
Fixes the example commands listed in `CONTRIBUTING.md` that showed how to run tests only for a certain component. These example commands needed to be updated after #599 since `wireit` needs an extra `--` to pass arguments to the script instead of wireit.

After running the fixed commands from this PR, the below error doesn't happen anymore:

```
⚠️ Unrecognized Wireit argument(s): "button". To pass arguments to the script, use a double-dash, e.g. "npm run build -- --extra".
```