### PR TITLE
fix IconButtonPresentation hover state

### DIFF
--- a/packages/bricks/src/IconButton.internal.tsx
+++ b/packages/bricks/src/IconButton.internal.tsx
@@ -41,6 +41,7 @@ export const IconButtonPresentation = forwardRef<
 				{ "🥝-ghost-aligner": variant === "ghost" },
 				props.className,
 			)}
+			data-kiwi-tone="neutral"
 			data-kiwi-variant={variant}
 			data-kiwi-ghost-align={variant === "ghost" ? ghostAlignment : undefined}
 			ref={forwardedRef}


### PR DESCRIPTION
Fixes #840 by adding missing `data-kiwi-tone` attribute (now required after #836, whereas previously it was optional).