### PR TITLE
adjust file paths in PR workflows

### DIFF
--- a/.github/workflows/pr-labels.js
+++ b/.github/workflows/pr-labels.js
@@ -68,7 +68,10 @@ const LABEL_MAP = {
 		"packages/compat/src/Alert.tsx",
 	],
 	[LABELS.BREADCRUMB]: [],
-	[LABELS.BUTTON]: ["packages/bricks/src/Button"],
+	[LABELS.BUTTON]: [
+		"packages/bricks/src/Button",
+		"packages/compat/src/Button.tsx",
+	],
 	[LABELS.CARD]: [],
 	[LABELS.CHECKBOX]: [
 		"packages/bricks/src/Checkbox",
@@ -100,7 +103,10 @@ const LABEL_MAP = {
 		"packages/foundations/src/Icon",
 		"packages/compat/src/Icon.tsx",
 	],
-	[LABELS.ICON_BUTTON]: ["packages/bricks/src/IconButton"],
+	[LABELS.ICON_BUTTON]: [
+		"packages/bricks/src/IconButton",
+		"packages/compat/src/IconButton.tsx",
+	],
 	[LABELS.KBD]: ["packages/bricks/src/Kbd", "packages/compat/src/Kbd.tsx"],
 	[LABELS.LABEL]: [
 		"packages/bricks/src/Label",
@@ -136,7 +142,7 @@ const LABEL_MAP = {
 		"packages/structures/src/Tabs",
 		"packages/compat/src/Tabs.tsx",
 	],
-	[LABELS.TEXT]: ["packages/bricks/src/Text", "packages/compat/src/Text.tsx"],
+	[LABELS.TEXT]: ["packages/bricks/src/Text.", "packages/compat/src/Text.tsx"],
 	[LABELS.TEXT_BOX]: [
 		"packages/bricks/src/TextBox",
 		"packages/compat/src/Input.tsx",
@@ -154,7 +160,7 @@ const LABEL_MAP = {
 		"packages/structures/src/Tree",
 		"packages/structures/src/TreeItem",
 	],
-	[LABELS.API_BRIDGE]: ["packages/compat/"],
+	[LABELS.API_BRIDGE]: ["packages/compat/src"],
 	[LABELS.GITHUB_ACTIONS]: [".github/workflows"],
 };
 

--- a/.github/workflows/pr-milestone.js
+++ b/.github/workflows/pr-milestone.js
@@ -9,7 +9,7 @@ const MILESTONES = {
 
 const MILESTONE_MAP = {
 	[MILESTONES.DEFAULT]: "packages/",
-	[MILESTONES.API_BRIDGE]: "packages/compat/",
+	[MILESTONES.API_BRIDGE]: "packages/compat/src",
 };
 
 /**


### PR DESCRIPTION
Small changes to `pr-labels` and `pr-milestone` workflows:

- Added missing `compat/src/Button.tsx` and `compat/src/IconButton.tsx`.
- Appended `.` to `bricks/src/Text` to disambiguate from `TextBox`.
- Appended `src` to `packages/compat` to exclude `package.json`-only changes.