### PR TITLE
Adjust `reduced-motion` in `ProgressBar` & `Spinner`

### DIFF
--- a/.changeset/cruel-poems-beg.md
+++ b/.changeset/cruel-poems-beg.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Slowed down `reduced-motion` animation in `Spinner` and `ProgressBar`.

--- a/.changeset/witty-regions-design.md
+++ b/.changeset/witty-regions-design.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Fixed regression in `ProgressBar`'s `reduced-motion` animation.

--- a/packages/bricks/src/Progress.css
+++ b/packages/bricks/src/Progress.css
@@ -9,7 +9,7 @@
 	--✨easing: cubic-bezier(0.5, 0, 0.5, 1);
 	--✨steps: 4;
 
-	--✨animation--indeterminate-steps: calc(var(--✨steps) * var(--✨duration))
+	--✨animation--indeterminate-steps: calc(var(--✨steps) * var(--✨duration) * 2)
 		--🥝progress-bar-animation-indeterminate steps(var(--✨steps), end) infinite;
 	--✨animation--indeterminate: var(--✨duration) --🥝progress-bar-animation-indeterminate
 		var(--✨easing) var(--✨count);
@@ -28,8 +28,8 @@
 		&::before {
 			content: "";
 			block-size: inherit;
-			inline-size: 100%;
-			transform: translateX(calc(-100% + var(--🥝progress-bar-fill-size)));
+			inline-size: var(--🥝progress-bar-fill-size);
+			transform: translateX(calc(-100% + var(--🥝progress-bar-fill-portion-shown)));
 			border-radius: inherit;
 			background-color: var(--🥝progress-bar-fill-color);
 			animation: var(--🥝progress-bar-animation);
@@ -69,6 +69,10 @@
 				--🥝progress-bar-animation:
 					var(--✨animation--indeterminate), var(--✨animation--indeterminate-slow);
 			}
+		}
+
+		&:where([data-kiwi-variant="determinate"]) {
+			--🥝progress-bar-fill-size: 100%;
 		}
 	}
 }

--- a/packages/bricks/src/Progress.css
+++ b/packages/bricks/src/Progress.css
@@ -64,12 +64,12 @@
 		&:where([data-kiwi-variant="indeterminate"]) {
 			--🥝progress-bar-animation: var(--✨animation--indeterminate-steps);
 			--🥝progress-bar-fill-size: 25%;
-			--🥝progress-bar-fill-start-point: 0%;
+			--🥝progress-bar-fill-start-point: 0%; /* 0% keeps the fill in view. */
 
 			@media (prefers-reduced-motion: no-preference) {
 				--🥝progress-bar-animation:
 					var(--✨animation--indeterminate), var(--✨animation--indeterminate-slow);
-				--🥝progress-bar-fill-start-point: -100%;
+				--🥝progress-bar-fill-start-point: -100%; /* -100% moves the fill out of view on the left side. */
 			}
 		}
 
@@ -81,7 +81,7 @@
 
 @keyframes --🥝progress-bar-animation-indeterminate {
 	from {
-		transform: translateX(var(--🥝progress-bar-fill-start-point)); /* -100% moves the fill out of view on the left side. */
+		transform: translateX(var(--🥝progress-bar-fill-start-point));
 	}
 
 	to {

--- a/packages/bricks/src/Progress.css
+++ b/packages/bricks/src/Progress.css
@@ -64,10 +64,12 @@
 		&:where([data-kiwi-variant="indeterminate"]) {
 			--🥝progress-bar-animation: var(--✨animation--indeterminate-steps);
 			--🥝progress-bar-fill-size: 25%;
+			--🥝progress-bar-fill-start-point: 0%;
 
 			@media (prefers-reduced-motion: no-preference) {
 				--🥝progress-bar-animation:
 					var(--✨animation--indeterminate), var(--✨animation--indeterminate-slow);
+				--🥝progress-bar-fill-start-point: -100%;
 			}
 		}
 
@@ -79,7 +81,7 @@
 
 @keyframes --🥝progress-bar-animation-indeterminate {
 	from {
-		transform: translateX(-100%); /* -100% moves the fill out of view on the left side. */
+		transform: translateX(var(--🥝progress-bar-fill-start-point)); /* -100% moves the fill out of view on the left side. */
 	}
 
 	to {

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -81,7 +81,7 @@ const ProgressBar = forwardRef<"div", ProgressBarProps>(
 			return value != null
 				? {
 						...styleProp,
-						"--🥝progress-bar-fill-size": `${value}%`,
+						"--🥝progress-bar-fill-portion-shown": `${value}%`,
 					}
 				: styleProp;
 		}, [styleProp, value]);

--- a/packages/bricks/src/Spinner.css
+++ b/packages/bricks/src/Spinner.css
@@ -46,7 +46,7 @@
 			--🥝spinner-animation: var(--✨animation--indeterminate);
 			--🥝spinner-animation-duration: var(--✨duration);
 			--🥝spinner-dash-array: 25 75;
-			
+
 			@media (prefers-reduced-motion) {
 				--🥝spinner-animation-duration: var(--✨duration-slow);
 			}

--- a/packages/bricks/src/Spinner.css
+++ b/packages/bricks/src/Spinner.css
@@ -8,7 +8,7 @@
 	--✨easing: linear;
 	--✨steps: 4;
 
-	--✨animation--indeterminate-steps: calc(var(--✨steps) * var(--✨duration))
+	--✨animation--indeterminate-steps: calc(var(--✨steps) * var(--✨duration) * 2)
 		--🥝spinner-animation-indeterminate steps(var(--✨steps), end) infinite;
 	--✨animation--indeterminate: var(--✨duration) --🥝spinner-animation-indeterminate
 		var(--✨easing) infinite;

--- a/packages/bricks/src/Spinner.css
+++ b/packages/bricks/src/Spinner.css
@@ -5,13 +5,9 @@
 
 .🥝-spinner {
 	--✨duration: 1s;
-	--✨easing: linear;
-	--✨steps: 4;
+	--✨duration-slow: 2s;
 
-	--✨animation--indeterminate-steps: calc(var(--✨steps) * var(--✨duration) * 2)
-		--🥝spinner-animation-indeterminate steps(var(--✨steps), end) infinite;
-	--✨animation--indeterminate: var(--✨duration) --🥝spinner-animation-indeterminate
-		var(--✨easing) infinite;
+	--✨animation--indeterminate: --🥝spinner-animation-indeterminate linear infinite;
 
 	@layer base {
 		display: inline-block;
@@ -47,11 +43,12 @@
 		}
 
 		&:where([data-kiwi-variant="indeterminate"]) {
-			--🥝spinner-animation: var(--✨animation--indeterminate-steps);
+			--🥝spinner-animation: var(--✨animation--indeterminate);
+			--🥝spinner-animation-duration: var(--✨duration);
 			--🥝spinner-dash-array: 25 75;
-
-			@media (prefers-reduced-motion: no-preference) {
-				--🥝spinner-animation: var(--✨animation--indeterminate);
+			
+			@media (prefers-reduced-motion) {
+				--🥝spinner-animation-duration: var(--✨duration-slow);
 			}
 		}
 	}
@@ -71,6 +68,7 @@
 
 .🥝-spinner-svg-fill {
 	animation: var(--🥝spinner-animation);
+	animation-duration: var(--🥝spinner-animation-duration);
 	stroke: var(--🥝spinner-fill-color);
 	stroke-dasharray: var(--🥝spinner-dash-array);
 	stroke-dashoffset: 25;


### PR DESCRIPTION
- Double the `reduced-motion`'s animation `--✨duration` for both `<ProgressBar />` and `<Spinner />`.
- `<ProgressBar />` continues to use steps, `<Spinner />` does not because https://github.com/iTwin/design-system/pull/866#discussion_r2228834019.
- There was a regression in #614 `<ProgressBar />`'s `reduced-motion` animation.
  - Renamed `--🥝progress-bar-fill-size` to `--🥝progress-bar-fill-portion-shown`.
  - Added new `--🥝progress-bar-fill-size`.
- Updated `<ProgressBar />`'s animation so the fill is always visible by introducing `--🥝progress-bar-fill-start-point`.

| Before regression | After regression |
| --- | --- |
| ![progress-bar-reduced-motion-before](https://github.com/user-attachments/assets/e36aaebd-c3d7-4d92-9b01-12d479b50252) | ![progress-bar-reduced-motion-after](https://github.com/user-attachments/assets/0720c189-701e-41a8-9ae8-1afae075209d) |

Closes #609.