### PR TITLE
fix Context usage for React 18

### DIFF
--- a/.changeset/ninety-worms-invent.md
+++ b/.changeset/ninety-worms-invent.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fixed an issue where `Tree` was using Context as a component which doesn't work in React 18.

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -294,7 +294,7 @@ function TreeItemRootProvider(props: TreeItemRootProviderProps) {
 		<TreeItemErrorContext.Provider value={error}>
 			<TreeItemInlineActionsContext.Provider value={inlineActions}>
 				<TreeItemActionsContext.Provider value={actions}>
-					<TreeItemDisplayActionsMenuContext
+					<TreeItemDisplayActionsMenuContext.Provider
 						value={actions ? actions.length > 0 : false}
 					>
 						<TreeItemDecorationIdContext.Provider
@@ -316,7 +316,7 @@ function TreeItemRootProvider(props: TreeItemRootProviderProps) {
 								</TreeItemIconContext.Provider>
 							</TreeItemDecorationsContext.Provider>
 						</TreeItemDecorationIdContext.Provider>
-					</TreeItemDisplayActionsMenuContext>
+					</TreeItemDisplayActionsMenuContext.Provider>
 				</TreeItemActionsContext.Provider>
 			</TreeItemInlineActionsContext.Provider>
 		</TreeItemErrorContext.Provider>


### PR DESCRIPTION
This is the same as #815 but within `TreeItemRootProvider`.

We'll probably need a lint rule or something, but I'm hoping to release this fix quickly.