### PR TITLE
remove end indentation from `AccordionItem.Content`

### DIFF
--- a/.changeset/green-otters-guess.md
+++ b/.changeset/green-otters-guess.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fixed an issue where `AccordionItem.Content` was being offset by decorations placed at the end of `AccordionItem.Header`. The content will now only include start indentation, and correctly stretch all the way up to the right edge.

--- a/packages/structures/src/AccordionItem.css
+++ b/packages/structures/src/AccordionItem.css
@@ -14,9 +14,9 @@
 		grid-template-columns:
 			[marker-before-start] auto [marker-before-end
 			decoration-before-start] auto [decoration-before-end
-			content-start] minmax(0, 1fr) [content-end
+			header-content-start body-content-start] minmax(0, 1fr) [header-content-end
 			decoration-after-start] auto [decoration-after-end
-			marker-after-start] auto [marker-after-end];
+			marker-after-start] auto [marker-after-end body-content-end];
 		grid-template-rows: [header-start] auto [header-end content-start] auto [content-end];
 		border-block-end: 1px solid var(--stratakit-color-border-neutral-muted);
 	}
@@ -109,7 +109,7 @@
 
 .🥝-accordion-item-button {
 	@layer base {
-		grid-column: content;
+		grid-column: header-content;
 		cursor: pointer;
 		border-radius: 12px;
 		--🥝focus-outline-offset: -4px;
@@ -137,7 +137,7 @@
 .🥝-accordion-item-content {
 	@layer base {
 		grid-row: content;
-		grid-column: content;
+		grid-column: body-content;
 		padding-block: var(--🥝accordion-item-padding);
 		text-box: cap alphabetic;
 		color: var(--stratakit-color-text-neutral-secondary);
@@ -162,7 +162,7 @@
 
 .🥝-accordion-item-heading {
 	@layer base {
-		grid-column: content;
+		grid-column: header-content;
 		margin-block: 0;
 		text-box: cap alphabetic;
 	}


### PR DESCRIPTION
Fixes #867. See https://github.com/iTwin/design-system/issues/867#issuecomment-3113579705.

<img height="200" alt="Screenshot highlighting the accordion-item content hugging the right edge when there are multiple decorations at the end of the header." src="https://github.com/user-attachments/assets/9613e04b-dfb1-443a-bcb6-b477364965ab" />

To distinguish between header and body content, I've split the `content` column into `header-content` and `body-content`. Only the latter hugs the right edge.