### PR TITLE
rework `Tabs` animation using FLIP technique

### DIFF
--- a/.changeset/neat-clouds-behave.md
+++ b/.changeset/neat-clouds-behave.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Improved the `Tabs` active stripe animation to make it smoother and more performant.

--- a/packages/structures/src/Tabs.css
+++ b/packages/structures/src/Tabs.css
@@ -23,12 +23,7 @@
 				inline-size: calc(anchor-size(inline) - 2 * var(--🥝tab-padding-inline));
 				block-size: var(--🥝tab-active-stripe-size);
 				background-color: var(--🥝tab-active-stripe-color);
-
-				@media (prefers-reduced-motion: no-preference) {
-					transition:
-						inset-inline-start 150ms ease-in-out,
-						inline-size 150ms ease-in-out;
-				}
+				will-change: transform;
 			}
 		}
 	}

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -82,15 +82,15 @@ function Tabs(props: TabsProps) {
 		// Bail if anchor positioning is not supported because the pseudo-element does not exist.
 		if (!supportsAnchorPositioning) return;
 
-		const ownerDocument = tablist?.ownerDocument;
-		if (!ownerDocument || !selectedIdFromStore || !newSelectedId) return;
+		const rootNode = tablist?.getRootNode() as Document | ShadowRoot;
+		if (!rootNode || !selectedIdFromStore || !newSelectedId) return;
 
 		// Read layout of the previous ("First") and next ("Last") tabs
-		const previousTabRect = ownerDocument
-			.getElementById(selectedIdFromStore)
+		const previousTabRect = rootNode
+			.getElementById?.(selectedIdFromStore)
 			?.getBoundingClientRect();
-		const nextTabRect = ownerDocument
-			.getElementById(newSelectedId)
+		const nextTabRect = rootNode
+			.getElementById?.(newSelectedId)
 			?.getBoundingClientRect();
 
 		if (!previousTabRect || !nextTabRect) return;
@@ -100,7 +100,7 @@ function Tabs(props: TabsProps) {
 		const deltaWidth = previousTabRect.width / nextTabRect.width;
 
 		// Animate the active stripe pseudo-element's `transform` property. ("Play")
-		tablist.animate(
+		tablist?.animate(
 			[
 				{ transform: `translateX(${deltaX}px) scaleX(${deltaWidth})` },
 				{ transform: "none" },


### PR DESCRIPTION
> [!NOTE]
> This is a replay of #838.

This PR replaces the CSS-based `transition` for Tab's active stripe (added in #464) with the [FLIP technique](https://css-tricks.com/animating-layouts-with-the-flip-technique/) (using [WAAPI](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)). No changes in `Tree` (complements #829).

Instead of animating `inset` and `inline-size`, we are now animating `transform`, which results in a much smoother animation, especially on lower end devices.

When not actively animating, we continue to rely on CSS anchor positioning.

### Background

This effort started as part of #759, which was partially addressed by #829 — the rendering performance of `Tree` was greatly improved, but the animation remained janky at times. This is mainly because CSS anchor positioning does not support `transform` which is [essential](https://web.dev/articles/stick-to-compositor-only-properties-and-manage-layer-count) for smooth, hardware-accelerated animation.

### Preview

https://itwin.github.io/design-system/838/sandbox

<details>
<summary>Screen recordings</summary>

No throttling:

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/caee8760-9ce0-499c-95c5-8d7e6d5b349a"> | <video src="https://github.com/user-attachments/assets/146c590f-1814-4eb4-bb62-86138e694a86"> |

20x CPU slowdown:

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a42464cf-d983-4791-8df9-6816ec6c7eb7"> | <video src="https://github.com/user-attachments/assets/0d256120-33fb-4d6f-98a8-f7cbee79f665"> |


Note: There is a bit (~500ms) of delay noticed with 20x slowdown. This is the time it takes to render the panel content. The animation remains smooth regardless of this delay.

</details>