### PR TITLE
Use `spacing` variables

### DIFF
--- a/.changeset/every-rocks-laugh.md
+++ b/.changeset/every-rocks-laugh.md
@@ -3,4 +3,6 @@
 "@stratakit/bricks": patch
 ---
 
-Use `space` variables instead of hardcoded values in all bricks, structures, and demo pages.
+- Use `space` variables instead of hardcoded values in all components.
+- In `Tooltip`, replace hardcoded `rem` spacing values with new `space` variables.
+- In `Anchor`, change hover state's `text-underline-offset` from `3px` to `4px`.

--- a/.changeset/every-rocks-laugh.md
+++ b/.changeset/every-rocks-laugh.md
@@ -1,0 +1,6 @@
+---
+"@stratakit/structures": patch
+"@stratakit/bricks": patch
+---
+
+Use `space` variables instead of hardcoded values in all bricks, structures, and demo pages.

--- a/.changeset/witty-ravens-punch.md
+++ b/.changeset/witty-ravens-punch.md
@@ -1,5 +1,0 @@
----
-"@stratakit/bricks": patch
----
-
-In `Tooltip`, replace hardcoded `rem` spacing values with new `space` variables.

--- a/apps/test-app/app/compat/compat.module.css
+++ b/apps/test-app/app/compat/compat.module.css
@@ -3,5 +3,5 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .main {
-	padding: 2rem;
+	padding: var(--stratakit-space-x8);
 }

--- a/apps/test-app/app/icons.css
+++ b/apps/test-app/app/icons.css
@@ -3,5 +3,5 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 body {
-	padding: 1rem;
+	padding: var(--stratakit-space-x4);
 }

--- a/apps/test-app/app/index.module.css
+++ b/apps/test-app/app/index.module.css
@@ -3,11 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .main {
-	padding: 2rem;
+	padding: var(--stratakit-space-x8);
 }
 
 .list {
-	padding-block: 0.5rem;
+	padding-block: var(--stratakit-space-x2);
 	list-style-type: "";
 }
 
@@ -15,10 +15,10 @@
 	border-block-end: 1px solid var(--stratakit-color-border-neutral-base);
 
 	> * {
-		margin-block-end: 0.5rem;
+		margin-block-end: var(--stratakit-space-x2);
 	}
 }
 
 .h2 {
-	margin-block-start: 1rem;
+	margin-block-start: var(--stratakit-space-x4);
 }

--- a/apps/test-app/app/sandbox/index.module.css
+++ b/apps/test-app/app/sandbox/index.module.css
@@ -125,7 +125,7 @@
 	justify-content: center;
 	flex-direction: column;
 	block-size: 100%;
-	gap: 0.5rem;
+	gap: var(--stratakit-space-x2);
 }
 
 .skeletonTree {

--- a/apps/test-app/app/sandbox/index.module.css
+++ b/apps/test-app/app/sandbox/index.module.css
@@ -140,7 +140,12 @@
 	align-items: center;
 	gap: var(--stratakit-space-x2);
 	width: 100%;
-	padding-inline-start: calc(var(--stratakit-space-x3) + 6px * (var(--level) - 1)); /* TODO: What to do about 6px? */
+	padding-inline-start: calc(
+		var(--stratakit-space-x3) +
+		var(--stratakit-space-x1) +
+		var(--stratakit-space-x05) *
+		(var(--level) - 1)
+	);
 	padding-inline-end: var(--stratakit-space-x2);
 }
 

--- a/apps/test-app/app/sandbox/index.module.css
+++ b/apps/test-app/app/sandbox/index.module.css
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .appLayout {
-	--_platformBar-width: var(--stratakit-space-x10);
-	--_splitter-width: var(--stratakit-space-x3);
+	--_platformBar-width: 40px;
+	--_splitter-width: 12px;
 
 	block-size: 100dvb;
 	display: grid;
@@ -16,7 +16,7 @@
 }
 
 .header {
-	--_header-height: var(--stratakit-space-x10);
+	--_header-height: 40px;
 	grid-area: header;
 	background-color: var(--stratakit-color-bg-page-base);
 	border-block-end: 1px solid var(--stratakit-color-border-neutral-base);
@@ -193,7 +193,7 @@
 	&::before {
 		content: "";
 		position: absolute;
-		inline-size: var(--stratakit-space-x05);
+		inline-size: 2px;
 		inset-inline-start: calc(var(--_splitter-width) / 2);
 		inset-block: 0;
 		background-color: var(--_bg);

--- a/apps/test-app/app/sandbox/index.module.css
+++ b/apps/test-app/app/sandbox/index.module.css
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .appLayout {
-	--_platformBar-width: 40px;
-	--_splitter-width: 12px;
+	--_platformBar-width: var(--stratakit-space-x10);
+	--_splitter-width: var(--stratakit-space-x3);
 
 	block-size: 100dvb;
 	display: grid;
@@ -16,7 +16,7 @@
 }
 
 .header {
-	--_header-height: 40px;
+	--_header-height: var(--stratakit-space-x10);
 	grid-area: header;
 	background-color: var(--stratakit-color-bg-page-base);
 	border-block-end: 1px solid var(--stratakit-color-border-neutral-base);
@@ -24,8 +24,8 @@
 	min-block-size: var(--_header-height);
 	display: flex;
 	align-items: center;
-	gap: 12px;
-	padding-inline: 12px;
+	gap: var(--stratakit-space-x3);
+	padding-inline: var(--stratakit-space-x3);
 }
 
 .platformBar {
@@ -46,13 +46,13 @@
 }
 
 .tools {
-	padding-block: 12px;
+	padding-block: var(--stratakit-space-x3);
 
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 12px;
+	gap: var(--stratakit-space-x3);
 }
 
 .content {
@@ -60,26 +60,26 @@
 }
 
 .leftPanel {
-	padding-block-start: 12px;
+	padding-block-start: var(--stratakit-space-x3);
 	background-color: var(--stratakit-color-bg-page-base);
 	min-block-size: 0;
 
 	contain: size layout; /* prevent unnecessary overflow */
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: var(--stratakit-space-x3);
 }
 
 .panelHeader {
 	display: flex;
-	padding-inline: 12px;
+	padding-inline: var(--stratakit-space-x3);
 	justify-content: space-between;
 
 	font-size: var(--stratakit-font-size-12);
 }
 
 .panelTitleWrapper {
-	margin-inline-start: -8px;
+	margin-inline-start: calc(var(--stratakit-space-x2) * -1);
 }
 
 .panelCaption {
@@ -87,17 +87,17 @@
 }
 
 .shiftIconRight {
-	margin-inline-end: -4px;
+	margin-inline-end: calc(var(--stratakit-space-x1) * -1);
 }
 
 .subheader {
 	min-block-size: 2.5rem;
-	padding-inline: 12px;
+	padding-inline: var(--stratakit-space-x3);
 	border-block: 1px solid var(--stratakit-color-border-neutral-base);
 	border-inline: none;
 
 	display: flex;
-	gap: 4px;
+	gap: var(--stratakit-space-x1);
 	align-items: center;
 }
 
@@ -131,22 +131,22 @@
 .skeletonTree {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: var(--stratakit-space-x2);
 	overflow: auto;
 }
 
 .skeletonTreeItem {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: var(--stratakit-space-x2);
 	width: 100%;
-	padding-inline-start: calc(12px + 6px * (var(--level) - 1));
-	padding-inline-end: 8px;
+	padding-inline-start: calc(var(--stratakit-space-x3) + 6px * (var(--level) - 1)); /* TODO: What to do about 6px? */
+	padding-inline-end: var(--stratakit-space-x2);
 }
 
 .canvasWrapper {
-	padding-block: 8px;
-	padding-inline-end: 8px;
+	padding-block: var(--stratakit-space-x2);
+	padding-inline-end: var(--stratakit-space-x2);
 }
 
 .canvas {
@@ -155,7 +155,7 @@
 	box-shadow: var(--stratakit-shadow-surface-xl);
 	border: 1px solid var(--stratakit-color-border-neutral-muted);
 	position: relative;
-	padding: 8px;
+	padding: var(--stratakit-space-x2);
 
 	&::before {
 		content: "";
@@ -188,7 +188,7 @@
 	&::before {
 		content: "";
 		position: absolute;
-		inline-size: 2px;
+		inline-size: var(--stratakit-space-x05);
 		inset-inline-start: calc(var(--_splitter-width) / 2);
 		inset-block: 0;
 		background-color: var(--_bg);
@@ -203,14 +203,14 @@
 	}
 
 	&:focus-visible {
-		outline-offset: -2px;
+		outline-offset: calc(var(--stratakit-space-x05) * -1);
 	}
 }
 
 .tabPanel {
 	min-block-size: 0;
 	flex-grow: 1;
-	padding-block-end: 12px;
+	padding-block-end: var(--stratakit-space-x3);
 
 	display: flex;
 	flex-direction: column;

--- a/apps/test-app/app/tests/tests.module.css
+++ b/apps/test-app/app/tests/tests.module.css
@@ -10,7 +10,7 @@
 }
 
 .main {
-	padding: 1rem;
+	padding: var(--stratakit-space-x4);
 	flex: 999;
 	min-inline-size: 50%; /* never less than half the screen */
 }

--- a/apps/test-app/app/tests/tests.module.css
+++ b/apps/test-app/app/tests/tests.module.css
@@ -5,7 +5,7 @@
 .page {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 16px;
+	gap: var(--stratakit-space-x4);
 	container-type: inline-size;
 }
 

--- a/apps/test-app/app/tokens.css
+++ b/apps/test-app/app/tokens.css
@@ -8,9 +8,9 @@ html {
 }
 
 body {
-	padding: 1rem;
+	padding: var(--stratakit-space-x4);
 }
 
 h2 {
-	margin-block-start: 1rem;
+	margin-block-start: var(--stratakit-space-x4);
 }

--- a/apps/test-app/app/~utils.module.css
+++ b/apps/test-app/app/~utils.module.css
@@ -22,7 +22,7 @@
 	min-block-size: 2rem;
 	position: relative;
 	border-radius: 4px;
-	padding-inline-start: calc(8px + 1rem); /* 8px padding + 1rem back icon size */
+	padding-inline-start: calc(var(--stratakit-space-x2) + 1rem); /* 8px padding + 1rem back icon size */
 
 	/* Outline listItem when the listItemLink has focus */
 	&:has(.listItemLink:focus-visible) {

--- a/apps/test-app/app/~utils.module.css
+++ b/apps/test-app/app/~utils.module.css
@@ -5,7 +5,7 @@
 
 .list {
 	position: relative;
-	--indent-guide-left-inset: calc(4px + 0.5rem); /* 4px button left padding + 1/2 of SVG icon size */
+	--indent-guide-left-inset: calc(var(--stratakit-space-x1) + 0.5rem); /* 4px button left padding + 1/2 of SVG icon size */
 
 	/* Indent guide */
 	&::before {
@@ -80,10 +80,10 @@
 	background-color: var(--stratakit-color-bg-page-depth);
 	min-inline-size: min(100vi, 256px);
 	overflow: auto;
-	padding: 8px;
+	padding: var(--stratakit-space-x2);
 	display: flex;
 	flex-direction: column;
-	row-gap: 8px;
+	row-gap: var(--stratakit-space-x2);
 	border-inline-start: 1px solid var(--stratakit-color-border-neutral-muted);
 	border-block-start: 1px solid var(--stratakit-color-border-neutral-muted);
 

--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -32,8 +32,8 @@
 		cursor: pointer;
 		font-size: var(--stratakit-font-size-12);
 		font-weight: 500;
-		text-underline-offset: var(--🌀anchor-state--default, 2px) var(--🌀anchor-state--hover, 3px)
-			var(--🌀anchor-state--pressed, 3px);
+		text-underline-offset: var(--🌀anchor-state--default, var(--stratakit-space-x05))
+			var(--🌀anchor-state--hover, 3px) var(--🌀anchor-state--pressed, 3px); /* TODO: What to do about 3px? */
 		text-decoration-color: var(--🌀anchor-state--default, currentColor)
 			var(--🌀anchor-state--hover, currentColor) var(--🌀anchor-state--pressed, transparent);
 		text-decoration-line: underline;
@@ -79,7 +79,7 @@
 		}
 
 		&:where(:focus-visible) {
-			--🥝focus-outline-offset: 2px;
+			--🥝focus-outline-offset: var(--stratakit-space-x05);
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {

--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -33,7 +33,8 @@
 		font-size: var(--stratakit-font-size-12);
 		font-weight: 500;
 		text-underline-offset: var(--🌀anchor-state--default, var(--stratakit-space-x05))
-			var(--🌀anchor-state--hover, 3px) var(--🌀anchor-state--pressed, 3px); /* TODO: What to do about 3px? */
+			var(--🌀anchor-state--hover, var(--stratakit-space-x1))
+			var(--🌀anchor-state--pressed, var(--stratakit-space-x1));
 		text-decoration-color: var(--🌀anchor-state--default, currentColor)
 			var(--🌀anchor-state--hover, currentColor) var(--🌀anchor-state--pressed, transparent);
 		text-decoration-line: underline;

--- a/packages/bricks/src/Badge.css
+++ b/packages/bricks/src/Badge.css
@@ -17,7 +17,7 @@
 		color: var(--🥝badge-text-color);
 		font-weight: 500;
 		block-size: 1.25rem;
-		padding-inline: 8px;
+		padding-inline: var(--stratakit-space-x2);
 
 		@media (forced-colors: active) {
 			border: 1px solid;

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝-button {
 	--✨color--default: var(--stratakit-color-text-neutral-primary);
-	--✨gap: 4px;
+	--✨gap: var(--stratakit-space-x1);
 	--✨height: 1.5rem;
-	--✨padding-inline: 12px;
-	--✨padding-block: 4px;
+	--✨padding-inline: var(--stratakit-space-x3);
+	--✨padding-block: var(--stratakit-space-x1);
 
 	--✨shadow-border: 0px 0px 0px 1px var(--🥝button-border-color) inset;
 

--- a/packages/bricks/src/Checkbox.css
+++ b/packages/bricks/src/Checkbox.css
@@ -81,7 +81,7 @@
 
 		/* This pseudo-element increases tap target size to 24x24 */
 		&::before {
-			inset: calc((var(--✨size) - 24px) / 2);
+			inset: calc((var(--✨size) - var(--stratakit-space-x6)) / 2);
 		}
 
 		/* This pseudo-element adds the actual checkmark SVG via --🥝checkbox-mask-image */

--- a/packages/bricks/src/Field.css
+++ b/packages/bricks/src/Field.css
@@ -9,7 +9,7 @@
 
 	@layer base {
 		display: grid;
-		gap: 4px; /* space/x1 */
+		gap: var(--stratakit-space-x1);
 		align-items: center;
 		justify-content: start;
 

--- a/packages/bricks/src/IconButton.css
+++ b/packages/bricks/src/IconButton.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .🥝-icon-button:is(.🥝-button) {
-	--✨padding-inline: 4px;
+	--✨padding-inline: var(--stratakit-space-x1);
 
 	@layer base {
 		aspect-ratio: 1;
@@ -15,8 +15,8 @@
 .🥝-icon-button-dot:is(.🥝-dot) {
 	@layer base {
 		position: absolute;
-		inset-block-start: 2px;
-		inset-inline-end: 2px;
+		inset-block-start: var(--stratakit-space-x05);
+		inset-inline-end: var(--stratakit-space-x05);
 	}
 }
 

--- a/packages/bricks/src/Kbd.css
+++ b/packages/bricks/src/Kbd.css
@@ -13,18 +13,18 @@
 		color: var(--stratakit-color-text-neutral-secondary);
 
 		display: inline-flex;
-		column-gap: 4px;
+		column-gap: var(--stratakit-space-x1);
 		align-items: center;
 		justify-content: center;
 		flex-shrink: 0;
-		min-block-size: 16px;
+		min-block-size: var(--stratakit-space-x4);
 	}
 
 	@layer modifiers {
 		&:where([data-kiwi-variant="solid"], [data-kiwi-variant="muted"]) {
 			border-radius: 4px;
 			background-color: var(--stratakit-color-bg-neutral-base);
-			padding-inline: 4px;
+			padding-inline: var(--stratakit-space-x1);
 		}
 
 		&:where([data-kiwi-variant="solid"]) {

--- a/packages/bricks/src/Select.css
+++ b/packages/bricks/src/Select.css
@@ -19,15 +19,10 @@
 .🥝-select:is(.🥝-button) {
 	--✨padding-inline-start: var(--stratakit-space-x2);
 	--✨padding-inline-end: calc(
-		var(--stratakit-space-x1) +
-		var(--stratakit-space-x4) +
-		var(--stratakit-space-x1)
+		var(--stratakit-space-x1) /* Gap */ +
+		var(--stratakit-space-x4) /* Arrow size */ +
+		var(--stratakit-space-x1) /* Padding - disclosure arrow offset */
 	);
-	/* padding-inline-end:
-	(gap) +
-	(arrow size) +
-	(padding-inline - disclosure arrow offset)
-	*/
 
 	@layer base {
 		min-inline-size: calc(var(--✨padding-inline-start) + 1ch + var(--✨padding-inline-end));

--- a/packages/bricks/src/Select.css
+++ b/packages/bricks/src/Select.css
@@ -22,7 +22,12 @@
 		var(--stratakit-space-x1) +
 		var(--stratakit-space-x4) +
 		var(--stratakit-space-x1)
-	); /* (gap) + (arrow size) + (padding-inline - disclosure arrow offset) */
+	);
+	/* padding-inline-end:
+	(gap) +
+	(arrow size) +
+	(padding-inline - disclosure arrow offset)
+	*/
 
 	@layer base {
 		min-inline-size: calc(var(--✨padding-inline-start) + 1ch + var(--✨padding-inline-end));

--- a/packages/bricks/src/Select.css
+++ b/packages/bricks/src/Select.css
@@ -17,8 +17,12 @@
 }
 
 .🥝-select:is(.🥝-button) {
-	--✨padding-inline-start: 8px;
-	--✨padding-inline-end: calc(4px + 16px + 4px); /* (gap) + (arrow size) + (padding-inline - disclosure arrow offset) */
+	--✨padding-inline-start: var(--stratakit-space-x2);
+	--✨padding-inline-end: calc(
+		var(--stratakit-space-x1) +
+		var(--stratakit-space-x4) +
+		var(--stratakit-space-x1)
+	); /* (gap) + (arrow size) + (padding-inline - disclosure arrow offset) */
 
 	@layer base {
 		min-inline-size: calc(var(--✨padding-inline-start) + 1ch + var(--✨padding-inline-end));
@@ -39,7 +43,7 @@
 .🥝-select-arrow:is(.🥝-disclosure-arrow) {
 	@layer base {
 		justify-self: end;
-		margin-inline-end: 4px; /* (padding - disclosure offset) */
+		margin-inline-end: var(--stratakit-space-x1); /* (padding - disclosure offset) */
 		pointer-events: none;
 		z-index: 1; /* should be above the button */
 

--- a/packages/bricks/src/Switch.css
+++ b/packages/bricks/src/Switch.css
@@ -81,7 +81,7 @@
 		&::before {
 			position: absolute;
 			inline-size: var(--✨width);
-			block-size: 24px;
+			block-size: var(--stratakit-space-x6);
 			margin: -1px; /* account for border */
 		}
 
@@ -89,7 +89,7 @@
 		&::after {
 			block-size: var(--✨thumb-size);
 			inline-size: var(--✨thumb-size);
-			margin: calc(0.125rem - 1px) /* spacing-2 - 1px to account for border */;
+			margin: calc(0.125rem - 1px) /* sizing-2 - 1px to account for border */;
 			background-color: var(--🥝switch-thumb-color);
 			box-shadow:
 				var(--stratakit-shadow-button-base-inset), var(--✨shadow-border),

--- a/packages/bricks/src/TextBox.css
+++ b/packages/bricks/src/TextBox.css
@@ -22,10 +22,10 @@
 	--✨color--placeholder: var(--stratakit-color-text-neutral-secondary);
 	--✨color--disabled: var(--stratakit-color-text-neutral-disabled);
 	--✨height: 1.5rem;
-	--✨padding-inline: 8px;
+	--✨padding-inline: var(--stratakit-space-x2);
 	/* Dynamically adjust the padding to avoid issues with baseline alignment */
-	--✨padding-block: max(0px, (var(--✨height) - 2px - 1lh) / 2);
-	--✨gap: 4px;
+	--✨padding-block: max(0px, (var(--✨height) - var(--stratakit-space-x05) - 1lh) / 2);
+	--✨gap: var(--stratakit-space-x1);
 
 	@layer base {
 		cursor: var(--🥝text-box-cursor);

--- a/packages/foundations/src/Icon.css
+++ b/packages/foundations/src/Icon.css
@@ -24,7 +24,7 @@
 
 .🥝-disclosure-arrow {
 	@layer base {
-		margin-inline-end: -8px; /* space/x2 */
+		margin-inline-end: calc(var(--stratakit-space-x2) * -1);
 		rotate: var(--🥝disclosure-arrow-rotate);
 
 		@media (prefers-reduced-motion: no-preference) {

--- a/packages/structures/src/AccordionItem.css
+++ b/packages/structures/src/AccordionItem.css
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 .🥝-accordion-item {
-	--🥝accordion-item-gap: 12px;
-	--🥝accordion-item-padding: 12px;
+	--🥝accordion-item-gap: var(--stratakit-space-x3);
+	--🥝accordion-item-padding: var(--stratakit-space-x3);
 
 	@layer base {
 		contain: paint;
@@ -111,8 +111,8 @@
 	@layer base {
 		grid-column: header-content;
 		cursor: pointer;
-		border-radius: 12px;
-		--🥝focus-outline-offset: -4px;
+		border-radius: var(--stratakit-space-x3);
+		--🥝focus-outline-offset: calc(var(--stratakit-space-x1) * -1);
 
 		&::after {
 			content: "";

--- a/packages/structures/src/AccordionItem.css
+++ b/packages/structures/src/AccordionItem.css
@@ -150,7 +150,7 @@
 		margin-inline-end: var(--🥝accordion-item-gap);
 		display: flex;
 		align-items: center;
-		gap: 0.25rem;
+		gap: var(--stratakit-space-x1);
 
 		:where(.🥝-accordion-item-heading, .🥝-accordion-item-button) ~ & {
 			grid-column: decoration-after;

--- a/packages/structures/src/Banner.css
+++ b/packages/structures/src/Banner.css
@@ -10,7 +10,7 @@
 		background-color: var(--🥝banner-color-background);
 		border: 1px solid var(--🥝banner-color-border);
 		border-radius: 8px;
-		padding: 12px;
+		padding: var(--stratakit-space-x3);
 		align-items: center;
 		inline-size: 100%;
 	}
@@ -51,7 +51,7 @@
 		grid-column: start;
 		grid-row: 1;
 		align-self: start;
-		margin-inline-end: 8px;
+		margin-inline-end: var(--stratakit-space-x2);
 	}
 }
 
@@ -60,7 +60,7 @@
 		grid-column: content;
 		font-weight: 500;
 		align-self: start;
-		margin-block-end: 4px;
+		margin-block-end: var(--stratakit-space-x1);
 	}
 }
 
@@ -80,8 +80,8 @@
 		display: flex;
 		flex-wrap: wrap;
 		align-items: baseline;
-		gap: 8px;
-		margin-block-start: 12px;
+		gap: var(--stratakit-space-x2);
+		margin-block-start: var(--stratakit-space-x3);
 	}
 }
 
@@ -90,7 +90,7 @@
 		grid-column: end;
 		grid-row: 1;
 		align-self: start;
-		margin-inline-start: 12px;
+		margin-inline-start: var(--stratakit-space-x3);
 	}
 }
 

--- a/packages/structures/src/Chip.css
+++ b/packages/structures/src/Chip.css
@@ -10,7 +10,7 @@
 		align-items: center;
 		position: relative;
 
-		--🥝chip-padding-inline: 0.5rem;
+		--🥝chip-padding-inline: var(--stratakit-space-x2);
 		padding-inline: var(--🥝chip-padding-inline);
 
 		min-block-size: 1.5rem;

--- a/packages/structures/src/DropdownMenu.css
+++ b/packages/structures/src/DropdownMenu.css
@@ -53,7 +53,7 @@
 
 .🥝-dropdown-menu-item-shortcuts {
 	@layer base {
-		margin-inline-start: 0.5rem;
+		margin-inline-start: var(--stratakit-space-x2);
 	}
 }
 

--- a/packages/structures/src/DropdownMenu.css
+++ b/packages/structures/src/DropdownMenu.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝-dropdown-menu {
 	--✨bg: var(--stratakit-color-bg-elevation-level-1);
-	--✨padding: 4px; /* space(in progress)/x1 */
+	--✨padding: var(--stratakit-space-x1);
 
 	@layer base {
 		background-color: var(--✨bg);

--- a/packages/structures/src/ErrorRegion.css
+++ b/packages/structures/src/ErrorRegion.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .🥝-error-region {
-	--✨padding: 4px;
+	--✨padding: var(--stratakit-space-x1);
 
 	@layer base {
 		position: relative;
@@ -62,8 +62,8 @@
 	@layer base {
 		flex-wrap: wrap;
 		min-block-size: 2rem;
-		padding-inline-start: 8px;
-		padding-inline-end: 4px;
+		padding-inline-start: var(--stratakit-space-x2);
+		padding-inline-end: var(--stratakit-space-x1);
 		font-weight: 400;
 		border-start-start-radius: var(--✨border-radius);
 		border-start-end-radius: var(--✨border-radius);
@@ -144,11 +144,11 @@
 }
 
 .🥝-error-region-item {
-	--✨container-padding: 8px;
+	--✨container-padding: var(--stratakit-space-x2);
 	--✨icon-size: 1rem;
-	--✨gap: 4px;
+	--✨gap: var(--stratakit-space-x1);
 	--✨padding-inline-start: calc(var(--✨container-padding) + var(--✨icon-size) + var(--✨gap));
-	--✨padding-block: calc(4px + 8px);
+	--✨padding-block: calc(var(--stratakit-space-x1) + var(--stratakit-space-x2)); /* TODO: Why? */
 
 	@layer base {
 		display: flex;
@@ -156,7 +156,7 @@
 
 		padding-block: var(--✨padding-block);
 		padding-inline-start: var(--✨padding-inline-start);
-		padding-inline-end: 4px;
+		padding-inline-end: var(--stratakit-space-x1);
 
 		&:where(:not(:nth-child(1 of &))) {
 			border-block-start: 1px solid var(--stratakit-color-border-page-base);
@@ -166,6 +166,6 @@
 
 .🥝-error-region-item-actions {
 	@layer base {
-		margin-block-start: 8px;
+		margin-block-start: var(--stratakit-space-x2);
 	}
 }

--- a/packages/structures/src/ErrorRegion.css
+++ b/packages/structures/src/ErrorRegion.css
@@ -148,7 +148,7 @@
 	--✨icon-size: 1rem;
 	--✨gap: var(--stratakit-space-x1);
 	--✨padding-inline-start: calc(var(--✨container-padding) + var(--✨icon-size) + var(--✨gap));
-	--✨padding-block: calc(var(--stratakit-space-x1) + var(--stratakit-space-x2)); /* TODO: Why? */
+	--✨padding-block: calc(var(--stratakit-space-x1) + var(--stratakit-space-x2));
 
 	@layer base {
 		display: flex;

--- a/packages/structures/src/Table.css
+++ b/packages/structures/src/Table.css
@@ -84,7 +84,7 @@
 		position: relative;
 
 		&:where(:not(th, td)) {
-			column-gap: 0.5rem;
+			column-gap: var(--stratakit-space-x2);
 			flex-grow: 1;
 			flex-basis: 4rem;
 		}

--- a/packages/structures/src/Table.css
+++ b/packages/structures/src/Table.css
@@ -30,9 +30,9 @@
 
 .🥝-table-caption,
 .🥝-table-cell {
-	--✨cell-padding-block: 0.5rem;
-	--✨cell-padding-inline-start: 1rem;
-	--✨cell-padding-inline-end: 0.75rem;
+	--✨cell-padding-block: var(--stratakit-space-x2);
+	--✨cell-padding-inline-start: var(--stratakit-space-x4);
+	--✨cell-padding-inline-end: var(--stratakit-space-x3);
 	--✨cell-height-min: 3rem;
 
 	@layer base {

--- a/packages/structures/src/Tabs.css
+++ b/packages/structures/src/Tabs.css
@@ -5,12 +5,12 @@
 
 .🥝-tab-list {
 	@layer base {
-		--🥝tab-active-stripe-gap: 8px;
-		--🥝tab-active-stripe-size: 2px;
-		--🥝tab-padding-inline: 4px;
+		--🥝tab-active-stripe-gap: var(--stratakit-space-x2);
+		--🥝tab-active-stripe-size: var(--stratakit-space-x05);
+		--🥝tab-padding-inline: var(--stratakit-space-x1);
 
 		display: flex;
-		gap: 8px;
+		gap: var(--stratakit-space-x2);
 		position: relative;
 
 		@supports (position-anchor: --foo) {
@@ -45,7 +45,7 @@
 
 .🥝-tab {
 	--✨height: 1.25rem;
-	--✨gap: 4px;
+	--✨gap: var(--stratakit-space-x1);
 
 	--✨bg--default: transparent;
 	--✨bg--hover-neutral: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
@@ -159,7 +159,7 @@
 
 .🥝-tab-panel {
 	@layer base {
-		--🥝focus-outline-offset: -2px;
+		--🥝focus-outline-offset: calc(var(--stratakit-space-x05) * -1);
 
 		/* Prevents stacking when multiple panels are mounted (during animation) */
 		&:not([data-open]) {

--- a/packages/structures/src/Toolbar.css
+++ b/packages/structures/src/Toolbar.css
@@ -5,12 +5,12 @@
 .🥝-toolbar {
 	@layer base {
 		display: inline-flex;
-		gap: 4px;
+		gap: var(--stratakit-space-x1);
 
 		background-color: var(--stratakit-color-bg-page-base);
 		box-shadow: var(--stratakit-shadow-toolbar-base);
 		border-radius: 8px;
-		padding: 4px;
+		padding: var(--stratakit-space-x1);
 	}
 }
 

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -158,7 +158,7 @@
 	@layer base {
 		display: flex;
 		align-items: center;
-		gap: 0.25rem;
+		gap: var(--stratakit-space-x1);
 	}
 }
 

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -40,7 +40,7 @@
 
 .🥝-tree-item-node:is(.🥝-list-item) {
 	--✨first-level-indent: var(--stratakit-space-x2);
-	--✨subsequent-level-indent: 6px; /* TODO: What to do about 6px? */
+	--✨subsequent-level-indent: calc(var(--stratakit-space-x1) + var(--stratakit-space-x05));
 
 	@layer base {
 		position: relative;

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -39,8 +39,8 @@
 }
 
 .🥝-tree-item-node:is(.🥝-list-item) {
-	--✨first-level-indent: 8px;
-	--✨subsequent-level-indent: 6px;
+	--✨first-level-indent: var(--stratakit-space-x2);
+	--✨subsequent-level-indent: 6px; /* TODO: What to do about 6px? */
 
 	@layer base {
 		position: relative;
@@ -104,7 +104,7 @@
 		align-self: stretch;
 		position: sticky;
 		inset-inline-end: 0;
-		padding-inline-end: 4px;
+		padding-inline-end: var(--stratakit-space-x1);
 		background-color: var(--stratakit-color-bg-page-base);
 		display: inline-flex;
 		/** If actions are made visible (by a parent), the actions container should also become visible. */

--- a/packages/structures/src/~utils.ListItem.css
+++ b/packages/structures/src/~utils.ListItem.css
@@ -5,7 +5,7 @@
 .🥝-list-item {
 	--✨height--default: 1.75rem;
 	--✨height--large: 2.75rem;
-	--✨padding-inline: 0.5rem;
+	--✨padding-inline: var(--stratakit-space-x2);
 
 	--✨bg--default: transparent;
 	--✨bg--hover: var(--stratakit-color-bg-glow-on-surface-neutral-hover);

--- a/packages/structures/src/~utils.ListItem.css
+++ b/packages/structures/src/~utils.ListItem.css
@@ -106,7 +106,7 @@
 }
 
 .🥝-list-item-decoration {
-	--✨gap: 0.25rem;
+	--✨gap: var(--stratakit-space-x1);
 
 	@layer base {
 		grid-column: decoration-before;


### PR DESCRIPTION
- Update all hardcoded `px` values for `padding`, `margin`, `gap`, etc. to use new `spacing` variables.  Did **not** make changes to `border-width`, `border-radius`, `height`, `width`.
- Changed `text-underline-offset` on hover from `3px` to `4px`.

Follow up to #877, part of #857.