### PR TITLE
make `Icon` respect any valid `href`

### DIFF
--- a/.changeset/beige-forks-talk.md
+++ b/.changeset/beige-forks-talk.md
@@ -1,0 +1,14 @@
+---
+"@stratakit/structures": minor
+---
+
+`Toolbar.Item` component no longer automatically uses the large version of the icon.
+
+`#icon-large` must now be explicitly added to the URL to select the large icons from `@stratakit/icons`. For example:
+
+```diff
+  <Toolbar.Item
+-   render={<IconButton icon={placeholderIcon} />}
++   render={<IconButton icon={`${placeholderIcon}#icon-large`} />}
+  />
+```

--- a/.changeset/brave-eagles-camp.md
+++ b/.changeset/brave-eagles-camp.md
@@ -1,0 +1,11 @@
+---
+"@stratakit/foundations": patch
+---
+
+`Icon` component now supports URLs containing an explicit hash.
+
+```tsx
+import placeholderIcon from "@stratakit/icons/placeholder.svg";
+
+<Icon href={`${placeholderIcon}#icon-large`} size="large" />;
+```

--- a/.changeset/poor-boxes-stop.md
+++ b/.changeset/poor-boxes-stop.md
@@ -1,0 +1,12 @@
+---
+"@stratakit/foundations": minor
+---
+
+`Icon` component no longer automatically adjusts the URL based on `size`.
+
+`#icon-large` must now be explicitly added to the URL to select the large icons from `@stratakit/icons`. For example:
+
+```diff
+- <Icon href={placeholderIcon} size="large" />
++ <Icon href={`${placeholderIcon}#icon-large`} size="large" />
+```

--- a/apps/test-app/app/icons.tsx
+++ b/apps/test-app/app/icons.tsx
@@ -52,10 +52,10 @@ export default function Page() {
 							<Table.Row key={icon}>
 								<Table.Cell>{icon}</Table.Cell>
 								<Table.Cell>
-									<Icon href={iconHref} />
+									<Icon href={`${iconHref}#icon`} />
 								</Table.Cell>
 								<Table.Cell>
-									<Icon size="large" href={iconHref} />
+									<Icon size="large" href={`${iconHref}#icon-large`} />
 								</Table.Cell>
 							</Table.Row>
 						);

--- a/apps/test-app/app/sandbox/index.tsx
+++ b/apps/test-app/app/sandbox/index.tsx
@@ -154,20 +154,38 @@ function Canvas() {
 			<Toolbar.Group variant="solid">
 				<Toolbar.Item
 					render={
-						<IconButton label="Select" icon={cursorIcon} variant="ghost" />
+						<IconButton
+							label="Select"
+							icon={`${cursorIcon}#icon-large`}
+							variant="ghost"
+						/>
 					}
 				/>
 				<Toolbar.Item
 					render={
-						<IconButton label="Move" icon={cursorSelectIcon} variant="ghost" />
+						<IconButton
+							label="Move"
+							icon={`${cursorSelectIcon}#icon-large`}
+							variant="ghost"
+						/>
 					}
 				/>
 				<Toolbar.Item
-					render={<IconButton label="Draw" icon={drawIcon} variant="ghost" />}
+					render={
+						<IconButton
+							label="Draw"
+							icon={`${drawIcon}#icon-large`}
+							variant="ghost"
+						/>
+					}
 				/>
 				<Toolbar.Item
 					render={
-						<IconButton label="Measure" icon={measureIcon} variant="ghost" />
+						<IconButton
+							label="Measure"
+							icon={`${measureIcon}#icon-large`}
+							variant="ghost"
+						/>
 					}
 				/>
 			</Toolbar.Group>

--- a/apps/test-app/app/tests/icon/index.tsx
+++ b/apps/test-app/app/tests/icon/index.tsx
@@ -16,7 +16,7 @@ export default definePage(
 			<Icon
 				alt={alt}
 				size={size as "regular" | "large"}
-				href={placeholderIcon}
+				href={`${placeholderIcon}#${size === "large" ? "icon-large" : "icon"}`}
 			/>
 		);
 	},

--- a/apps/test-app/app/tests/toolbar/index.tsx
+++ b/apps/test-app/app/tests/toolbar/index.tsx
@@ -16,7 +16,7 @@ export default definePage(
 				<Toolbar.Item
 					render={
 						<IconButton
-							icon={placeholderIcon}
+							icon={`${placeholderIcon}#icon-large`}
 							label="Click me"
 							variant="ghost"
 						/>
@@ -25,7 +25,7 @@ export default definePage(
 				<Toolbar.Item
 					render={
 						<IconButton
-							icon={placeholderIcon}
+							icon={`${placeholderIcon}#icon-large`}
 							label="Click me"
 							variant="ghost"
 						/>
@@ -34,7 +34,7 @@ export default definePage(
 				<Toolbar.Item
 					render={
 						<IconButton
-							icon={placeholderIcon}
+							icon={`${placeholderIcon}#icon-large`}
 							label="Click me"
 							variant="ghost"
 						/>
@@ -51,17 +51,29 @@ function VisualTest() {
 		<Toolbar.Group variant="solid">
 			<Toolbar.Item
 				render={
-					<IconButton icon={placeholderIcon} label="Click me" variant="ghost" />
+					<IconButton
+						icon={`${placeholderIcon}#icon-large`}
+						label="Click me"
+						variant="ghost"
+					/>
 				}
 			/>
 			<Toolbar.Item
 				render={
-					<IconButton icon={placeholderIcon} label="Click me" variant="ghost" />
+					<IconButton
+						icon={`${placeholderIcon}#icon-large`}
+						label="Click me"
+						variant="ghost"
+					/>
 				}
 			/>
 			<Toolbar.Item
 				render={
-					<IconButton icon={placeholderIcon} label="Click me" variant="ghost" />
+					<IconButton
+						icon={`${placeholderIcon}#icon-large`}
+						label="Click me"
+						variant="ghost"
+					/>
 				}
 			/>
 		</Toolbar.Group>

--- a/packages/foundations/src/Icon.tsx
+++ b/packages/foundations/src/Icon.tsx
@@ -16,11 +16,17 @@ import {
 
 import type { BaseProps } from "./~utils.js";
 
+// ----------------------------------------------------------------------------
+
+const DEFAULT_ICON_HASH = "#icon";
+
+// ----------------------------------------------------------------------------
+
 interface IconProps extends Omit<BaseProps<"svg">, "children"> {
 	/**
-	 * URL of the symbol sprite.
+	 * URL of the `.svg` file (e.g. from `@stratakit/icons`).
 	 *
-	 * Should be a URL to an `.svg` file from `@stratakit/icons`.
+	 * The URL can contain a hash pointing to a specific symbol within the SVG (e.g. `#icon`, `#icon-large`).
 	 *
 	 * Note: The `.svg` must be an external HTTP resource for it to be processed by
 	 * the `<use>` element. As a fallback, JS will be used to `fetch` the SVG from
@@ -29,8 +35,7 @@ interface IconProps extends Omit<BaseProps<"svg">, "children"> {
 	 */
 	href?: string;
 	/**
-	 * Size of the icon. This affects the icon's physical dimensions, as well as the
-	 * actual SVG contents (different sizes might have different fidelity).
+	 * Size of the icon. This only affects the icon's physical dimensions (not the SVG contents).
 	 *
 	 * Defaults to `"regular"` (16px) and can be optionally set to `"large"` (24px).
 	 */
@@ -47,13 +52,20 @@ interface IconProps extends Omit<BaseProps<"svg">, "children"> {
 	alt?: string;
 }
 
+// ----------------------------------------------------------------------------
+
 /**
  * Icon component that provides fill and sizing to the SVGs from `@stratakit/icons`.
- * It renders the correct symbol sprite based on the specified `size`.
  *
  * ```tsx
  * const arrowIcon = new URL("@stratakit/icons/arrow.svg", import.meta.url).href;
  * <Icon href={arrowIcon} />
+ * ```
+ *
+ * The `href` can point to a specific symbol (e.g. `#icon`, `#icon-large`) within the SVG file:
+ *
+ * ```tsx
+ * <Icon href={`${arrowIcon}#icon-large`} />
  * ```
  *
  * It also accepts a custom SVG, via the `render `prop:
@@ -86,7 +98,7 @@ export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
 			className={cx("🥝-icon", props.className)}
 			ref={forwardedRef}
 		>
-			{hrefBase ? <use href={toIconHref(hrefBase, size)} /> : null}
+			{hrefBase ? <use href={toIconHref(hrefBase)} /> : null}
 		</Role.svg>
 	);
 });
@@ -95,21 +107,12 @@ DEV: Icon.displayName = "Icon";
 // ----------------------------------------------------------------------------
 
 /**
- * Constructs a final URL from the base and "size".
- *
- * For external URLs, we use a regular URL hash (e.g. `placeholder.svg#${id}`).
- * For same-document URLs, we append `--${id}` (e.g. `#placeholder--${id}`).
+ * Constructs a final URL from the base.
+ * Adds default hash (`#icon`) if the URL does not already contain a hash.
  */
-function toIconHref(hrefBase: string, size: IconProps["size"]) {
-	const separator = hrefBase.includes("#") ? "--" : "#";
-	const suffix = toIconId(size);
-	return `${hrefBase}${separator}${suffix}`;
-}
-
-/** Returns a symbol ID matching the conventions used in `@stratakit/icons`. */
-function toIconId(size: IconProps["size"]) {
-	if (size === "large") return "icon-large";
-	return "icon";
+function toIconHref(hrefBase: string) {
+	if (!hrefBase.includes("#")) return `${hrefBase}${DEFAULT_ICON_HASH}`;
+	return hrefBase;
 }
 
 // ----------------------------------------------------------------------------
@@ -169,6 +172,8 @@ function useNormalizedHrefBase(rawHref: string | undefined) {
 					const response = await fetch(rawHref, { signal });
 					if (!response.ok) throw new Error(`Failed to fetch ${rawHref}`);
 
+					const hash = new URL(rawHref).hash || DEFAULT_ICON_HASH;
+
 					// Find all `<symbol>` elements from the response.
 					const fetchedSvgString = sanitizeHtml.current(await response.text());
 					const parsedSvgContent = parseDOM(fetchedSvgString, {
@@ -177,12 +182,12 @@ function useNormalizedHrefBase(rawHref: string | undefined) {
 					const symbols = parsedSvgContent.querySelectorAll("symbol");
 
 					for (const symbol of symbols) {
-						symbol.id = `${prefix}--${symbol.id}`; // unique ID
+						symbol.id = `${prefix}--${symbol.id}`; // unique ID, using `--` instead as the delimiter for icon-specific symbols.
 						if (ownerDocument.getElementById(symbol.id)) continue; // Skip if already present.
-						spriteSheet.appendChild(symbol.cloneNode(true)); // Store symbols in the spritesheet renderered by `<Root>`.
+						spriteSheet.appendChild(symbol.cloneNode(true)); // Store symbols in the spritesheet rendered by `<Root>`.
 					}
 
-					inlineHref.current = `#${prefix}`;
+					inlineHref.current = `#${prefix}--${hash.slice(1)}`; // Replacing `#` with `--`, per convention above.
 					cache.set(rawHref, inlineHref.current); // Cache for future use.
 					if (!signal.aborted) notify();
 				} catch (error) {

--- a/packages/foundations/src/Icon.tsx
+++ b/packages/foundations/src/Icon.tsx
@@ -27,6 +27,7 @@ interface IconProps extends Omit<BaseProps<"svg">, "children"> {
 	 * URL of the `.svg` file (e.g. from `@stratakit/icons`).
 	 *
 	 * The URL can contain a hash pointing to a specific symbol within the SVG (e.g. `#icon`, `#icon-large`).
+	 * By default, the `#icon` symbol is used if no hash is provided.
 	 *
 	 * Note: The `.svg` must be an external HTTP resource for it to be processed by
 	 * the `<use>` element. As a fallback, JS will be used to `fetch` the SVG from

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -2,12 +2,14 @@
 
 Standalone `.svg` icons for StrataKit.
 
-Each icon is available as an SVG symbol sprite and contains multiple resolutions of the same icon using [`<symbol>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol) elements. This allows the icon to be used at different sizes with increasing detail and quality.
+Each icon is available as an SVG containing multiple resolutions of the same icon using [`<symbol>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol) elements. This allows the icon to be used at different sizes with increasing detail and quality.
 
 Currently supported symbols as identified by their `id` attribute values are:
 
 - `icon`
 - `icon-large`
+
+These symbols can be accessed by appending a hash (e.g. `#icon`, `#icon-large`) to the `.svg` URL.
 
 ## Installation
 
@@ -44,22 +46,25 @@ Preferred usage is with the `Icon` component from `@stratakit/foundations`:
    ```tsx
    import { Icon } from "@stratakit/foundations";
 
-   <Icon href={placeholderIcon} />
-
-   // Specify `size` prop to render the large icon:
-   <Icon href={placeholderIcon} size="large" />
+   <Icon href={placeholderIcon} />;
    ```
 
-   Alternatively, you can use the SVG sprite directly:
+   An optional hash can be specified to select a specific symbol from the `.svg`:
+
+   ```tsx
+   <Icon href={`${placeholderIcon}#icon`} />
+   <Icon href={`${placeholderIcon}#icon-large`} size="large" />
+   ```
+
+   Alternatively, you can `<use>` the SVG sprite directly (without `Icon`):
 
    ```tsx
    <svg>
-   	<use href={`${placeholderIcon}#icon`} />
+   	 <use href={`${placeholderIcon}#icon`} />
    </svg>
 
-   // To display the large icon:
    <svg>
-   	<use href={`${placeholderIcon}#icon-large`} />
+   	 <use href={`${placeholderIcon}#icon-large`} />
    </svg>
    ```
 

--- a/packages/structures/src/Toolbar.tsx
+++ b/packages/structures/src/Toolbar.tsx
@@ -57,10 +57,12 @@ interface ToolbarItemProps
  * An item within the toolbar.
  * Should be used with the `render` prop.
  *
+ * If rendering an `IconButton`, be sure to append `#icon-large` to the icon URL.
+ *
  * Example:
  * ```jsx
  * <Toolbar.Item
- *   render={<IconButton variant="ghost" … />}
+ *   render={<IconButton variant="ghost" icon={`${placeholderIcon}#icon-large`} />}
  * />
  * ```
  */


### PR DESCRIPTION
This PR implements the changes proposed in #802.

_This PR is considered a prerequisite for #884 to reduce the number of breaking changes._

### Changes

- Any valid `href` is now supported. This means fragment URLs can now be handled on the outside (same as `<use>`).
- `size` is no longer given special treatment. The same symbol is rendered regardless of `size`.

#### Notes

- When the URL does not contain a hash, the default `#icon` is used. We rely on this in several places in our test-app.
- Runtime fetch logic from #455 still works. Can be verified manually by commenting out the `assetsInlineLimit` part in vite config.

---

### Breaking change (for consumers)

While the icons will continue to appear in the correct physical size everywhere, there are two places where the symbol is affected:
- `Icon` (with `size="large"`)
- `Toolbar.Item` (with `render={<IconButton />}`) 

These will now need an explicit hash to render the large version of the icon.

```diff
  import { Icon } from "@stratakit/foundations";
  import { IconButton } from "@stratakit/bricks";
  import { unstable_Toolbar as Toolbar } from "@stratakit/structures";

  import placeholderIcon from "@stratakit/icons/placeholder.svg";

  <Icon
-   href={placeholderIcon}
+   href={`${placeholderIcon}#icon-large`}
    size="large"
  />

  <Toolbar.Item
    render={
      <IconButton
-       icon={placeholderIcon}
+       icon={`${placeholderIcon}#icon-large`}
        label={…}
      />
    }
  />
```

