### PR TITLE
fix `Toolbar.Item` alignment

### DIFF
--- a/.changeset/ninety-taxis-give.md
+++ b/.changeset/ninety-taxis-give.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fixed vertical centering of `Toolbar.Item`.

--- a/packages/structures/src/Toolbar.css
+++ b/packages/structures/src/Toolbar.css
@@ -6,6 +6,7 @@
 	@layer base {
 		display: inline-flex;
 		gap: var(--stratakit-space-x1);
+		align-items: center;
 
 		background-color: var(--stratakit-color-bg-page-base);
 		box-shadow: var(--stratakit-shadow-toolbar-base);


### PR DESCRIPTION
This fixes an issue where toolbar items would expand to fill the available height instead of using their intrinsic size.

| Before | After |
| --- | --- |
| <img width="231" height="74" alt="Screenshot showing an awkwardly large dropdown button inside a toolbar" src="https://github.com/user-attachments/assets/db57d8eb-f910-419e-9b41-c2f9d77b4740" /> | <img width="228" height="74" alt="Screenshot showing the same button using its proportional size and vertically centered in the toolbar." src="https://github.com/user-attachments/assets/2746a2ac-16b9-4e48-90dc-26a6b0bbf78d" /> |