### PR TITLE
change CSS conventions

### DIFF
--- a/.changeset/fifty-roses-attack.md
+++ b/.changeset/fifty-roses-attack.md
@@ -1,0 +1,7 @@
+---
+"@stratakit/foundations": patch
+"@stratakit/structures": patch
+"@stratakit/bricks": patch
+---
+
+Updated internal CSS selectors in every component.

--- a/apps/test-app/app/tests/chip/index.spec.ts
+++ b/apps/test-app/app/tests/chip/index.spec.ts
@@ -21,7 +21,7 @@ test.describe("@visual", () => {
 test("onDismiss prop", async ({ page }) => {
 	await page.goto("/tests/chip?dismiss=true");
 
-	const chip = page.locator(".🥝-chip").first();
+	const chip = page.locator("[data-dismissed]").first();
 	const dismissButton = chip.getByRole("button", { name: "Dismiss" }).first();
 
 	await dismissButton.click();

--- a/apps/test-app/app/tests/field/index.spec.ts
+++ b/apps/test-app/app/tests/field/index.spec.ts
@@ -54,7 +54,9 @@ test.describe("default", () => {
 
 	test("rendering as a label", async ({ page }) => {
 		await page.goto("/tests/field?control=checkbox&asLabel");
-		await expect(page.locator(".🥝-label.🥝-field")).toBeVisible();
+		const label = page.locator("label");
+		const checkbox = label.getByRole("checkbox");
+		await expect(checkbox).toBeVisible();
 	});
 
 	test("with explicit id", async ({ page }) => {

--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -53,14 +53,14 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-tone="accent"]) {
+		&:where([data-_sk-tone="accent"]) {
 			--🥝Anchor-color: var(--🌀Anchor-state--default, var(--✨color--accent))
 				var(--🌀Anchor-state--hover, var(--✨color--accent-hover))
 				var(--🌀Anchor-state--pressed, var(--✨color--accent-pressed));
 			-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 		}
 
-		&:where([data-kiwi-tone="critical"]) {
+		&:where([data-_sk-tone="critical"]) {
 			--🥝Anchor-color: var(--🌀Anchor-state--default, var(--✨color--critical))
 				var(--🌀Anchor-state--hover, var(--✨color--critical-hover))
 				var(--🌀Anchor-state--pressed, var(--✨color--critical-pressed));

--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-anchor {
+.🥝Anchor {
 	--✨color--default: var(--stratakit-color-text-neutral-primary);
 	--✨color--accent: var(--stratakit-color-text-accent-strong);
 	--✨color--accent-hover: color-mix(
@@ -39,7 +39,7 @@
 			var(--🌀anchor-state--hover, currentColor) var(--🌀anchor-state--pressed, transparent);
 		text-decoration-line: underline;
 
-		&:where(:has(.🥝-anchor-text)) {
+		&:where(:has(.🥝AnchorText)) {
 			text-decoration-line: none;
 		}
 
@@ -99,21 +99,21 @@
 	}
 }
 
-.🥝-anchor-text {
+.🥝AnchorText {
 	@layer base {
 		text-decoration-line: underline;
 		unicode-bidi: bidi-override;
 	}
 }
 
-.🥝-anchor-external-marker {
+.🥝AnchorExternalMarker {
 	@layer base {
 		user-select: none;
 	}
 }
 
 @media (forced-colors: active) {
-	.🥝-anchor:where(button) {
+	.🥝Anchor:where(button) {
 		color: LinkText;
 	}
 }

--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -32,11 +32,11 @@
 		cursor: pointer;
 		font-size: var(--stratakit-font-size-12);
 		font-weight: 500;
-		text-underline-offset: var(--🌀anchor-state--default, var(--stratakit-space-x05))
-			var(--🌀anchor-state--hover, var(--stratakit-space-x1))
-			var(--🌀anchor-state--pressed, var(--stratakit-space-x1));
-		text-decoration-color: var(--🌀anchor-state--default, currentColor)
-			var(--🌀anchor-state--hover, currentColor) var(--🌀anchor-state--pressed, transparent);
+		text-underline-offset: var(--🌀Anchor-state--default, var(--stratakit-space-x05))
+			var(--🌀Anchor-state--hover, var(--stratakit-space-x1))
+			var(--🌀Anchor-state--pressed, var(--stratakit-space-x1));
+		text-decoration-color: var(--🌀Anchor-state--default, currentColor)
+			var(--🌀Anchor-state--hover, currentColor) var(--🌀Anchor-state--pressed, transparent);
 		text-decoration-line: underline;
 
 		&:where(:has(.🥝AnchorText)) {
@@ -45,7 +45,7 @@
 
 		border-radius: 4px;
 
-		color: var(--🥝anchor-color, var(--✨color--default));
+		color: var(--🥝Anchor-color, var(--✨color--default));
 		-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-neutral-pressed);
 
 		transition: all 150ms ease-out;
@@ -54,16 +54,16 @@
 
 	@layer modifiers {
 		&:where([data-kiwi-tone="accent"]) {
-			--🥝anchor-color: var(--🌀anchor-state--default, var(--✨color--accent))
-				var(--🌀anchor-state--hover, var(--✨color--accent-hover))
-				var(--🌀anchor-state--pressed, var(--✨color--accent-pressed));
+			--🥝Anchor-color: var(--🌀Anchor-state--default, var(--✨color--accent))
+				var(--🌀Anchor-state--hover, var(--✨color--accent-hover))
+				var(--🌀Anchor-state--pressed, var(--✨color--accent-pressed));
 			-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 		}
 
 		&:where([data-kiwi-tone="critical"]) {
-			--🥝anchor-color: var(--🌀anchor-state--default, var(--✨color--critical))
-				var(--🌀anchor-state--hover, var(--✨color--critical-hover))
-				var(--🌀anchor-state--pressed, var(--✨color--critical-pressed));
+			--🥝Anchor-color: var(--🌀Anchor-state--default, var(--✨color--critical))
+				var(--🌀Anchor-state--hover, var(--✨color--critical-hover))
+				var(--🌀Anchor-state--pressed, var(--✨color--critical-pressed));
 			-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-critical-pressed);
 		}
 	}
@@ -71,12 +71,12 @@
 	@layer states {
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀anchor-state: var(--🌀anchor-state--hover);
+				--🌀Anchor-state: var(--🌀Anchor-state--hover);
 			}
 		}
 
 		&:where(:active) {
-			--🌀anchor-state: var(--🌀anchor-state--pressed);
+			--🌀Anchor-state: var(--🌀Anchor-state--pressed);
 		}
 
 		&:where(:focus-visible) {
@@ -84,7 +84,7 @@
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {
-			--🥝anchor-color: var(--✨color--disabled);
+			--🥝Anchor-color: var(--✨color--disabled);
 			cursor: not-allowed;
 			text-decoration: none;
 		}
@@ -92,10 +92,10 @@
 
 	@layer base.🌀 {
 		/* https://kizu.dev/cyclic-toggles/ */
-		--🌀anchor-state: var(--🌀anchor-state--default);
-		--🌀anchor-state--default: var(--🌀anchor-state,);
-		--🌀anchor-state--hover: var(--🌀anchor-state,);
-		--🌀anchor-state--pressed: var(--🌀anchor-state,);
+		--🌀Anchor-state: var(--🌀Anchor-state--default);
+		--🌀Anchor-state--default: var(--🌀Anchor-state,);
+		--🌀Anchor-state--hover: var(--🌀Anchor-state,);
+		--🌀Anchor-state--pressed: var(--🌀Anchor-state,);
 	}
 }
 

--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -44,7 +44,7 @@ const AnchorRoot = forwardRef<"a", AnchorRootProps>((props, forwardedRef) => {
 		<Role.a
 			{...rest}
 			data-kiwi-tone={tone}
-			className={cx("🥝-anchor", props.className)}
+			className={cx("🥝Anchor", props.className)}
 			render={
 				<Focusable accessibleWhenDisabled render={props.render || <a />} />
 			}
@@ -71,7 +71,7 @@ const AnchorText = forwardRef<"span", AnchorTextProps>(
 		return (
 			<Role.span
 				{...props}
-				className={cx("🥝-anchor-text", props.className)}
+				className={cx("🥝AnchorText", props.className)}
 				ref={forwardedRef}
 			/>
 		);
@@ -101,7 +101,7 @@ const AnchorExternalMarker = forwardRef<"span", AnchorExternalMarkerProps>(
 				<Role.span
 					aria-hidden="true"
 					{...rest}
-					className={cx("🥝-anchor-external-marker", props.className)}
+					className={cx("🥝AnchorExternalMarker", props.className)}
 					ref={forwardedRef}
 				>
 					&nbsp;↗

--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -43,7 +43,7 @@ const AnchorRoot = forwardRef<"a", AnchorRootProps>((props, forwardedRef) => {
 	return (
 		<Role.a
 			{...rest}
-			data-kiwi-tone={tone}
+			data-_sk-tone={tone}
 			className={cx("🥝Anchor", props.className)}
 			render={
 				<Focusable accessibleWhenDisabled render={props.render || <a />} />

--- a/packages/bricks/src/Avatar.css
+++ b/packages/bricks/src/Avatar.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-avatar {
+.🥝Avatar {
 	--✨shadow-border: 0px 0px 0px 1px var(--stratakit-color-border-glow-strong-default) inset;
 
 	@layer base {
@@ -63,7 +63,7 @@
 	}
 }
 
-.🥝-avatar-initials {
+.🥝AvatarInitials {
 	@layer base {
 		font-size: var(--🥝avatar-font-size);
 		font-weight: 600;
@@ -73,7 +73,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-avatar {
+	.🥝Avatar {
 		border: 1px solid;
 	}
 }

--- a/packages/bricks/src/Avatar.css
+++ b/packages/bricks/src/Avatar.css
@@ -37,25 +37,25 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-size="small"]) {
+		&:where([data-_sk-size="small"]) {
 			--🥝Avatar-size: 1rem;
 			--🥝Avatar-font-size: var(--stratakit-font-size-8);
 			--🥝Icon-size: 0.75rem;
 		}
 
-		&:where([data-kiwi-size="medium"]) {
+		&:where([data-_sk-size="medium"]) {
 			--🥝Avatar-size: 1.5rem;
 			--🥝Avatar-font-size: var(--stratakit-font-size-10);
 			--🥝Icon-size: 1rem;
 		}
 
-		&:where([data-kiwi-size="large"]) {
+		&:where([data-_sk-size="large"]) {
 			--🥝Avatar-size: 2rem;
 			--🥝Avatar-font-size: var(--stratakit-font-size-12);
 			--🥝Icon-size: 1rem;
 		}
 
-		&:where([data-kiwi-size="xlarge"]) {
+		&:where([data-_sk-size="xlarge"]) {
 			--🥝Avatar-size: 3rem;
 			--🥝Avatar-font-size: var(--stratakit-font-size-16);
 			--🥝Icon-size: 1.5rem;

--- a/packages/bricks/src/Avatar.css
+++ b/packages/bricks/src/Avatar.css
@@ -6,11 +6,11 @@
 	--✨shadow-border: 0px 0px 0px 1px var(--stratakit-color-border-glow-strong-default) inset;
 
 	@layer base {
-		--🥝avatar-background-color: var(--stratakit-color-bg-mono-base);
+		--🥝Avatar-background-color: var(--stratakit-color-bg-mono-base);
 
-		block-size: var(--🥝avatar-size);
-		inline-size: var(--🥝avatar-size);
-		background-color: var(--🥝avatar-background-color);
+		block-size: var(--🥝Avatar-size);
+		inline-size: var(--🥝Avatar-size);
+		background-color: var(--🥝Avatar-background-color);
 		color: var(--stratakit-color-text-neutral-emphasis);
 		display: inline-grid;
 		place-items: center;
@@ -38,34 +38,34 @@
 
 	@layer modifiers {
 		&:where([data-kiwi-size="small"]) {
-			--🥝avatar-size: 1rem;
-			--🥝avatar-font-size: var(--stratakit-font-size-8);
-			--🥝icon-size: 0.75rem;
+			--🥝Avatar-size: 1rem;
+			--🥝Avatar-font-size: var(--stratakit-font-size-8);
+			--🥝Icon-size: 0.75rem;
 		}
 
 		&:where([data-kiwi-size="medium"]) {
-			--🥝avatar-size: 1.5rem;
-			--🥝avatar-font-size: var(--stratakit-font-size-10);
-			--🥝icon-size: 1rem;
+			--🥝Avatar-size: 1.5rem;
+			--🥝Avatar-font-size: var(--stratakit-font-size-10);
+			--🥝Icon-size: 1rem;
 		}
 
 		&:where([data-kiwi-size="large"]) {
-			--🥝avatar-size: 2rem;
-			--🥝avatar-font-size: var(--stratakit-font-size-12);
-			--🥝icon-size: 1rem;
+			--🥝Avatar-size: 2rem;
+			--🥝Avatar-font-size: var(--stratakit-font-size-12);
+			--🥝Icon-size: 1rem;
 		}
 
 		&:where([data-kiwi-size="xlarge"]) {
-			--🥝avatar-size: 3rem;
-			--🥝avatar-font-size: var(--stratakit-font-size-16);
-			--🥝icon-size: 1.5rem;
+			--🥝Avatar-size: 3rem;
+			--🥝Avatar-font-size: var(--stratakit-font-size-16);
+			--🥝Icon-size: 1.5rem;
 		}
 	}
 }
 
 .🥝AvatarInitials {
 	@layer base {
-		font-size: var(--🥝avatar-font-size);
+		font-size: var(--🥝Avatar-font-size);
 		font-weight: 600;
 		text-align: center;
 		text-transform: uppercase;

--- a/packages/bricks/src/Avatar.tsx
+++ b/packages/bricks/src/Avatar.tsx
@@ -67,7 +67,7 @@ const Avatar = forwardRef<"span", AvatarProps>((props, forwardedRef) => {
 			role={isDecorative ? undefined : "img"}
 			aria-label={isDecorative ? undefined : alt}
 			{...rest}
-			data-kiwi-size={size}
+			data-_sk-size={size}
 			className={cx("🥝Avatar", props.className)}
 			ref={forwardedRef}
 		>

--- a/packages/bricks/src/Avatar.tsx
+++ b/packages/bricks/src/Avatar.tsx
@@ -68,11 +68,11 @@ const Avatar = forwardRef<"span", AvatarProps>((props, forwardedRef) => {
 			aria-label={isDecorative ? undefined : alt}
 			{...rest}
 			data-kiwi-size={size}
-			className={cx("🥝-avatar", props.className)}
+			className={cx("🥝Avatar", props.className)}
 			ref={forwardedRef}
 		>
 			{image ?? (
-				<abbr className="🥝-avatar-initials" aria-hidden="true">
+				<abbr className="🥝AvatarInitials" aria-hidden="true">
 					{initials?.substring(0, 1)}
 				</abbr>
 			)}

--- a/packages/bricks/src/Badge.css
+++ b/packages/bricks/src/Badge.css
@@ -12,9 +12,9 @@
 		flex-shrink: 0;
 		white-space: nowrap;
 		border-radius: 9999px;
-		box-shadow: 0px 0px 0px 1px var(--🥝badge-border-color) inset;
-		background-color: var(--🥝badge-background-color);
-		color: var(--🥝badge-text-color);
+		box-shadow: 0px 0px 0px 1px var(--🥝Badge-border-color) inset;
+		background-color: var(--🥝Badge-background-color);
+		color: var(--🥝Badge-text-color);
 		font-weight: 500;
 		block-size: 1.25rem;
 		padding-inline: var(--stratakit-space-x2);
@@ -22,103 +22,103 @@
 
 	@layer modifiers {
 		&:where([data-kiwi-variant="solid"]) {
-			--🥝badge-border-color: var(--stratakit-color-border-glow-strong-default);
-			--🥝badge-text-color: var(--stratakit-color-text-neutral-emphasis);
+			--🥝Badge-border-color: var(--stratakit-color-border-glow-strong-default);
+			--🥝Badge-text-color: var(--stratakit-color-text-neutral-emphasis);
 
 			&:where([data-kiwi-tone="neutral"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-mono-base);
+				--🥝Badge-background-color: var(--stratakit-color-bg-mono-base);
 			}
 
 			&:where([data-kiwi-tone="info"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-info-base);
+				--🥝Badge-background-color: var(--stratakit-color-bg-info-base);
 			}
 
 			&:where([data-kiwi-tone="positive"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-positive-base);
+				--🥝Badge-background-color: var(--stratakit-color-bg-positive-base);
 			}
 
 			&:where([data-kiwi-tone="attention"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-attention-base);
+				--🥝Badge-background-color: var(--stratakit-color-bg-attention-base);
 			}
 
 			&:where([data-kiwi-tone="critical"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-critical-base);
+				--🥝Badge-background-color: var(--stratakit-color-bg-critical-base);
 			}
 
 			&:where([data-kiwi-tone="accent"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-accent-base);
+				--🥝Badge-background-color: var(--stratakit-color-bg-accent-base);
 			}
 		}
 
 		&:where([data-kiwi-variant="muted"]) {
 			&:where([data-kiwi-tone="neutral"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-mono-muted);
-				--🥝badge-border-color: var(--stratakit-color-border-mono-muted);
-				--🥝badge-text-color: var(--stratakit-color-text-mono-faded);
+				--🥝Badge-background-color: var(--stratakit-color-bg-mono-muted);
+				--🥝Badge-border-color: var(--stratakit-color-border-mono-muted);
+				--🥝Badge-text-color: var(--stratakit-color-text-mono-faded);
 			}
 
 			&:where([data-kiwi-tone="info"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-info-muted);
-				--🥝badge-border-color: var(--stratakit-color-border-info-muted);
-				--🥝badge-text-color: var(--stratakit-color-text-info-faded);
+				--🥝Badge-background-color: var(--stratakit-color-bg-info-muted);
+				--🥝Badge-border-color: var(--stratakit-color-border-info-muted);
+				--🥝Badge-text-color: var(--stratakit-color-text-info-faded);
 			}
 
 			&:where([data-kiwi-tone="positive"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-positive-muted);
-				--🥝badge-border-color: var(--stratakit-color-border-positive-muted);
-				--🥝badge-text-color: var(--stratakit-color-text-positive-faded);
+				--🥝Badge-background-color: var(--stratakit-color-bg-positive-muted);
+				--🥝Badge-border-color: var(--stratakit-color-border-positive-muted);
+				--🥝Badge-text-color: var(--stratakit-color-text-positive-faded);
 			}
 
 			&:where([data-kiwi-tone="attention"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-attention-muted);
-				--🥝badge-border-color: var(--stratakit-color-border-attention-muted);
-				--🥝badge-text-color: var(--stratakit-color-text-attention-faded);
+				--🥝Badge-background-color: var(--stratakit-color-bg-attention-muted);
+				--🥝Badge-border-color: var(--stratakit-color-border-attention-muted);
+				--🥝Badge-text-color: var(--stratakit-color-text-attention-faded);
 			}
 
 			&:where([data-kiwi-tone="critical"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-critical-muted);
-				--🥝badge-border-color: var(--stratakit-color-border-critical-muted);
-				--🥝badge-text-color: var(--stratakit-color-text-critical-faded);
+				--🥝Badge-background-color: var(--stratakit-color-bg-critical-muted);
+				--🥝Badge-border-color: var(--stratakit-color-border-critical-muted);
+				--🥝Badge-text-color: var(--stratakit-color-text-critical-faded);
 			}
 
 			&:where([data-kiwi-tone="accent"]) {
-				--🥝badge-background-color: var(--stratakit-color-bg-accent-muted);
-				--🥝badge-border-color: var(--stratakit-color-border-accent-muted);
-				--🥝badge-text-color: var(--stratakit-color-text-accent-faded);
+				--🥝Badge-background-color: var(--stratakit-color-bg-accent-muted);
+				--🥝Badge-border-color: var(--stratakit-color-border-accent-muted);
+				--🥝Badge-text-color: var(--stratakit-color-text-accent-faded);
 			}
 		}
 
 		&:where([data-kiwi-variant="outline"]) {
-			--🥝badge-background-color: transparent;
+			--🥝Badge-background-color: transparent;
 
 			&:where([data-kiwi-tone="neutral"]) {
-				--🥝badge-text-color: var(--stratakit-color-text-mono-base);
-				--🥝badge-border-color: var(--stratakit-color-border-mono-base);
+				--🥝Badge-text-color: var(--stratakit-color-text-mono-base);
+				--🥝Badge-border-color: var(--stratakit-color-border-mono-base);
 			}
 
 			&:where([data-kiwi-tone="info"]) {
-				--🥝badge-text-color: var(--stratakit-color-text-info-base);
-				--🥝badge-border-color: var(--stratakit-color-border-info-base);
+				--🥝Badge-text-color: var(--stratakit-color-text-info-base);
+				--🥝Badge-border-color: var(--stratakit-color-border-info-base);
 			}
 
 			&:where([data-kiwi-tone="positive"]) {
-				--🥝badge-text-color: var(--stratakit-color-text-positive-base);
-				--🥝badge-border-color: var(--stratakit-color-border-positive-base);
+				--🥝Badge-text-color: var(--stratakit-color-text-positive-base);
+				--🥝Badge-border-color: var(--stratakit-color-border-positive-base);
 			}
 
 			&:where([data-kiwi-tone="attention"]) {
-				--🥝badge-text-color: var(--stratakit-color-text-attention-base);
-				--🥝badge-border-color: var(--stratakit-color-border-attention-base);
+				--🥝Badge-text-color: var(--stratakit-color-text-attention-base);
+				--🥝Badge-border-color: var(--stratakit-color-border-attention-base);
 			}
 
 			&:where([data-kiwi-tone="critical"]) {
-				--🥝badge-text-color: var(--stratakit-color-text-critical-base);
-				--🥝badge-border-color: var(--stratakit-color-border-critical-base);
+				--🥝Badge-text-color: var(--stratakit-color-text-critical-base);
+				--🥝Badge-border-color: var(--stratakit-color-border-critical-base);
 			}
 
 			&:where([data-kiwi-tone="accent"]) {
-				--🥝badge-text-color: var(--stratakit-color-text-accent-base);
-				--🥝badge-border-color: var(--stratakit-color-border-accent-base);
+				--🥝Badge-text-color: var(--stratakit-color-text-accent-base);
+				--🥝Badge-border-color: var(--stratakit-color-border-accent-base);
 			}
 		}
 	}

--- a/packages/bricks/src/Badge.css
+++ b/packages/bricks/src/Badge.css
@@ -21,102 +21,102 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-variant="solid"]) {
+		&:where([data-_sk-variant="solid"]) {
 			--🥝Badge-border-color: var(--stratakit-color-border-glow-strong-default);
 			--🥝Badge-text-color: var(--stratakit-color-text-neutral-emphasis);
 
-			&:where([data-kiwi-tone="neutral"]) {
+			&:where([data-_sk-tone="neutral"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-mono-base);
 			}
 
-			&:where([data-kiwi-tone="info"]) {
+			&:where([data-_sk-tone="info"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-info-base);
 			}
 
-			&:where([data-kiwi-tone="positive"]) {
+			&:where([data-_sk-tone="positive"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-positive-base);
 			}
 
-			&:where([data-kiwi-tone="attention"]) {
+			&:where([data-_sk-tone="attention"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-attention-base);
 			}
 
-			&:where([data-kiwi-tone="critical"]) {
+			&:where([data-_sk-tone="critical"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-critical-base);
 			}
 
-			&:where([data-kiwi-tone="accent"]) {
+			&:where([data-_sk-tone="accent"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-accent-base);
 			}
 		}
 
-		&:where([data-kiwi-variant="muted"]) {
-			&:where([data-kiwi-tone="neutral"]) {
+		&:where([data-_sk-variant="muted"]) {
+			&:where([data-_sk-tone="neutral"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-mono-muted);
 				--🥝Badge-border-color: var(--stratakit-color-border-mono-muted);
 				--🥝Badge-text-color: var(--stratakit-color-text-mono-faded);
 			}
 
-			&:where([data-kiwi-tone="info"]) {
+			&:where([data-_sk-tone="info"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-info-muted);
 				--🥝Badge-border-color: var(--stratakit-color-border-info-muted);
 				--🥝Badge-text-color: var(--stratakit-color-text-info-faded);
 			}
 
-			&:where([data-kiwi-tone="positive"]) {
+			&:where([data-_sk-tone="positive"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-positive-muted);
 				--🥝Badge-border-color: var(--stratakit-color-border-positive-muted);
 				--🥝Badge-text-color: var(--stratakit-color-text-positive-faded);
 			}
 
-			&:where([data-kiwi-tone="attention"]) {
+			&:where([data-_sk-tone="attention"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-attention-muted);
 				--🥝Badge-border-color: var(--stratakit-color-border-attention-muted);
 				--🥝Badge-text-color: var(--stratakit-color-text-attention-faded);
 			}
 
-			&:where([data-kiwi-tone="critical"]) {
+			&:where([data-_sk-tone="critical"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-critical-muted);
 				--🥝Badge-border-color: var(--stratakit-color-border-critical-muted);
 				--🥝Badge-text-color: var(--stratakit-color-text-critical-faded);
 			}
 
-			&:where([data-kiwi-tone="accent"]) {
+			&:where([data-_sk-tone="accent"]) {
 				--🥝Badge-background-color: var(--stratakit-color-bg-accent-muted);
 				--🥝Badge-border-color: var(--stratakit-color-border-accent-muted);
 				--🥝Badge-text-color: var(--stratakit-color-text-accent-faded);
 			}
 		}
 
-		&:where([data-kiwi-variant="outline"]) {
+		&:where([data-_sk-variant="outline"]) {
 			--🥝Badge-background-color: transparent;
 
-			&:where([data-kiwi-tone="neutral"]) {
+			&:where([data-_sk-tone="neutral"]) {
 				--🥝Badge-text-color: var(--stratakit-color-text-mono-base);
 				--🥝Badge-border-color: var(--stratakit-color-border-mono-base);
 			}
 
-			&:where([data-kiwi-tone="info"]) {
+			&:where([data-_sk-tone="info"]) {
 				--🥝Badge-text-color: var(--stratakit-color-text-info-base);
 				--🥝Badge-border-color: var(--stratakit-color-border-info-base);
 			}
 
-			&:where([data-kiwi-tone="positive"]) {
+			&:where([data-_sk-tone="positive"]) {
 				--🥝Badge-text-color: var(--stratakit-color-text-positive-base);
 				--🥝Badge-border-color: var(--stratakit-color-border-positive-base);
 			}
 
-			&:where([data-kiwi-tone="attention"]) {
+			&:where([data-_sk-tone="attention"]) {
 				--🥝Badge-text-color: var(--stratakit-color-text-attention-base);
 				--🥝Badge-border-color: var(--stratakit-color-border-attention-base);
 			}
 
-			&:where([data-kiwi-tone="critical"]) {
+			&:where([data-_sk-tone="critical"]) {
 				--🥝Badge-text-color: var(--stratakit-color-text-critical-base);
 				--🥝Badge-border-color: var(--stratakit-color-border-critical-base);
 			}
 
-			&:where([data-kiwi-tone="accent"]) {
+			&:where([data-_sk-tone="accent"]) {
 				--🥝Badge-text-color: var(--stratakit-color-text-accent-base);
 				--🥝Badge-border-color: var(--stratakit-color-border-accent-base);
 			}

--- a/packages/bricks/src/Badge.css
+++ b/packages/bricks/src/Badge.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems: Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-badge {
+.🥝Badge {
 	@layer base {
 		@apply --typography("body-sm");
 
@@ -125,7 +125,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-badge {
+	.🥝Badge {
 		border: 1px solid;
 	}
 }

--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -43,8 +43,8 @@ const Badge = forwardRef<"span", BadgeProps>((props, forwardedRef) => {
 	return (
 		<Role.span
 			{...rest}
-			data-kiwi-tone={tone}
-			data-kiwi-variant={variant}
+			data-_sk-tone={tone}
+			data-_sk-variant={variant}
 			className={cx("🥝Badge", props.className)}
 			ref={forwardedRef}
 		>

--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -45,7 +45,7 @@ const Badge = forwardRef<"span", BadgeProps>((props, forwardedRef) => {
 			{...rest}
 			data-kiwi-tone={tone}
 			data-kiwi-variant={variant}
-			className={cx("🥝-badge", props.className)}
+			className={cx("🥝Badge", props.className)}
 			ref={forwardedRef}
 		>
 			{label}

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -9,7 +9,7 @@
 	--✨padding-inline: var(--stratakit-space-x3);
 	--✨padding-block: var(--stratakit-space-x1);
 
-	--✨shadow-border: 0px 0px 0px 1px var(--🥝button-border-color) inset;
+	--✨shadow-border: 0px 0px 0px 1px var(--🥝Button-border-color) inset;
 
 	--✨glow--bg-hover: var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%);
 	--✨glow--bg-press: var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-pressed-\%);
@@ -22,12 +22,12 @@
 	--✨bg--solid-accent-default: var(--stratakit-color-bg-accent-base);
 	--✨bg--solid-hover: color-mix(
 		in oklch,
-		var(--🥝button-bg--solid-default) 100%,
+		var(--🥝Button-bg--solid-default) 100%,
 		var(--✨glow--bg-hover)
 	);
 	--✨bg--solid-pressed: color-mix(
 		in oklch,
-		var(--🥝button-bg--solid-default) 100%,
+		var(--🥝Button-bg--solid-default) 100%,
 		var(--✨glow--bg-press)
 	);
 	--✨bg--solid-disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
@@ -177,132 +177,132 @@
 
 		min-block-size: var(--✨height);
 		border-radius: 4px;
-		padding-inline: var(--🥝button-padding-inline, var(--✨padding-inline));
+		padding-inline: var(--🥝Button-padding-inline, var(--✨padding-inline));
 		padding-block: var(--✨padding-block);
-		--🥝ghost-inline-offset: var(--✨padding-inline);
-		--🥝ghost-block-offset: var(--✨padding-block);
+		--🥝GhostAligner-inline-offset: var(--✨padding-inline);
+		--🥝GhostAligner-block-offset: var(--✨padding-block);
 
-		background-color: var(--🥝button-background-color);
+		background-color: var(--🥝Button-background-color);
 		box-shadow: var(--✨shadow-border);
-		color: var(--🥝button-color, var(--✨color--default));
+		color: var(--🥝Button-color, var(--✨color--default));
 		transition: background-color 150ms ease-out;
 		-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-neutral-pressed);
-		--🥝icon-color: var(--🌀button-state--default, var(--stratakit-color-icon-neutral-base))
-			var(--🌀button-state--hover, var(--stratakit-color-icon-neutral-hover))
-			var(--🌀button-state--pressed, var(--stratakit-color-icon-neutral-hover))
-			var(--🌀button-state--active, var(--stratakit-color-icon-accent-strong));
+		--🥝Icon-color: var(--🌀Button-state--default, var(--stratakit-color-icon-neutral-base))
+			var(--🌀Button-state--hover, var(--stratakit-color-icon-neutral-hover))
+			var(--🌀Button-state--pressed, var(--stratakit-color-icon-neutral-hover))
+			var(--🌀Button-state--active, var(--stratakit-color-icon-accent-strong));
 	}
 
 	@layer modifiers {
 		&:where([data-kiwi-variant="solid"]) {
-			--🥝button-background-color: var(--🌀button-state--default, var(--🥝button-bg--solid-default))
-				var(--🌀button-state--hover, var(--✨bg--solid-hover))
-				var(--🌀button-state--pressed, var(--✨bg--solid-pressed))
-				var(--🌀button-state--active, var(--✨bg--active))
-				var(--🌀button-state--disabled, var(--✨bg--solid-disabled));
-			box-shadow: var(--🌀button-state--default, var(--✨shadow--solid))
-				var(--🌀button-state--hover, var(--✨shadow--solid))
-				var(--🌀button-state--pressed, var(--✨shadow-border))
-				var(--🌀button-state--active, var(--✨shadow-border)) var(--🌀button-state--disabled, none);
+			--🥝Button-background-color: var(--🌀Button-state--default, var(--🥝Button-bg--solid-default))
+				var(--🌀Button-state--hover, var(--✨bg--solid-hover))
+				var(--🌀Button-state--pressed, var(--✨bg--solid-pressed))
+				var(--🌀Button-state--active, var(--✨bg--active))
+				var(--🌀Button-state--disabled, var(--✨bg--solid-disabled));
+			box-shadow: var(--🌀Button-state--default, var(--✨shadow--solid))
+				var(--🌀Button-state--hover, var(--✨shadow--solid))
+				var(--🌀Button-state--pressed, var(--✨shadow-border))
+				var(--🌀Button-state--active, var(--✨shadow-border)) var(--🌀Button-state--disabled, none);
 
 			&:where([data-kiwi-tone="neutral"]) {
-				--🥝button-bg--solid-default: var(--✨bg--solid-neutral-default);
-				--🥝button-border-color: var(
-						--🌀button-state--default,
+				--🥝Button-bg--solid-default: var(--✨bg--solid-neutral-default);
+				--🥝Button-border-color: var(
+						--🌀Button-state--default,
 						var(--✨border--solid-neutral-default)
 					)
-					var(--🌀button-state--hover, var(--✨border--solid-neutral-hover))
-					var(--🌀button-state--pressed, var(--✨border--solid-neutral-pressed))
-					var(--🌀button-state--active, var(--✨border--active))
-					var(--🌀button-state--disabled, var(--✨border--solid-neutral-disabled));
+					var(--🌀Button-state--hover, var(--✨border--solid-neutral-hover))
+					var(--🌀Button-state--pressed, var(--✨border--solid-neutral-pressed))
+					var(--🌀Button-state--active, var(--✨border--active))
+					var(--🌀Button-state--disabled, var(--✨border--solid-neutral-disabled));
 			}
 
 			&:where([data-kiwi-tone="accent"]) {
-				--🥝button-bg--solid-default: var(--✨bg--solid-accent-default);
-				--🥝button-border-color: var(
-						--🌀button-state--default,
+				--🥝Button-bg--solid-default: var(--✨bg--solid-accent-default);
+				--🥝Button-border-color: var(
+						--🌀Button-state--default,
 						var(--✨border--solid-accent-default)
 					)
-					var(--🌀button-state--hover, var(--✨border--solid-accent-hover))
-					var(--🌀button-state--pressed, var(--✨border--solid-accent-pressed))
-					var(--🌀button-state--active, var(--✨border--active))
-					var(--🌀button-state--disabled, var(--✨border--solid-accent-disabled));
+					var(--🌀Button-state--hover, var(--✨border--solid-accent-hover))
+					var(--🌀Button-state--pressed, var(--✨border--solid-accent-pressed))
+					var(--🌀Button-state--active, var(--✨border--active))
+					var(--🌀Button-state--disabled, var(--✨border--solid-accent-disabled));
 
-				--🥝button-color: var(--stratakit-color-text-neutral-emphasis);
-				--🥝icon-color: var(--stratakit-color-icon-neutral-emphasis);
+				--🥝Button-color: var(--stratakit-color-text-neutral-emphasis);
+				--🥝Icon-color: var(--stratakit-color-icon-neutral-emphasis);
 				-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 			}
 		}
 
 		&:where([data-kiwi-variant="outline"]) {
 			&:where([data-kiwi-tone="neutral"]) {
-				--🥝button-background-color: var(--🌀button-state--default, var(--✨bg--outline-default))
-					var(--🌀button-state--hover, var(--✨bg--outline-hover))
-					var(--🌀button-state--pressed, var(--✨bg--outline-pressed))
-					var(--🌀button-state--active, var(--✨bg--active))
-					var(--🌀button-state--disabled, var(--✨bg--outline-disabled));
-				--🥝button-border-color: var(--🌀button-state--default, var(--✨border--outline-default))
-					var(--🌀button-state--hover, var(--✨border--outline-hover))
-					var(--🌀button-state--pressed, var(--✨border--outline-pressed))
-					var(--🌀button-state--active, var(--✨border--active))
-					var(--🌀button-state--disabled, var(--✨border--outline-disabled));
+				--🥝Button-background-color: var(--🌀Button-state--default, var(--✨bg--outline-default))
+					var(--🌀Button-state--hover, var(--✨bg--outline-hover))
+					var(--🌀Button-state--pressed, var(--✨bg--outline-pressed))
+					var(--🌀Button-state--active, var(--✨bg--active))
+					var(--🌀Button-state--disabled, var(--✨bg--outline-disabled));
+				--🥝Button-border-color: var(--🌀Button-state--default, var(--✨border--outline-default))
+					var(--🌀Button-state--hover, var(--✨border--outline-hover))
+					var(--🌀Button-state--pressed, var(--✨border--outline-pressed))
+					var(--🌀Button-state--active, var(--✨border--active))
+					var(--🌀Button-state--disabled, var(--✨border--outline-disabled));
 			}
 
 			&:where([data-kiwi-tone="accent"]) {
-				--🥝button-background-color: var(
-						--🌀button-state--default,
+				--🥝Button-background-color: var(
+						--🌀Button-state--default,
 						var(--✨bg--outline-accent-default)
 					)
-					var(--🌀button-state--hover, var(--✨bg--outline-accent-hover))
-					var(--🌀button-state--pressed, var(--✨bg--outline-accent-pressed))
-					var(--🌀button-state--active, var(--✨bg--active))
-					var(--🌀button-state--disabled, var(--✨bg--outline-accent-disabled));
-				--🥝button-border-color: var(
-						--🌀button-state--default,
+					var(--🌀Button-state--hover, var(--✨bg--outline-accent-hover))
+					var(--🌀Button-state--pressed, var(--✨bg--outline-accent-pressed))
+					var(--🌀Button-state--active, var(--✨bg--active))
+					var(--🌀Button-state--disabled, var(--✨bg--outline-accent-disabled));
+				--🥝Button-border-color: var(
+						--🌀Button-state--default,
 						var(--✨border--outline-accent-default)
 					)
-					var(--🌀button-state--hover, var(--✨border--outline-accent-hover))
-					var(--🌀button-state--pressed, var(--✨border--outline-accent-pressed))
-					var(--🌀button-state--active, var(--✨border--active))
-					var(--🌀button-state--disabled, var(--✨border--outline-accent-disabled));
-				--🥝button-color: var(--🌀button-state--default, var(--✨color--outline-accent-default))
-					var(--🌀button-state--hover, var(--✨color--outline-accent-hover))
-					var(--🌀button-state--pressed, var(--✨color--outline-accent-pressed));
-				--🥝icon-color: var(--🌀button-state--default, var(--✨icon--outline-accent-default))
-					var(--🌀button-state--hover, var(--✨icon--outline-accent-hover))
-					var(--🌀button-state--pressed, var(--✨icon--outline-accent-pressed));
+					var(--🌀Button-state--hover, var(--✨border--outline-accent-hover))
+					var(--🌀Button-state--pressed, var(--✨border--outline-accent-pressed))
+					var(--🌀Button-state--active, var(--✨border--active))
+					var(--🌀Button-state--disabled, var(--✨border--outline-accent-disabled));
+				--🥝Button-color: var(--🌀Button-state--default, var(--✨color--outline-accent-default))
+					var(--🌀Button-state--hover, var(--✨color--outline-accent-hover))
+					var(--🌀Button-state--pressed, var(--✨color--outline-accent-pressed));
+				--🥝Icon-color: var(--🌀Button-state--default, var(--✨icon--outline-accent-default))
+					var(--🌀Button-state--hover, var(--✨icon--outline-accent-hover))
+					var(--🌀Button-state--pressed, var(--✨icon--outline-accent-pressed));
 			}
 		}
 
 		&:where([data-kiwi-variant="ghost"]) {
-			--🥝button-border-color: var(--🌀button-state--default, transparent)
-				var(--🌀button-state--hover, transparent) var(--🌀button-state--pressed, transparent)
-				var(--🌀button-state--active, var(--✨border--active))
-				var(--🌀button-state--disabled, transparent);
+			--🥝Button-border-color: var(--🌀Button-state--default, transparent)
+				var(--🌀Button-state--hover, transparent) var(--🌀Button-state--pressed, transparent)
+				var(--🌀Button-state--active, var(--✨border--active))
+				var(--🌀Button-state--disabled, transparent);
 
 			&:where([data-kiwi-tone="neutral"]) {
-				--🥝button-background-color: var(--🌀button-state--default, var(--✨bg--ghost-default))
-					var(--🌀button-state--hover, var(--✨bg--ghost-hover))
-					var(--🌀button-state--pressed, var(--✨bg--ghost-pressed))
-					var(--🌀button-state--active, var(--✨bg--active))
-					var(--🌀button-state--disabled, var(--✨bg--ghost-disabled));
+				--🥝Button-background-color: var(--🌀Button-state--default, var(--✨bg--ghost-default))
+					var(--🌀Button-state--hover, var(--✨bg--ghost-hover))
+					var(--🌀Button-state--pressed, var(--✨bg--ghost-pressed))
+					var(--🌀Button-state--active, var(--✨bg--active))
+					var(--🌀Button-state--disabled, var(--✨bg--ghost-disabled));
 			}
 
 			&:where([data-kiwi-tone="accent"]) {
-				--🥝button-background-color: var(
-						--🌀button-state--default,
+				--🥝Button-background-color: var(
+						--🌀Button-state--default,
 						var(--✨bg--ghost-accent-default)
 					)
-					var(--🌀button-state--hover, var(--✨bg--ghost-accent-hover))
-					var(--🌀button-state--pressed, var(--✨bg--ghost-accent-pressed))
-					var(--🌀button-state--active, var(--✨bg--active))
-					var(--🌀button-state--disabled, var(--✨bg--ghost-accent-disabled));
-				--🥝button-color: var(--🌀button-state--default, var(--✨color--ghost-accent-default))
-					var(--🌀button-state--hover, var(--✨color--ghost-accent-hover))
-					var(--🌀button-state--pressed, var(--✨color--ghost-accent-pressed));
-				--🥝icon-color: var(--🌀button-state--default, var(--✨icon--ghost-accent-default))
-					var(--🌀button-state--hover, var(--✨icon--ghost-accent-hover))
-					var(--🌀button-state--pressed, var(--✨icon--ghost-accent-pressed));
+					var(--🌀Button-state--hover, var(--✨bg--ghost-accent-hover))
+					var(--🌀Button-state--pressed, var(--✨bg--ghost-accent-pressed))
+					var(--🌀Button-state--active, var(--✨bg--active))
+					var(--🌀Button-state--disabled, var(--✨bg--ghost-accent-disabled));
+				--🥝Button-color: var(--🌀Button-state--default, var(--✨color--ghost-accent-default))
+					var(--🌀Button-state--hover, var(--✨color--ghost-accent-hover))
+					var(--🌀Button-state--pressed, var(--✨color--ghost-accent-pressed));
+				--🥝Icon-color: var(--🌀Button-state--default, var(--✨icon--ghost-accent-default))
+					var(--🌀Button-state--hover, var(--✨icon--ghost-accent-hover))
+					var(--🌀Button-state--pressed, var(--✨icon--ghost-accent-pressed));
 			}
 		}
 	}
@@ -310,40 +310,40 @@
 	@layer states {
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀button-state: var(--🌀button-state--hover);
+				--🌀Button-state: var(--🌀Button-state--hover);
 			}
 		}
 
 		/* Reuse hover state when an associated popover is open. */
 		&:where([data-has-popover-open]) {
-			--🌀button-state: var(--🌀button-state--hover);
+			--🌀Button-state: var(--🌀Button-state--hover);
 		}
 
 		&:where(:active) {
-			--🌀button-state: var(--🌀button-state--pressed);
+			--🌀Button-state: var(--🌀Button-state--pressed);
 		}
 
 		&:where([aria-pressed="true"]) {
-			--🌀button-state: var(--🌀button-state--active);
+			--🌀Button-state: var(--🌀Button-state--active);
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {
-			--🌀button-state: var(--🌀button-state--disabled);
+			--🌀Button-state: var(--🌀Button-state--disabled);
 			color: var(--stratakit-color-text-neutral-disabled);
 			cursor: not-allowed;
 			-webkit-tap-highlight-color: transparent;
-			--🥝icon-color: var(--stratakit-color-icon-neutral-disabled);
+			--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
 		}
 	}
 
 	@layer base.🌀 {
 		/* Cyclic toggles for default/hover/pressed/active/disabled states. See https://kizu.dev/cyclic-toggles/ */
-		--🌀button-state: var(--🌀button-state--default);
-		--🌀button-state--default: var(--🌀button-state,);
-		--🌀button-state--hover: var(--🌀button-state,);
-		--🌀button-state--pressed: var(--🌀button-state,);
-		--🌀button-state--active: var(--🌀button-state,);
-		--🌀button-state--disabled: var(--🌀button-state,);
+		--🌀Button-state: var(--🌀Button-state--default);
+		--🌀Button-state--default: var(--🌀Button-state,);
+		--🌀Button-state--hover: var(--🌀Button-state,);
+		--🌀Button-state--pressed: var(--🌀Button-state,);
+		--🌀Button-state--active: var(--🌀Button-state,);
+		--🌀Button-state--disabled: var(--🌀Button-state,);
 	}
 }
 

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -194,7 +194,7 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-variant="solid"]) {
+		&:where([data-_sk-variant="solid"]) {
 			--🥝Button-background-color: var(--🌀Button-state--default, var(--🥝Button-bg--solid-default))
 				var(--🌀Button-state--hover, var(--✨bg--solid-hover))
 				var(--🌀Button-state--pressed, var(--✨bg--solid-pressed))
@@ -205,7 +205,7 @@
 				var(--🌀Button-state--pressed, var(--✨shadow-border))
 				var(--🌀Button-state--active, var(--✨shadow-border)) var(--🌀Button-state--disabled, none);
 
-			&:where([data-kiwi-tone="neutral"]) {
+			&:where([data-_sk-tone="neutral"]) {
 				--🥝Button-bg--solid-default: var(--✨bg--solid-neutral-default);
 				--🥝Button-border-color: var(
 						--🌀Button-state--default,
@@ -217,7 +217,7 @@
 					var(--🌀Button-state--disabled, var(--✨border--solid-neutral-disabled));
 			}
 
-			&:where([data-kiwi-tone="accent"]) {
+			&:where([data-_sk-tone="accent"]) {
 				--🥝Button-bg--solid-default: var(--✨bg--solid-accent-default);
 				--🥝Button-border-color: var(
 						--🌀Button-state--default,
@@ -234,8 +234,8 @@
 			}
 		}
 
-		&:where([data-kiwi-variant="outline"]) {
-			&:where([data-kiwi-tone="neutral"]) {
+		&:where([data-_sk-variant="outline"]) {
+			&:where([data-_sk-tone="neutral"]) {
 				--🥝Button-background-color: var(--🌀Button-state--default, var(--✨bg--outline-default))
 					var(--🌀Button-state--hover, var(--✨bg--outline-hover))
 					var(--🌀Button-state--pressed, var(--✨bg--outline-pressed))
@@ -248,7 +248,7 @@
 					var(--🌀Button-state--disabled, var(--✨border--outline-disabled));
 			}
 
-			&:where([data-kiwi-tone="accent"]) {
+			&:where([data-_sk-tone="accent"]) {
 				--🥝Button-background-color: var(
 						--🌀Button-state--default,
 						var(--✨bg--outline-accent-default)
@@ -274,13 +274,13 @@
 			}
 		}
 
-		&:where([data-kiwi-variant="ghost"]) {
+		&:where([data-_sk-variant="ghost"]) {
 			--🥝Button-border-color: var(--🌀Button-state--default, transparent)
 				var(--🌀Button-state--hover, transparent) var(--🌀Button-state--pressed, transparent)
 				var(--🌀Button-state--active, var(--✨border--active))
 				var(--🌀Button-state--disabled, transparent);
 
-			&:where([data-kiwi-tone="neutral"]) {
+			&:where([data-_sk-tone="neutral"]) {
 				--🥝Button-background-color: var(--🌀Button-state--default, var(--✨bg--ghost-default))
 					var(--🌀Button-state--hover, var(--✨bg--ghost-hover))
 					var(--🌀Button-state--pressed, var(--✨bg--ghost-pressed))
@@ -288,7 +288,7 @@
 					var(--🌀Button-state--disabled, var(--✨bg--ghost-disabled));
 			}
 
-			&:where([data-kiwi-tone="accent"]) {
+			&:where([data-_sk-tone="accent"]) {
 				--🥝Button-background-color: var(
 						--🌀Button-state--default,
 						var(--✨bg--ghost-accent-default)

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-button {
+.🥝Button {
 	--✨color--default: var(--stratakit-color-text-neutral-primary);
 	--✨gap: var(--stratakit-space-x1);
 	--✨height: 1.5rem;
@@ -348,7 +348,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-button {
+	.🥝Button {
 		background-color: ButtonFace;
 		border: 1px solid ButtonBorder;
 		color: ButtonText;

--- a/packages/bricks/src/Button.tsx
+++ b/packages/bricks/src/Button.tsx
@@ -59,8 +59,8 @@ const Button = forwardRef<"button", ButtonProps>((props, forwardedRef) => {
 			data-kiwi-tone={tone}
 			data-kiwi-ghost-align={variant === "ghost" ? ghostAlignment : undefined}
 			className={cx(
-				"🥝-button",
-				{ "🥝-ghost-aligner": variant === "ghost" },
+				"🥝Button",
+				{ "🥝GhostAligner": variant === "ghost" },
 				props.className,
 			)}
 			ref={forwardedRef}

--- a/packages/bricks/src/Button.tsx
+++ b/packages/bricks/src/Button.tsx
@@ -55,9 +55,9 @@ const Button = forwardRef<"button", ButtonProps>((props, forwardedRef) => {
 		<AkButton
 			accessibleWhenDisabled
 			{...rest}
-			data-kiwi-variant={variant}
-			data-kiwi-tone={tone}
-			data-kiwi-ghost-align={variant === "ghost" ? ghostAlignment : undefined}
+			data-_sk-variant={variant}
+			data-_sk-tone={tone}
+			data-_sk-ghost-align={variant === "ghost" ? ghostAlignment : undefined}
 			className={cx(
 				"🥝Button",
 				{ "🥝GhostAligner": variant === "ghost" },

--- a/packages/bricks/src/Checkbox.css
+++ b/packages/bricks/src/Checkbox.css
@@ -5,7 +5,7 @@
 .🥝Checkbox {
 	--✨size: 1rem;
 
-	--✨shadow-border: 0px 0px 0px 1px var(--🥝checkbox-border-color) inset;
+	--✨shadow-border: 0px 0px 0px 1px var(--🥝Checkbox-border-color) inset;
 
 	--✨glow--bg-hover: var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%);
 	--✨glow--bg-press: var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-pressed-\%);
@@ -31,46 +31,46 @@
 	--✨border--disabled: transparent;
 
 	@layer base {
-		--🥝checkbox-color-svg: var(--stratakit-color-icon-neutral-emphasis);
-		--🥝checkbox-border-radius: 4px;
+		--🥝Checkbox-color-svg: var(--stratakit-color-icon-neutral-emphasis);
+		--🥝Checkbox-border-radius: 4px;
 
-		--🥝checkbox-unchecked-svg: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');
-		--🥝checkbox-checkmark-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M11.73 5.47a.75.75 0 0 1 0 1.06l-4.4 4.4a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06L6.8 9.34l3.87-3.87a.75.75 0 0 1 1.06 0Z"/></svg>');
-		--🥝checkbox-indeterminate-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M4.25 8A.75.75 0 0 1 5 7.25h6.5a.75.75 0 0 1 0 1.5H5A.75.75 0 0 1 4.25 8Z"/></svg>');
+		--🥝Checkbox-unchecked-svg: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');
+		--🥝Checkbox-checkmark-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M11.73 5.47a.75.75 0 0 1 0 1.06l-4.4 4.4a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06L6.8 9.34l3.87-3.87a.75.75 0 0 1 1.06 0Z"/></svg>');
+		--🥝Checkbox-indeterminate-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M4.25 8A.75.75 0 0 1 5 7.25h6.5a.75.75 0 0 1 0 1.5H5A.75.75 0 0 1 4.25 8Z"/></svg>');
 
 		appearance: none;
 		inline-size: var(--✨size);
 		block-size: var(--✨size);
 		cursor: pointer;
 
-		background-color: var(--🌀checkbox-visual-state--default, var(--✨bg--default))
-			var(--🌀checkbox-visual-state--hover, var(--✨bg--hover))
-			var(--🌀checkbox-visual-state--checked, var(--✨bg--checked))
-			var(--🌀checkbox-visual-state--checked-hover, var(--✨bg--checked-hover))
-			var(--🌀checkbox-visual-state--disabled, var(--✨bg--disabled));
-		border-radius: var(--🥝checkbox-border-radius);
-		color: var(--🌀checkbox-aria-state--unchecked, transparent)
-			var(--🌀checkbox-aria-state--checked, var(--🥝checkbox-color-svg))
-			var(--🌀checkbox-aria-state--indeterminate, var(--🥝checkbox-color-svg));
+		background-color: var(--🌀Checkbox-visual-state--default, var(--✨bg--default))
+			var(--🌀Checkbox-visual-state--hover, var(--✨bg--hover))
+			var(--🌀Checkbox-visual-state--checked, var(--✨bg--checked))
+			var(--🌀Checkbox-visual-state--checked-hover, var(--✨bg--checked-hover))
+			var(--🌀Checkbox-visual-state--disabled, var(--✨bg--disabled));
+		border-radius: var(--🥝Checkbox-border-radius);
+		color: var(--🌀Checkbox-aria-state--unchecked, transparent)
+			var(--🌀Checkbox-aria-state--checked, var(--🥝Checkbox-color-svg))
+			var(--🌀Checkbox-aria-state--indeterminate, var(--🥝Checkbox-color-svg));
 		transition: all 150ms ease-out;
-		transition-property: background-color, border-color, box-shadow, --🥝checkbox-border-color;
+		transition-property: background-color, border-color, box-shadow, --🥝Checkbox-border-color;
 		position: relative;
 		box-shadow:
 			var(--stratakit-shadow-button-base-inset), var(--✨shadow-border),
 			var(--stratakit-shadow-button-base-drop);
 		-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 
-		--🥝checkbox-border-color: var(--🌀checkbox-visual-state--default, var(--✨border--default))
-			var(--🌀checkbox-visual-state--hover, var(--✨border--hover))
-			var(--🌀checkbox-visual-state--checked, var(--✨border--checked))
-			var(--🌀checkbox-visual-state--checked-hover, var(--✨border--checked-hover))
-			var(--🌀checkbox-visual-state--disabled, var(--✨border--disabled));
-		--🥝checkbox-mask-image: var(
-				--🌀checkbox-aria-state--unchecked,
-				var(--🥝checkbox-unchecked-svg)
+		--🥝Checkbox-border-color: var(--🌀Checkbox-visual-state--default, var(--✨border--default))
+			var(--🌀Checkbox-visual-state--hover, var(--✨border--hover))
+			var(--🌀Checkbox-visual-state--checked, var(--✨border--checked))
+			var(--🌀Checkbox-visual-state--checked-hover, var(--✨border--checked-hover))
+			var(--🌀Checkbox-visual-state--disabled, var(--✨border--disabled));
+		--🥝Checkbox-mask-image: var(
+				--🌀Checkbox-aria-state--unchecked,
+				var(--🥝Checkbox-unchecked-svg)
 			)
-			var(--🌀checkbox-aria-state--checked, var(--🥝checkbox-checkmark-svg))
-			var(--🌀checkbox-aria-state--indeterminate, var(--🥝checkbox-indeterminate-svg));
+			var(--🌀Checkbox-aria-state--checked, var(--🥝Checkbox-checkmark-svg))
+			var(--🌀Checkbox-aria-state--indeterminate, var(--🥝Checkbox-indeterminate-svg));
 
 		&::before,
 		&::after {
@@ -84,10 +84,10 @@
 			inset: calc((var(--✨size) - var(--stratakit-space-x6)) / 2);
 		}
 
-		/* This pseudo-element adds the actual checkmark SVG via --🥝checkbox-mask-image */
+		/* This pseudo-element adds the actual checkmark SVG via --🥝Checkbox-mask-image */
 		&::after {
 			background-color: currentColor;
-			mask-image: var(--🥝checkbox-mask-image, initial);
+			mask-image: var(--🥝Checkbox-mask-image, initial);
 			mask-repeat: no-repeat;
 			mask-position: center;
 		}
@@ -96,29 +96,29 @@
 	@layer states {
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀checkbox-visual-state: var(--🌀checkbox-visual-state--hover);
+				--🌀Checkbox-visual-state: var(--🌀Checkbox-visual-state--hover);
 			}
 		}
 
 		&:where(:checked, [aria-checked="true"]) {
-			--🌀checkbox-visual-state: var(--🌀checkbox-visual-state--checked);
-			--🌀checkbox-aria-state: var(--🌀checkbox-aria-state--checked);
+			--🌀Checkbox-visual-state: var(--🌀Checkbox-visual-state--checked);
+			--🌀Checkbox-aria-state: var(--🌀Checkbox-aria-state--checked);
 
 			@media (any-hover: hover) {
 				&:where(:hover) {
-					--🌀checkbox-visual-state: var(--🌀checkbox-visual-state--checked-hover);
+					--🌀Checkbox-visual-state: var(--🌀Checkbox-visual-state--checked-hover);
 				}
 			}
 		}
 
 		&:where(:indeterminate, [aria-checked="mixed"]) {
-			--🌀checkbox-visual-state: var(--🌀checkbox-visual-state--checked);
-			--🌀checkbox-aria-state: var(--🌀checkbox-aria-state--indeterminate);
+			--🌀Checkbox-visual-state: var(--🌀Checkbox-visual-state--checked);
+			--🌀Checkbox-aria-state: var(--🌀Checkbox-aria-state--indeterminate);
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {
-			--🌀checkbox-visual-state: var(--🌀checkbox-visual-state--disabled);
-			--🥝checkbox-color-svg: var(--stratakit-color-icon-neutral-disabled);
+			--🌀Checkbox-visual-state: var(--🌀Checkbox-visual-state--disabled);
+			--🥝Checkbox-color-svg: var(--stratakit-color-icon-neutral-disabled);
 			cursor: not-allowed;
 			box-shadow: none;
 			-webkit-tap-highlight-color: transparent;
@@ -127,18 +127,18 @@
 
 	@layer base.🌀 {
 		/* Cyclic toggles for default/hover/checked/checked+hover/disabled states. See https://kizu.dev/cyclic-toggles/ */
-		--🌀checkbox-visual-state: var(--🌀checkbox-visual-state--default);
-		--🌀checkbox-visual-state--default: var(--🌀checkbox-visual-state,);
-		--🌀checkbox-visual-state--hover: var(--🌀checkbox-visual-state,);
-		--🌀checkbox-visual-state--checked: var(--🌀checkbox-visual-state,);
-		--🌀checkbox-visual-state--checked-hover: var(--🌀checkbox-visual-state,);
-		--🌀checkbox-visual-state--disabled: var(--🌀checkbox-visual-state,);
+		--🌀Checkbox-visual-state: var(--🌀Checkbox-visual-state--default);
+		--🌀Checkbox-visual-state--default: var(--🌀Checkbox-visual-state,);
+		--🌀Checkbox-visual-state--hover: var(--🌀Checkbox-visual-state,);
+		--🌀Checkbox-visual-state--checked: var(--🌀Checkbox-visual-state,);
+		--🌀Checkbox-visual-state--checked-hover: var(--🌀Checkbox-visual-state,);
+		--🌀Checkbox-visual-state--disabled: var(--🌀Checkbox-visual-state,);
 
 		/* Cyclic toggles for unchecked/checked/indeterminate states. */
-		--🌀checkbox-aria-state: var(--🌀checkbox-aria-state--unchecked);
-		--🌀checkbox-aria-state--unchecked: var(--🌀checkbox-aria-state,);
-		--🌀checkbox-aria-state--checked: var(--🌀checkbox-aria-state,);
-		--🌀checkbox-aria-state--indeterminate: var(--🌀checkbox-aria-state,);
+		--🌀Checkbox-aria-state: var(--🌀Checkbox-aria-state--unchecked);
+		--🌀Checkbox-aria-state--unchecked: var(--🌀Checkbox-aria-state,);
+		--🌀Checkbox-aria-state--checked: var(--🌀Checkbox-aria-state,);
+		--🌀Checkbox-aria-state--indeterminate: var(--🌀Checkbox-aria-state,);
 	}
 }
 

--- a/packages/bricks/src/Checkbox.css
+++ b/packages/bricks/src/Checkbox.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-checkbox {
+.🥝Checkbox {
 	--✨size: 1rem;
 
 	--✨shadow-border: 0px 0px 0px 1px var(--🥝checkbox-border-color) inset;
@@ -143,7 +143,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-checkbox {
+	.🥝Checkbox {
 		border: 1px solid CanvasText;
 
 		&:where(

--- a/packages/bricks/src/Checkbox.tsx
+++ b/packages/bricks/src/Checkbox.tsx
@@ -52,7 +52,7 @@ const Checkbox = forwardRef<"input", CheckboxProps>((props, forwardedRef) => {
 		<AkCheckbox
 			accessibleWhenDisabled
 			{...props}
-			className={cx("🥝-checkbox", props.className)}
+			className={cx("🥝Checkbox", props.className)}
 			ref={forwardedRef}
 		/>
 	);

--- a/packages/bricks/src/Description.css
+++ b/packages/bricks/src/Description.css
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝Description:is(.🥝Text) {
 	@layer modifiers {
-		&:where([data-kiwi-tone="neutral"]) {
+		&:where([data-_sk-tone="neutral"]) {
 			color: var(--stratakit-color-text-neutral-tertiary);
 		}
 
-		&:where([data-kiwi-tone="critical"]) {
+		&:where([data-_sk-tone="critical"]) {
 			color: var(--stratakit-color-text-critical-base);
 		}
 	}

--- a/packages/bricks/src/Description.css
+++ b/packages/bricks/src/Description.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-description:is(.🥝-text) {
+.🥝Description:is(.🥝Text) {
 	@layer modifiers {
 		&:where([data-kiwi-tone="neutral"]) {
 			color: var(--stratakit-color-text-neutral-tertiary);

--- a/packages/bricks/src/Description.tsx
+++ b/packages/bricks/src/Description.tsx
@@ -31,7 +31,7 @@ const Description = forwardRef<"div", DescriptionProps>(
 				{...rest}
 				variant="caption-lg"
 				data-kiwi-tone={tone ?? "neutral"}
-				className={cx("🥝-description", props.className)}
+				className={cx("🥝Description", props.className)}
 				ref={forwardedRef}
 			/>
 		);

--- a/packages/bricks/src/Description.tsx
+++ b/packages/bricks/src/Description.tsx
@@ -30,7 +30,7 @@ const Description = forwardRef<"div", DescriptionProps>(
 			<Text
 				{...rest}
 				variant="caption-lg"
-				data-kiwi-tone={tone ?? "neutral"}
+				data-_sk-tone={tone ?? "neutral"}
 				className={cx("🥝Description", props.className)}
 				ref={forwardedRef}
 			/>

--- a/packages/bricks/src/Divider.css
+++ b/packages/bricks/src/Divider.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-divider {
+.🥝Divider {
 	@layer base {
 		flex: 0 0 auto;
 		align-self: stretch;
@@ -31,7 +31,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-divider {
+	.🥝Divider {
 		background-color: CanvasText;
 	}
 }

--- a/packages/bricks/src/Divider.css
+++ b/packages/bricks/src/Divider.css
@@ -17,15 +17,15 @@
 	@layer modifiers {
 		&:where(:not([aria-orientation="vertical"], [data-kiwi-orientation="vertical"])) {
 			block-size: 1px;
-			margin-inline: var(--🥝divider-main-axis-margin);
-			margin-block: var(--🥝divider-cross-axis-margin);
+			margin-inline: var(--🥝Divider-main-axis-margin);
+			margin-block: var(--🥝Divider-cross-axis-margin);
 		}
 
 		&:where([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
 			inline-size: 1px;
 			min-block-size: 100%;
-			margin-inline: var(--🥝divider-cross-axis-margin);
-			margin-block: var(--🥝divider-main-axis-margin);
+			margin-inline: var(--🥝Divider-cross-axis-margin);
+			margin-block: var(--🥝Divider-main-axis-margin);
 		}
 	}
 }

--- a/packages/bricks/src/Divider.css
+++ b/packages/bricks/src/Divider.css
@@ -15,13 +15,13 @@
 	}
 
 	@layer modifiers {
-		&:where(:not([aria-orientation="vertical"], [data-kiwi-orientation="vertical"])) {
+		&:where(:not([aria-orientation="vertical"], [data-_sk-orientation="vertical"])) {
 			block-size: 1px;
 			margin-inline: var(--🥝Divider-main-axis-margin);
 			margin-block: var(--🥝Divider-cross-axis-margin);
 		}
 
-		&:where([aria-orientation="vertical"], [data-kiwi-orientation="vertical"]) {
+		&:where([aria-orientation="vertical"], [data-_sk-orientation="vertical"]) {
 			inline-size: 1px;
 			min-block-size: 100%;
 			margin-inline: var(--🥝Divider-cross-axis-margin);

--- a/packages/bricks/src/Divider.tsx
+++ b/packages/bricks/src/Divider.tsx
@@ -36,7 +36,7 @@ const Divider = forwardRef<"hr", DividerProps>((props, forwardedRef) => {
 	return (
 		<Comp
 			{...rest}
-			className={cx("🥝-divider", props.className)}
+			className={cx("🥝Divider", props.className)}
 			data-kiwi-orientation={props.orientation}
 			ref={forwardedRef}
 		/>

--- a/packages/bricks/src/Divider.tsx
+++ b/packages/bricks/src/Divider.tsx
@@ -37,7 +37,7 @@ const Divider = forwardRef<"hr", DividerProps>((props, forwardedRef) => {
 		<Comp
 			{...rest}
 			className={cx("🥝Divider", props.className)}
-			data-kiwi-orientation={props.orientation}
+			data-_sk-orientation={props.orientation}
 			ref={forwardedRef}
 		/>
 	);

--- a/packages/bricks/src/Field.css
+++ b/packages/bricks/src/Field.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-field {
+.🥝Field {
 	--✨layout-inline-label-first: [label-start] auto [label-end control-start] auto [control-end];
 	--✨layout-inline-control-first: [control-start] auto [control-end label-start] auto [label-end];
 	--✨layout-stacked: [label-start control-start] auto [label-end control-end];
@@ -38,7 +38,7 @@
 			}
 		}
 
-		:where(.🥝-description) {
+		:where(.🥝Description) {
 			grid-column: var(--🥝field-description-column);
 		}
 	}

--- a/packages/bricks/src/Field.css
+++ b/packages/bricks/src/Field.css
@@ -17,7 +17,7 @@
 		grid-template-columns: var(--✨layout-inline-label-first);
 
 		/* By default align the descriptions with the label */
-		--🥝field-description-column: label-start / label-end;
+		--🥝FieldDescription-column: label-start / label-end;
 
 		/* With checkable fields, when the label is not first, switch to control-first layout */
 		&:where([data-kiwi-control-type="checkable"][data-kiwi-label-placement="after"]) {
@@ -26,7 +26,7 @@
 
 		&:where([data-kiwi-control-type="textlike"]) {
 			/* Descriptions should be aligned with the control for text and combobox controls */
-			--🥝field-description-column: control-start / control-end;
+			--🥝FieldDescription-column: control-start / control-end;
 
 			/* Align labels with the control text (when inline) */
 			align-items: baseline;
@@ -39,7 +39,7 @@
 		}
 
 		:where(.🥝Description) {
-			grid-column: var(--🥝field-description-column);
+			grid-column: var(--🥝FieldDescription-column);
 		}
 	}
 }

--- a/packages/bricks/src/Field.css
+++ b/packages/bricks/src/Field.css
@@ -20,11 +20,11 @@
 		--🥝FieldDescription-column: label-start / label-end;
 
 		/* With checkable fields, when the label is not first, switch to control-first layout */
-		&:where([data-kiwi-control-type="checkable"][data-kiwi-label-placement="after"]) {
+		&:where([data-_sk-control-type="checkable"][data-_sk-label-placement="after"]) {
 			grid-template-columns: var(--✨layout-inline-control-first);
 		}
 
-		&:where([data-kiwi-control-type="textlike"]) {
+		&:where([data-_sk-control-type="textlike"]) {
 			/* Descriptions should be aligned with the control for text and combobox controls */
 			--🥝FieldDescription-column: control-start / control-end;
 
@@ -32,7 +32,7 @@
 			align-items: baseline;
 
 			/* Default to stacked layout unless inline has been specified */
-			&:where(:not([data-kiwi-layout="inline"])) {
+			&:where(:not([data-_sk-layout="inline"])) {
 				grid-template-columns: var(--✨layout-stacked);
 				justify-content: stretch; /* Stretch the entire width in stacked layout. */
 			}

--- a/packages/bricks/src/Field.internal.tsx
+++ b/packages/bricks/src/Field.internal.tsx
@@ -67,8 +67,8 @@ export function FieldCollection(props: Pick<CollectionProps, "render">) {
 		<Collection
 			{...props}
 			store={fieldElementCollection}
-			data-kiwi-label-placement={labelPlacement}
-			data-kiwi-control-type={controlType}
+			data-_sk-label-placement={labelPlacement}
+			data-_sk-control-type={controlType}
 		/>
 	);
 }

--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -63,7 +63,7 @@ const FieldRoot = forwardRef<"div", FieldRootProps>((props, forwardedRef) => {
 			render={
 				<Role.div
 					{...rest}
-					className={cx("🥝-field", props.className)}
+					className={cx("🥝Field", props.className)}
 					data-kiwi-layout={layout}
 					ref={forwardedRef}
 				/>

--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -64,7 +64,7 @@ const FieldRoot = forwardRef<"div", FieldRootProps>((props, forwardedRef) => {
 				<Role.div
 					{...rest}
 					className={cx("🥝Field", props.className)}
-					data-kiwi-layout={layout}
+					data-_sk-layout={layout}
 					ref={forwardedRef}
 				/>
 			}

--- a/packages/bricks/src/IconButton.css
+++ b/packages/bricks/src/IconButton.css
@@ -7,8 +7,8 @@
 
 	@layer base {
 		aspect-ratio: 1;
-		--🥝button-padding-inline: var(--✨padding-inline);
-		--🥝ghost-inline-offset: var(--✨padding-inline);
+		--🥝Button-padding-inline: var(--✨padding-inline);
+		--🥝GhostAligner-inline-offset: var(--✨padding-inline);
 	}
 }
 

--- a/packages/bricks/src/IconButton.css
+++ b/packages/bricks/src/IconButton.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-icon-button:is(.🥝-button) {
+.🥝IconButton:is(.🥝Button) {
 	--✨padding-inline: var(--stratakit-space-x1);
 
 	@layer base {
@@ -12,7 +12,7 @@
 	}
 }
 
-.🥝-icon-button-dot:is(.🥝-dot) {
+.🥝IconButtonDot:is(.🥝Dot) {
 	@layer base {
 		position: absolute;
 		inset-block-start: var(--stratakit-space-x05);
@@ -21,14 +21,14 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-icon-button {
+	.🥝IconButton {
 		&:where([inert]) {
 			border: none;
 		}
 	}
 
-	.🥝-icon-button-dot:is(.🥝-dot) {
-		:where(.🥝-icon-button[aria-pressed="true"]) & {
+	.🥝IconButtonDot:is(.🥝Dot) {
+		:where(.🥝IconButton[aria-pressed="true"]) & {
 			background-color: SelectedItemText;
 		}
 	}

--- a/packages/bricks/src/IconButton.internal.tsx
+++ b/packages/bricks/src/IconButton.internal.tsx
@@ -36,9 +36,9 @@ export const IconButtonPresentation = forwardRef<
 		<Role.span
 			{...rest}
 			className={cx(
-				"🥝-icon-button",
-				"🥝-button",
-				{ "🥝-ghost-aligner": variant === "ghost" },
+				"🥝IconButton",
+				"🥝Button",
+				{ "🥝GhostAligner": variant === "ghost" },
 				props.className,
 			)}
 			data-kiwi-tone="neutral"

--- a/packages/bricks/src/IconButton.internal.tsx
+++ b/packages/bricks/src/IconButton.internal.tsx
@@ -41,9 +41,9 @@ export const IconButtonPresentation = forwardRef<
 				{ "🥝GhostAligner": variant === "ghost" },
 				props.className,
 			)}
-			data-kiwi-tone="neutral"
-			data-kiwi-variant={variant}
-			data-kiwi-ghost-align={variant === "ghost" ? ghostAlignment : undefined}
+			data-_sk-tone="neutral"
+			data-_sk-variant={variant}
+			data-_sk-ghost-align={variant === "ghost" ? ghostAlignment : undefined}
 			ref={forwardedRef}
 		/>
 	);

--- a/packages/bricks/src/IconButton.tsx
+++ b/packages/bricks/src/IconButton.tsx
@@ -130,7 +130,7 @@ const IconButton = forwardRef<"button", IconButtonProps>(
 						)}
 
 						{dot ? (
-							<Dot id={dotId} className="🥝-icon-button-dot">
+							<Dot id={dotId} className="🥝IconButtonDot">
 								{dot}
 							</Dot>
 						) : null}

--- a/packages/bricks/src/Kbd.css
+++ b/packages/bricks/src/Kbd.css
@@ -21,26 +21,26 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-variant="solid"], [data-kiwi-variant="muted"]) {
+		&:where([data-_sk-variant="solid"], [data-_sk-variant="muted"]) {
 			border-radius: 4px;
 			background-color: var(--stratakit-color-bg-neutral-base);
 			padding-inline: var(--stratakit-space-x1);
 		}
 
-		&:where([data-kiwi-variant="solid"]) {
+		&:where([data-_sk-variant="solid"]) {
 			box-shadow:
 				var(--stratakit-shadow-button-base-inset), var(--✨shadow-border),
 				var(--stratakit-shadow-button-base-drop);
 		}
 
-		&:where([data-kiwi-variant="ghost"]) {
+		&:where([data-_sk-variant="ghost"]) {
 			color: var(--stratakit-color-text-neutral-tertiary);
 		}
 	}
 }
 
 @media (forced-colors: active) {
-	.🥝Kbd:where([data-kiwi-variant="solid"]) {
+	.🥝Kbd:where([data-_sk-variant="solid"]) {
 		border: 1px solid;
 	}
 }

--- a/packages/bricks/src/Kbd.css
+++ b/packages/bricks/src/Kbd.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-kbd {
+.🥝Kbd {
 	--✨shadow-border: 0px 0px 0px 1px var(--stratakit-color-border-shadow-base) inset;
 
 	@layer base {
@@ -40,7 +40,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-kbd:where([data-kiwi-variant="solid"]) {
+	.🥝Kbd:where([data-kiwi-variant="solid"]) {
 		border: 1px solid;
 	}
 }

--- a/packages/bricks/src/Kbd.tsx
+++ b/packages/bricks/src/Kbd.tsx
@@ -66,7 +66,7 @@ const Kbd = forwardRef<"kbd", KbdProps>((props, forwardedRef) => {
 	return (
 		<Role
 			{...rest}
-			data-kiwi-variant={variant}
+			data-_sk-variant={variant}
 			className={cx("🥝Kbd", props.className)}
 			render={props.render || <kbd />}
 			ref={forwardedRef as RoleProps["ref"]}

--- a/packages/bricks/src/Kbd.tsx
+++ b/packages/bricks/src/Kbd.tsx
@@ -67,7 +67,7 @@ const Kbd = forwardRef<"kbd", KbdProps>((props, forwardedRef) => {
 		<Role
 			{...rest}
 			data-kiwi-variant={variant}
-			className={cx("🥝-kbd", props.className)}
+			className={cx("🥝Kbd", props.className)}
 			render={props.render || <kbd />}
 			ref={forwardedRef as RoleProps["ref"]}
 		>

--- a/packages/bricks/src/Label.css
+++ b/packages/bricks/src/Label.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-label {
+.🥝Label {
 	@layer base {
 		color: var(--stratakit-color-text-neutral-secondary);
 		cursor: default;

--- a/packages/bricks/src/Label.tsx
+++ b/packages/bricks/src/Label.tsx
@@ -28,7 +28,7 @@ const Label = forwardRef<"label", LabelProps>((props, forwardedRef) => {
 	return (
 		<Role.label
 			{...props}
-			className={cx("🥝-label", props.className)}
+			className={cx("🥝Label", props.className)}
 			ref={forwardedRef}
 		/>
 	);

--- a/packages/bricks/src/Progress.css
+++ b/packages/bricks/src/Progress.css
@@ -35,7 +35,7 @@
 			animation: var(--🥝ProgressBar-animation);
 		}
 
-		&:where([data-kiwi-variant="determinate"])::before {
+		&:where([data-_sk-variant="determinate"])::before {
 			@media (prefers-reduced-motion: no-preference) {
 				transition: transform 150ms ease-in-out;
 			}
@@ -43,25 +43,25 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-tone="neutral"]) {
+		&:where([data-_sk-tone="neutral"]) {
 			--🥝ProgressBar-fill-color: var(--stratakit-color-icon-neutral-base);
 			--🥝ProgressBar-track-color: var(--stratakit-color-border-page-base);
 		}
 
-		&:where([data-kiwi-tone="accent"]) {
+		&:where([data-_sk-tone="accent"]) {
 			--🥝ProgressBar-fill-color: var(--stratakit-color-icon-accent-strong);
 			--🥝ProgressBar-track-color: var(--stratakit-color-bg-accent-muted);
 		}
 
-		&:where([data-kiwi-size="medium"]) {
+		&:where([data-_sk-size="medium"]) {
 			--🥝ProgressBar-size: 0.125rem;
 		}
 
-		&:where([data-kiwi-size="large"]) {
+		&:where([data-_sk-size="large"]) {
 			--🥝ProgressBar-size: 0.25rem;
 		}
 
-		&:where([data-kiwi-variant="indeterminate"]) {
+		&:where([data-_sk-variant="indeterminate"]) {
 			--🥝ProgressBar-animation: var(--✨animation--indeterminate-steps);
 			--🥝ProgressBar-fill-size: 25%;
 			--🥝ProgressBar-fill-start-point: 0%; /* 0% keeps the fill in view. */
@@ -73,7 +73,7 @@
 			}
 		}
 
-		&:where([data-kiwi-variant="determinate"]) {
+		&:where([data-_sk-variant="determinate"]) {
 			--🥝ProgressBar-fill-size: 100%;
 		}
 	}

--- a/packages/bricks/src/Progress.css
+++ b/packages/bricks/src/Progress.css
@@ -10,29 +10,29 @@
 	--✨steps: 4;
 
 	--✨animation--indeterminate-steps: calc(var(--✨steps) * var(--✨duration) * 2)
-		--🥝progress-bar-animation-indeterminate steps(var(--✨steps), end) infinite;
-	--✨animation--indeterminate: var(--✨duration) --🥝progress-bar-animation-indeterminate
+		--🥝ProgressBar-animation-indeterminate steps(var(--✨steps), end) infinite;
+	--✨animation--indeterminate: var(--✨duration) --🥝ProgressBar-animation-indeterminate
 		var(--✨easing) var(--✨count);
 	--✨animation--indeterminate-slow: calc(var(--✨duration) * 2)
-		--🥝progress-bar-animation-indeterminate-slow var(--✨easing)
+		--🥝ProgressBar-animation-indeterminate-slow var(--✨easing)
 		calc(var(--✨count) * var(--✨duration)) infinite;
 
 	@layer base {
-		block-size: var(--🥝progress-bar-size);
+		block-size: var(--🥝ProgressBar-size);
 		inline-size: 100%;
 		border-radius: 9999px;
 		contain: strict;
 		display: grid;
-		background-color: var(--🥝progress-bar-track-color);
+		background-color: var(--🥝ProgressBar-track-color);
 
 		&::before {
 			content: "";
 			block-size: inherit;
-			inline-size: var(--🥝progress-bar-fill-size);
-			transform: translateX(calc(-100% + var(--🥝progress-bar-fill-portion-shown)));
+			inline-size: var(--🥝ProgressBar-fill-size);
+			transform: translateX(calc(-100% + var(--🥝ProgressBar-fill-portion-shown)));
 			border-radius: inherit;
-			background-color: var(--🥝progress-bar-fill-color);
-			animation: var(--🥝progress-bar-animation);
+			background-color: var(--🥝ProgressBar-fill-color);
+			animation: var(--🥝ProgressBar-animation);
 		}
 
 		&:where([data-kiwi-variant="determinate"])::before {
@@ -44,44 +44,44 @@
 
 	@layer modifiers {
 		&:where([data-kiwi-tone="neutral"]) {
-			--🥝progress-bar-fill-color: var(--stratakit-color-icon-neutral-base);
-			--🥝progress-bar-track-color: var(--stratakit-color-border-page-base);
+			--🥝ProgressBar-fill-color: var(--stratakit-color-icon-neutral-base);
+			--🥝ProgressBar-track-color: var(--stratakit-color-border-page-base);
 		}
 
 		&:where([data-kiwi-tone="accent"]) {
-			--🥝progress-bar-fill-color: var(--stratakit-color-icon-accent-strong);
-			--🥝progress-bar-track-color: var(--stratakit-color-bg-accent-muted);
+			--🥝ProgressBar-fill-color: var(--stratakit-color-icon-accent-strong);
+			--🥝ProgressBar-track-color: var(--stratakit-color-bg-accent-muted);
 		}
 
 		&:where([data-kiwi-size="medium"]) {
-			--🥝progress-bar-size: 0.125rem;
+			--🥝ProgressBar-size: 0.125rem;
 		}
 
 		&:where([data-kiwi-size="large"]) {
-			--🥝progress-bar-size: 0.25rem;
+			--🥝ProgressBar-size: 0.25rem;
 		}
 
 		&:where([data-kiwi-variant="indeterminate"]) {
-			--🥝progress-bar-animation: var(--✨animation--indeterminate-steps);
-			--🥝progress-bar-fill-size: 25%;
-			--🥝progress-bar-fill-start-point: 0%; /* 0% keeps the fill in view. */
+			--🥝ProgressBar-animation: var(--✨animation--indeterminate-steps);
+			--🥝ProgressBar-fill-size: 25%;
+			--🥝ProgressBar-fill-start-point: 0%; /* 0% keeps the fill in view. */
 
 			@media (prefers-reduced-motion: no-preference) {
-				--🥝progress-bar-animation:
+				--🥝ProgressBar-animation:
 					var(--✨animation--indeterminate), var(--✨animation--indeterminate-slow);
-				--🥝progress-bar-fill-start-point: -100%; /* -100% moves the fill out of view on the left side. */
+				--🥝ProgressBar-fill-start-point: -100%; /* -100% moves the fill out of view on the left side. */
 			}
 		}
 
 		&:where([data-kiwi-variant="determinate"]) {
-			--🥝progress-bar-fill-size: 100%;
+			--🥝ProgressBar-fill-size: 100%;
 		}
 	}
 }
 
-@keyframes --🥝progress-bar-animation-indeterminate {
+@keyframes --🥝ProgressBar-animation-indeterminate {
 	from {
-		transform: translateX(var(--🥝progress-bar-fill-start-point));
+		transform: translateX(var(--🥝ProgressBar-fill-start-point));
 	}
 
 	to {
@@ -89,7 +89,7 @@
 	}
 }
 
-@keyframes --🥝progress-bar-animation-indeterminate-slow {
+@keyframes --🥝ProgressBar-animation-indeterminate-slow {
 	0% {
 		transform: translateX(-100%); /* -100% moves the fill out of view on the left side. */
 	}
@@ -103,8 +103,8 @@
 
 @media (forced-colors: active) {
 	.🥝ProgressBar {
-		--🥝progress-bar-fill-color: CanvasText;
-		--🥝progress-bar-track-color: Canvas;
+		--🥝ProgressBar-fill-color: CanvasText;
+		--🥝ProgressBar-track-color: Canvas;
 		outline: 1px solid;
 		outline-color: oklch(from CanvasText l c h / 50%);
 		forced-color-adjust: none;

--- a/packages/bricks/src/Progress.css
+++ b/packages/bricks/src/Progress.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-progress-bar {
+.🥝ProgressBar {
 	--✨count: 4;
 	--✨duration: 1.5s;
 	--✨easing: cubic-bezier(0.5, 0, 0.5, 1);
@@ -102,7 +102,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-progress-bar {
+	.🥝ProgressBar {
 		--🥝progress-bar-fill-color: CanvasText;
 		--🥝progress-bar-track-color: Canvas;
 		outline: 1px solid;

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -93,9 +93,9 @@ const ProgressBar = forwardRef<"div", ProgressBarProps>(
 				aria-valuemin={value != null ? 0 : undefined}
 				aria-valuemax={value != null ? 100 : undefined}
 				{...rest}
-				data-kiwi-size={size}
-				data-kiwi-tone={tone}
-				data-kiwi-variant={value != null ? "determinate" : "indeterminate"}
+				data-_sk-size={size}
+				data-_sk-tone={tone}
+				data-_sk-variant={value != null ? "determinate" : "indeterminate"}
 				className={cx("🥝ProgressBar", props.className)}
 				style={style}
 				ref={forwardedRef}

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -81,7 +81,7 @@ const ProgressBar = forwardRef<"div", ProgressBarProps>(
 			return value != null
 				? {
 						...styleProp,
-						"--🥝progress-bar-fill-portion-shown": `${value}%`,
+						"--🥝ProgressBar-fill-portion-shown": `${value}%`,
 					}
 				: styleProp;
 		}, [styleProp, value]);

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -96,7 +96,7 @@ const ProgressBar = forwardRef<"div", ProgressBarProps>(
 				data-kiwi-size={size}
 				data-kiwi-tone={tone}
 				data-kiwi-variant={value != null ? "determinate" : "indeterminate"}
-				className={cx("🥝-progress-bar", props.className)}
+				className={cx("🥝ProgressBar", props.className)}
 				style={style}
 				ref={forwardedRef}
 			/>

--- a/packages/bricks/src/Radio.css
+++ b/packages/bricks/src/Radio.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-radio:is(.🥝-checkbox) {
+.🥝Radio:is(.🥝Checkbox) {
 	--🥝checkbox-border-radius: 9999px;
 	--🥝checkbox-checkmark-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" ><circle cx="8" cy="8" r="4" /></svg>');
 	--🥝checkbox-indeterminate-svg: var(--🥝checkbox-unchecked-svg);

--- a/packages/bricks/src/Radio.css
+++ b/packages/bricks/src/Radio.css
@@ -3,13 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .🥝Radio:is(.🥝Checkbox) {
-	--🥝checkbox-border-radius: 9999px;
-	--🥝checkbox-checkmark-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" ><circle cx="8" cy="8" r="4" /></svg>');
-	--🥝checkbox-indeterminate-svg: var(--🥝checkbox-unchecked-svg);
+	--🥝Checkbox-border-radius: 9999px;
+	--🥝Checkbox-checkmark-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" ><circle cx="8" cy="8" r="4" /></svg>');
+	--🥝Checkbox-indeterminate-svg: var(--🥝Checkbox-unchecked-svg);
 
 	@layer states {
 		&:where(:indeterminate) {
-			--🌀checkbox-visual-state: var(--🌀checkbox-visual-state--default);
+			--🌀Checkbox-visual-state: var(--🌀Checkbox-visual-state--default);
 		}
 	}
 }

--- a/packages/bricks/src/Radio.tsx
+++ b/packages/bricks/src/Radio.tsx
@@ -47,7 +47,7 @@ const Radio = forwardRef<"input", RadioProps>((props, forwardedRef) => {
 		<AkRadio
 			accessibleWhenDisabled
 			{...props}
-			className={cx("🥝-checkbox", "🥝-radio", props.className)}
+			className={cx("🥝Checkbox", "🥝Radio", props.className)}
 			ref={forwardedRef}
 		/>
 	);

--- a/packages/bricks/src/Select.css
+++ b/packages/bricks/src/Select.css
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-select-root {
+.🥝SelectRoot {
 	@layer base {
-		&:where(:has(select.🥝-select), [data-kiwi-has-select="true"]) {
+		&:where(:has(select.🥝Select), [data-kiwi-has-select="true"]) {
 			display: inline-grid;
 			align-items: center;
 			isolation: isolate;
@@ -16,7 +16,7 @@
 	}
 }
 
-.🥝-select:is(.🥝-button) {
+.🥝Select:is(.🥝Button) {
 	--✨padding-inline-start: var(--stratakit-space-x2);
 	--✨padding-inline-end: calc(
 		var(--stratakit-space-x1) /* Gap */ +
@@ -40,7 +40,7 @@
 	}
 }
 
-.🥝-select-arrow:is(.🥝-disclosure-arrow) {
+.🥝SelectArrow:is(.🥝DisclosureArrow) {
 	@layer base {
 		justify-self: end;
 		margin-inline-end: var(--stratakit-space-x1); /* (padding - disclosure offset) */
@@ -54,12 +54,12 @@
 
 	@layer states {
 		@media (any-hover: hover) {
-			:where(.🥝-select:hover) + & {
+			:where(.🥝Select:hover) + & {
 				--🌀select-arrow-state: var(--🌀select-arrow-state--hover);
 			}
 		}
 
-		:where(.🥝-select:disabled) + & {
+		:where(.🥝Select:disabled) + & {
 			--🌀select-arrow-state: var(--🌀select-arrow-state--disabled);
 		}
 	}

--- a/packages/bricks/src/Select.css
+++ b/packages/bricks/src/Select.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝SelectRoot {
 	@layer base {
-		&:where(:has(select.🥝Select), [data-kiwi-has-select="true"]) {
+		&:where(:has(select.🥝Select), [data-_sk-has-select="true"]) {
 			display: inline-grid;
 			align-items: center;
 			isolation: isolate;

--- a/packages/bricks/src/Select.css
+++ b/packages/bricks/src/Select.css
@@ -30,8 +30,8 @@
 
 		&:where(select:not([multiple])) {
 			appearance: none;
-			--🥝button-padding-inline: var(--✨padding-inline-start) var(--✨padding-inline-end);
-			--🥝ghost-inline-offset: var(--✨padding-inline-start);
+			--🥝Button-padding-inline: var(--✨padding-inline-start) var(--✨padding-inline-end);
+			--🥝GhostAligner-inline-offset: var(--✨padding-inline-start);
 
 			> option {
 				background-color: var(--stratakit-color-bg-neutral-base);
@@ -47,27 +47,27 @@
 		pointer-events: none;
 		z-index: 1; /* should be above the button */
 
-		--🥝icon-color: var(--🌀select-arrow-state--default, var(--stratakit-color-icon-neutral-base))
-			var(--🌀select-arrow-state--hover, var(--stratakit-color-icon-neutral-hover))
-			var(--🌀select-arrow-state--disabled, var(--stratakit-color-icon-neutral-disabled));
+		--🥝Icon-color: var(--🌀SelectArrow-state--default, var(--stratakit-color-icon-neutral-base))
+			var(--🌀SelectArrow-state--hover, var(--stratakit-color-icon-neutral-hover))
+			var(--🌀SelectArrow-state--disabled, var(--stratakit-color-icon-neutral-disabled));
 	}
 
 	@layer states {
 		@media (any-hover: hover) {
 			:where(.🥝Select:hover) + & {
-				--🌀select-arrow-state: var(--🌀select-arrow-state--hover);
+				--🌀SelectArrow-state: var(--🌀SelectArrow-state--hover);
 			}
 		}
 
 		:where(.🥝Select:disabled) + & {
-			--🌀select-arrow-state: var(--🌀select-arrow-state--disabled);
+			--🌀SelectArrow-state: var(--🌀SelectArrow-state--disabled);
 		}
 	}
 
 	@layer base.🌀 {
-		--🌀select-arrow-state: var(--🌀select-arrow-state--default);
-		--🌀select-arrow-state--default: var(--🌀select-arrow-state,);
-		--🌀select-arrow-state--hover: var(--🌀select-arrow-state,);
-		--🌀select-arrow-state--disabled: var(--🌀select-arrow-state,);
+		--🌀SelectArrow-state: var(--🌀SelectArrow-state--default);
+		--🌀SelectArrow-state--default: var(--🌀SelectArrow-state,);
+		--🌀SelectArrow-state--hover: var(--🌀SelectArrow-state,);
+		--🌀SelectArrow-state--disabled: var(--🌀SelectArrow-state,);
 	}
 }

--- a/packages/bricks/src/Select.tsx
+++ b/packages/bricks/src/Select.tsx
@@ -67,7 +67,7 @@ const SelectRoot = forwardRef<"div", BaseProps>((props, forwardedRef) => {
 		<HtmlSelectContext.Provider value={setIsHtmlSelect}>
 			<Role.div
 				{...props}
-				className={cx("🥝-select-root", props.className)}
+				className={cx("🥝SelectRoot", props.className)}
 				data-kiwi-has-select={!supportsHas && isHtmlSelect ? "true" : undefined}
 				ref={forwardedRef}
 			/>
@@ -123,12 +123,12 @@ const HtmlSelect = forwardRef<"select", HtmlSelectProps>(
 			<>
 				<Role.select
 					{...rest}
-					className={cx("🥝-button", "🥝-select", props.className)}
+					className={cx("🥝Button", "🥝Select", props.className)}
 					data-kiwi-tone="neutral"
 					data-kiwi-variant={variant}
 					ref={forwardedRef}
 				/>
-				<DisclosureArrow className="🥝-select-arrow" />
+				<DisclosureArrow className="🥝SelectArrow" />
 			</>
 		);
 	},

--- a/packages/bricks/src/Select.tsx
+++ b/packages/bricks/src/Select.tsx
@@ -68,7 +68,7 @@ const SelectRoot = forwardRef<"div", BaseProps>((props, forwardedRef) => {
 			<Role.div
 				{...props}
 				className={cx("🥝SelectRoot", props.className)}
-				data-kiwi-has-select={!supportsHas && isHtmlSelect ? "true" : undefined}
+				data-_sk-has-select={!supportsHas && isHtmlSelect ? "true" : undefined}
 				ref={forwardedRef}
 			/>
 		</HtmlSelectContext.Provider>
@@ -124,8 +124,8 @@ const HtmlSelect = forwardRef<"select", HtmlSelectProps>(
 				<Role.select
 					{...rest}
 					className={cx("🥝Button", "🥝Select", props.className)}
-					data-kiwi-tone="neutral"
-					data-kiwi-variant={variant}
+					data-_sk-tone="neutral"
+					data-_sk-variant={variant}
 					ref={forwardedRef}
 				/>
 				<DisclosureArrow className="🥝SelectArrow" />

--- a/packages/bricks/src/Skeleton.css
+++ b/packages/bricks/src/Skeleton.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-skeleton {
+.🥝Skeleton {
 	--✨duration: 1.6s;
 	--✨easing: cubic-bezier(0.32, 1, 0.64, 1);
 	--✨gradient: linear-gradient(
@@ -95,7 +95,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-skeleton {
+	.🥝Skeleton {
 		border: 1px solid;
 		background-color: transparent;
 	}

--- a/packages/bricks/src/Skeleton.css
+++ b/packages/bricks/src/Skeleton.css
@@ -15,80 +15,80 @@
 
 	@layer base {
 		background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
-		border-radius: var(--🥝skeleton-border-radius);
-		block-size: var(--🥝skeleton-height);
-		inline-size: var(--🥝skeleton-width);
+		border-radius: var(--🥝Skeleton-border-radius);
+		block-size: var(--🥝Skeleton-height);
+		inline-size: var(--🥝Skeleton-width);
 
 		@media (prefers-reduced-motion: no-preference) {
 			background: var(--✨gradient);
 			background-size: 300%;
 			background-position-x: 100%;
 			background-attachment: fixed;
-			animation: --🥝skeleton-shimmer var(--✨duration) var(--✨easing) infinite;
+			animation: --🥝Skeleton-shimmer var(--✨duration) var(--✨easing) infinite;
 		}
 	}
 
 	@layer modifiers {
 		&:where([data-kiwi-variant="text"]) {
-			--🥝skeleton-width: 100%;
-			--🥝skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
+			--🥝Skeleton-width: 100%;
+			--🥝Skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
 
 			&:where([data-kiwi-size="xsmall"]) {
-				--🥝skeleton-height: 0.75rem;
+				--🥝Skeleton-height: 0.75rem;
 			}
 
 			&:where([data-kiwi-size="small"]) {
-				--🥝skeleton-height: 0.875rem;
+				--🥝Skeleton-height: 0.875rem;
 			}
 
 			&:where([data-kiwi-size="medium"]) {
-				--🥝skeleton-height: 1rem;
+				--🥝Skeleton-height: 1rem;
 			}
 
 			&:where([data-kiwi-size="large"]) {
-				--🥝skeleton-height: 1.25rem;
+				--🥝Skeleton-height: 1.25rem;
 			}
 
 			&:where([data-kiwi-size="xlarge"]) {
-				--🥝skeleton-height: 1.5rem;
+				--🥝Skeleton-height: 1.5rem;
 			}
 		}
 
 		&:where([data-kiwi-variant="object"]) {
 			&:where([data-kiwi-size="xsmall"]) {
-				--🥝skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
-				--🥝skeleton-height: 0.75rem;
-				--🥝skeleton-width: 0.75rem;
+				--🥝Skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
+				--🥝Skeleton-height: 0.75rem;
+				--🥝Skeleton-width: 0.75rem;
 			}
 
 			&:where([data-kiwi-size="small"]) {
-				--🥝skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
-				--🥝skeleton-height: 1rem;
-				--🥝skeleton-width: 1rem;
+				--🥝Skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
+				--🥝Skeleton-height: 1rem;
+				--🥝Skeleton-width: 1rem;
 			}
 
 			&:where([data-kiwi-size="medium"]) {
-				--🥝skeleton-border-radius: 4px /* radius(in progress)/small */;
-				--🥝skeleton-height: 1.5rem;
-				--🥝skeleton-width: 1.5rem;
+				--🥝Skeleton-border-radius: 4px /* radius(in progress)/small */;
+				--🥝Skeleton-height: 1.5rem;
+				--🥝Skeleton-width: 1.5rem;
 			}
 
 			&:where([data-kiwi-size="large"]) {
-				--🥝skeleton-border-radius: 4px /* radius(in progress)/small */;
-				--🥝skeleton-height: 2rem;
-				--🥝skeleton-width: 2rem;
+				--🥝Skeleton-border-radius: 4px /* radius(in progress)/small */;
+				--🥝Skeleton-height: 2rem;
+				--🥝Skeleton-width: 2rem;
 			}
 
 			&:where([data-kiwi-size="xlarge"]) {
-				--🥝skeleton-border-radius: 4px /* radius(in progress)/small */;
-				--🥝skeleton-height: 3rem;
-				--🥝skeleton-width: 3rem;
+				--🥝Skeleton-border-radius: 4px /* radius(in progress)/small */;
+				--🥝Skeleton-height: 3rem;
+				--🥝Skeleton-width: 3rem;
 			}
 		}
 	}
 }
 
-@keyframes --🥝skeleton-shimmer {
+@keyframes --🥝Skeleton-shimmer {
 	to {
 		background-position-x: 0%;
 	}

--- a/packages/bricks/src/Skeleton.css
+++ b/packages/bricks/src/Skeleton.css
@@ -29,57 +29,57 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-variant="text"]) {
+		&:where([data-_sk-variant="text"]) {
 			--🥝Skeleton-width: 100%;
 			--🥝Skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
 
-			&:where([data-kiwi-size="xsmall"]) {
+			&:where([data-_sk-size="xsmall"]) {
 				--🥝Skeleton-height: 0.75rem;
 			}
 
-			&:where([data-kiwi-size="small"]) {
+			&:where([data-_sk-size="small"]) {
 				--🥝Skeleton-height: 0.875rem;
 			}
 
-			&:where([data-kiwi-size="medium"]) {
+			&:where([data-_sk-size="medium"]) {
 				--🥝Skeleton-height: 1rem;
 			}
 
-			&:where([data-kiwi-size="large"]) {
+			&:where([data-_sk-size="large"]) {
 				--🥝Skeleton-height: 1.25rem;
 			}
 
-			&:where([data-kiwi-size="xlarge"]) {
+			&:where([data-_sk-size="xlarge"]) {
 				--🥝Skeleton-height: 1.5rem;
 			}
 		}
 
-		&:where([data-kiwi-variant="object"]) {
-			&:where([data-kiwi-size="xsmall"]) {
+		&:where([data-_sk-variant="object"]) {
+			&:where([data-_sk-size="xsmall"]) {
 				--🥝Skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
 				--🥝Skeleton-height: 0.75rem;
 				--🥝Skeleton-width: 0.75rem;
 			}
 
-			&:where([data-kiwi-size="small"]) {
+			&:where([data-_sk-size="small"]) {
 				--🥝Skeleton-border-radius: 2px /* radius(in progress)/xsmall */;
 				--🥝Skeleton-height: 1rem;
 				--🥝Skeleton-width: 1rem;
 			}
 
-			&:where([data-kiwi-size="medium"]) {
+			&:where([data-_sk-size="medium"]) {
 				--🥝Skeleton-border-radius: 4px /* radius(in progress)/small */;
 				--🥝Skeleton-height: 1.5rem;
 				--🥝Skeleton-width: 1.5rem;
 			}
 
-			&:where([data-kiwi-size="large"]) {
+			&:where([data-_sk-size="large"]) {
 				--🥝Skeleton-border-radius: 4px /* radius(in progress)/small */;
 				--🥝Skeleton-height: 2rem;
 				--🥝Skeleton-width: 2rem;
 			}
 
-			&:where([data-kiwi-size="xlarge"]) {
+			&:where([data-_sk-size="xlarge"]) {
 				--🥝Skeleton-border-radius: 4px /* radius(in progress)/small */;
 				--🥝Skeleton-height: 3rem;
 				--🥝Skeleton-width: 3rem;

--- a/packages/bricks/src/Skeleton.tsx
+++ b/packages/bricks/src/Skeleton.tsx
@@ -43,8 +43,8 @@ const Skeleton = forwardRef<"div", SkeletonProps>((props, forwardedRef) => {
 			{...rest}
 			ref={forwardedRef}
 			className={cx("🥝Skeleton", props.className)}
-			data-kiwi-variant={variant}
-			data-kiwi-size={size}
+			data-_sk-variant={variant}
+			data-_sk-size={size}
 			aria-hidden
 		/>
 	);

--- a/packages/bricks/src/Skeleton.tsx
+++ b/packages/bricks/src/Skeleton.tsx
@@ -42,7 +42,7 @@ const Skeleton = forwardRef<"div", SkeletonProps>((props, forwardedRef) => {
 		<Role.div
 			{...rest}
 			ref={forwardedRef}
-			className={cx("🥝-skeleton", props.className)}
+			className={cx("🥝Skeleton", props.className)}
 			data-kiwi-variant={variant}
 			data-kiwi-size={size}
 			aria-hidden

--- a/packages/bricks/src/Spinner.css
+++ b/packages/bricks/src/Spinner.css
@@ -7,48 +7,48 @@
 	--✨duration: 1s;
 	--✨duration-slow: 2s;
 
-	--✨animation--indeterminate: --🥝spinner-animation-indeterminate linear infinite;
+	--✨animation--indeterminate: --🥝Spinner-animation-indeterminate linear infinite;
 
 	@layer base {
 		display: inline-block;
-		block-size: var(--🥝spinner-size);
-		inline-size: var(--🥝spinner-size);
+		block-size: var(--🥝Spinner-size);
+		inline-size: var(--🥝Spinner-size);
 	}
 
 	@layer modifiers {
 		&:where([data-kiwi-tone="neutral"]) {
-			--🥝spinner-fill-color: var(--stratakit-color-icon-neutral-base);
-			--🥝spinner-track-color: var(--stratakit-color-border-page-base);
+			--🥝Spinner-fill-color: var(--stratakit-color-icon-neutral-base);
+			--🥝Spinner-track-color: var(--stratakit-color-border-page-base);
 		}
 
 		&:where([data-kiwi-tone="accent"]) {
-			--🥝spinner-fill-color: var(--stratakit-color-icon-accent-strong);
-			--🥝spinner-track-color: var(--stratakit-color-bg-accent-muted);
+			--🥝Spinner-fill-color: var(--stratakit-color-icon-accent-strong);
+			--🥝Spinner-track-color: var(--stratakit-color-bg-accent-muted);
 		}
 
 		&:where([data-kiwi-size="small"]) {
-			--🥝spinner-size: 1rem;
+			--🥝Spinner-size: 1rem;
 		}
 
 		&:where([data-kiwi-size="medium"]) {
-			--🥝spinner-size: 1.5rem;
+			--🥝Spinner-size: 1.5rem;
 		}
 
 		&:where([data-kiwi-size="large"]) {
-			--🥝spinner-size: 2rem;
+			--🥝Spinner-size: 2rem;
 		}
 
 		&:where([data-kiwi-size="xlarge"]) {
-			--🥝spinner-size: 3rem;
+			--🥝Spinner-size: 3rem;
 		}
 
 		&:where([data-kiwi-variant="indeterminate"]) {
-			--🥝spinner-animation: var(--✨animation--indeterminate);
-			--🥝spinner-animation-duration: var(--✨duration);
-			--🥝spinner-dash-array: 25 75;
+			--🥝Spinner-animation: var(--✨animation--indeterminate);
+			--🥝Spinner-animation-duration: var(--✨duration);
+			--🥝Spinner-dash-array: 25 75;
 
 			@media (prefers-reduced-motion) {
-				--🥝spinner-animation-duration: var(--✨duration-slow);
+				--🥝Spinner-animation-duration: var(--✨duration-slow);
 			}
 		}
 	}
@@ -63,21 +63,21 @@
 }
 
 .🥝SpinnerSvgTrack {
-	stroke: var(--🥝spinner-track-color);
+	stroke: var(--🥝Spinner-track-color);
 }
 
 .🥝SpinnerSvgFill {
-	animation: var(--🥝spinner-animation);
-	animation-duration: var(--🥝spinner-animation-duration);
-	stroke: var(--🥝spinner-fill-color);
-	stroke-dasharray: var(--🥝spinner-dash-array);
+	animation: var(--🥝Spinner-animation);
+	animation-duration: var(--🥝Spinner-animation-duration);
+	stroke: var(--🥝Spinner-fill-color);
+	stroke-dasharray: var(--🥝Spinner-dash-array);
 	stroke-dashoffset: 25;
 	stroke-linecap: round;
 	transform-box: fill-box;
 	transform-origin: center;
 }
 
-@keyframes --🥝spinner-animation-indeterminate {
+@keyframes --🥝Spinner-animation-indeterminate {
 	to {
 		rotate: 360deg;
 	}
@@ -86,11 +86,11 @@
 @media (forced-colors: active) {
 	.🥝Spinner {
 		/* Fill is used as track, track is used as fill. */
-		--🥝spinner-fill-color: Canvas;
-		--🥝spinner-track-color: CanvasText;
+		--🥝Spinner-fill-color: Canvas;
+		--🥝Spinner-track-color: CanvasText;
 
 		&:where([data-kiwi-variant="indeterminate"]) {
-			--🥝spinner-dash-array: 75 25; /* Inverts the sizes of fill & track. */
+			--🥝Spinner-dash-array: 75 25; /* Inverts the sizes of fill & track. */
 		}
 	}
 

--- a/packages/bricks/src/Spinner.css
+++ b/packages/bricks/src/Spinner.css
@@ -16,33 +16,33 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-tone="neutral"]) {
+		&:where([data-_sk-tone="neutral"]) {
 			--🥝Spinner-fill-color: var(--stratakit-color-icon-neutral-base);
 			--🥝Spinner-track-color: var(--stratakit-color-border-page-base);
 		}
 
-		&:where([data-kiwi-tone="accent"]) {
+		&:where([data-_sk-tone="accent"]) {
 			--🥝Spinner-fill-color: var(--stratakit-color-icon-accent-strong);
 			--🥝Spinner-track-color: var(--stratakit-color-bg-accent-muted);
 		}
 
-		&:where([data-kiwi-size="small"]) {
+		&:where([data-_sk-size="small"]) {
 			--🥝Spinner-size: 1rem;
 		}
 
-		&:where([data-kiwi-size="medium"]) {
+		&:where([data-_sk-size="medium"]) {
 			--🥝Spinner-size: 1.5rem;
 		}
 
-		&:where([data-kiwi-size="large"]) {
+		&:where([data-_sk-size="large"]) {
 			--🥝Spinner-size: 2rem;
 		}
 
-		&:where([data-kiwi-size="xlarge"]) {
+		&:where([data-_sk-size="xlarge"]) {
 			--🥝Spinner-size: 3rem;
 		}
 
-		&:where([data-kiwi-variant="indeterminate"]) {
+		&:where([data-_sk-variant="indeterminate"]) {
 			--🥝Spinner-animation: var(--✨animation--indeterminate);
 			--🥝Spinner-animation-duration: var(--✨duration);
 			--🥝Spinner-dash-array: 25 75;
@@ -89,7 +89,7 @@
 		--🥝Spinner-fill-color: Canvas;
 		--🥝Spinner-track-color: CanvasText;
 
-		&:where([data-kiwi-variant="indeterminate"]) {
+		&:where([data-_sk-variant="indeterminate"]) {
 			--🥝Spinner-dash-array: 75 25; /* Inverts the sizes of fill & track. */
 		}
 	}

--- a/packages/bricks/src/Spinner.css
+++ b/packages/bricks/src/Spinner.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-spinner {
+.🥝Spinner {
 	--✨duration: 1s;
 	--✨duration-slow: 2s;
 
@@ -54,7 +54,7 @@
 	}
 }
 
-.🥝-spinner-svg {
+.🥝SpinnerSvg {
 	@layer base {
 		block-size: inherit;
 		inline-size: inherit;
@@ -62,11 +62,11 @@
 	}
 }
 
-.🥝-spinner-svg-track {
+.🥝SpinnerSvgTrack {
 	stroke: var(--🥝spinner-track-color);
 }
 
-.🥝-spinner-svg-fill {
+.🥝SpinnerSvgFill {
 	animation: var(--🥝spinner-animation);
 	animation-duration: var(--🥝spinner-animation-duration);
 	stroke: var(--🥝spinner-fill-color);
@@ -84,7 +84,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-spinner {
+	.🥝Spinner {
 		/* Fill is used as track, track is used as fill. */
 		--🥝spinner-fill-color: Canvas;
 		--🥝spinner-track-color: CanvasText;
@@ -94,11 +94,11 @@
 		}
 	}
 
-	.🥝-spinner-svg-track {
+	.🥝SpinnerSvgTrack {
 		stroke-width: 2; /* Makes the track twice as thick to create an outline around the spinner. */
 	}
 
-	.🥝-spinner-svg-fill {
+	.🥝SpinnerSvgFill {
 		stroke-dashoffset: 0; /* Makes the fill start in the same location as non-forced-colors mode. */
 	}
 }

--- a/packages/bricks/src/Spinner.tsx
+++ b/packages/bricks/src/Spinner.tsx
@@ -55,20 +55,20 @@ const Spinner = forwardRef<"div", SpinnerProps>((props, forwardedRef) => {
 			data-kiwi-size={size}
 			data-kiwi-tone={tone}
 			data-kiwi-variant="indeterminate"
-			className={cx("🥝-spinner", props.className)}
+			className={cx("🥝Spinner", props.className)}
 			ref={forwardedRef}
 		>
-			<svg aria-hidden="true" className="🥝-spinner-svg" viewBox="0 0 16 16">
+			<svg aria-hidden="true" className="🥝SpinnerSvg" viewBox="0 0 16 16">
 				<circle
 					pathLength="100"
-					className="🥝-spinner-svg-track"
+					className="🥝SpinnerSvgTrack"
 					cx="8"
 					cy="8"
 					r="6.5"
 				/>
 				<circle
 					pathLength="100"
-					className="🥝-spinner-svg-fill"
+					className="🥝SpinnerSvgFill"
 					cx="8"
 					cy="8"
 					r="6.5"

--- a/packages/bricks/src/Spinner.tsx
+++ b/packages/bricks/src/Spinner.tsx
@@ -52,9 +52,9 @@ const Spinner = forwardRef<"div", SpinnerProps>((props, forwardedRef) => {
 	return (
 		<Role
 			{...rest}
-			data-kiwi-size={size}
-			data-kiwi-tone={tone}
-			data-kiwi-variant="indeterminate"
+			data-_sk-size={size}
+			data-_sk-tone={tone}
+			data-_sk-variant="indeterminate"
 			className={cx("🥝Spinner", props.className)}
 			ref={forwardedRef}
 		>

--- a/packages/bricks/src/Switch.css
+++ b/packages/bricks/src/Switch.css
@@ -54,18 +54,18 @@
 		inline-size: var(--✨width);
 		block-size: auto; /* Necessary to override iOS Safari UA styles */
 
-		background-color: var(--🌀switch-state--default, var(--✨bg--default))
-			var(--🌀switch-state--hover, var(--✨bg--hover))
-			var(--🌀switch-state--pressed, var(--✨bg--hover))
-			var(--🌀switch-state--checked, var(--✨bg--checked))
-			var(--🌀switch-state--checked-hover, var(--✨bg--checked-hover))
-			var(--🌀switch-state--disabled, var(--✨bg--default));
-		border-color: var(--🌀switch-state--default, var(--✨border--default))
-			var(--🌀switch-state--hover, var(--✨border--hover))
-			var(--🌀switch-state--pressed, var(--✨border--pressed))
-			var(--🌀switch-state--checked, var(--✨border--checked))
-			var(--🌀switch-state--checked-hover, var(--✨border--checked))
-			var(--🌀switch-state--disabled, var(--✨border--disabled));
+		background-color: var(--🌀Switch-state--default, var(--✨bg--default))
+			var(--🌀Switch-state--hover, var(--✨bg--hover))
+			var(--🌀Switch-state--pressed, var(--✨bg--hover))
+			var(--🌀Switch-state--checked, var(--✨bg--checked))
+			var(--🌀Switch-state--checked-hover, var(--✨bg--checked-hover))
+			var(--🌀Switch-state--disabled, var(--✨bg--default));
+		border-color: var(--🌀Switch-state--default, var(--✨border--default))
+			var(--🌀Switch-state--hover, var(--✨border--hover))
+			var(--🌀Switch-state--pressed, var(--✨border--pressed))
+			var(--🌀Switch-state--checked, var(--✨border--checked))
+			var(--🌀Switch-state--checked-hover, var(--✨border--checked))
+			var(--🌀Switch-state--disabled, var(--✨border--disabled));
 		transition: all 150ms ease-out;
 		transition-property: background-color, border-color;
 		-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
@@ -90,13 +90,13 @@
 			block-size: var(--✨thumb-size);
 			inline-size: var(--✨thumb-size);
 			margin: calc(0.125rem - 1px) /* sizing-2 - 1px to account for border */;
-			background-color: var(--🥝switch-thumb-color);
+			background-color: var(--🥝Switch-thumb-color);
 			box-shadow:
 				var(--stratakit-shadow-button-base-inset), var(--✨shadow-border),
 				var(--stratakit-shadow-button-base-drop);
-			border-radius: var(--🥝switch-thumb-radius, var(--✨radius));
+			border-radius: var(--🥝Switch-thumb-radius, var(--✨radius));
 			transform-origin: left;
-			transform: var(--🥝switch-thumb-transform);
+			transform: var(--🥝Switch-thumb-transform);
 
 			@media (prefers-reduced-motion: no-preference) {
 				transition: all 150ms ease-out;
@@ -107,36 +107,36 @@
 	}
 
 	@layer states {
-		--🥝switch-thumb-color: var(--stratakit-color-bg-neutral-inverse);
+		--🥝Switch-thumb-color: var(--stratakit-color-bg-neutral-inverse);
 
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀switch-state: var(--🌀switch-state--hover);
+				--🌀Switch-state: var(--🌀Switch-state--hover);
 			}
 		}
 
 		&:where(:checked, [aria-checked="true"]) {
-			--🌀switch-state: var(--🌀switch-state--checked);
-			--🥝switch-thumb-transform: translateX(var(--✨checked-translateX));
+			--🌀Switch-state: var(--🌀Switch-state--checked);
+			--🥝Switch-thumb-transform: translateX(var(--✨checked-translateX));
 
 			@media (any-hover: hover) {
 				&:where(:hover) {
-					--🌀switch-state: var(--🌀switch-state--checked-hover);
+					--🌀Switch-state: var(--🌀Switch-state--checked-hover);
 				}
 			}
 		}
 
 		&:where(:active) {
-			--🌀switch-state: var(--🌀switch-state--pressed);
+			--🌀Switch-state: var(--🌀Switch-state--pressed);
 
 			/* https://css-tricks.com/various-methods-for-expanding-a-box-while-preserving-the-border-radius/#aa-changing-scale */
-			--🥝switch-thumb-transform: scaleX(var(--✨pressed-scaleX));
-			--🥝switch-thumb-radius: calc(var(--✨radius) / var(--✨pressed-scaleX)) / var(--✨radius);
+			--🥝Switch-thumb-transform: scaleX(var(--✨pressed-scaleX));
+			--🥝Switch-thumb-radius: calc(var(--✨radius) / var(--✨pressed-scaleX)) / var(--✨radius);
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {
-			--🌀switch-state: var(--🌀switch-state--disabled);
-			--🥝switch-thumb-color: var(--stratakit-color-icon-neutral-disabled);
+			--🌀Switch-state: var(--🌀Switch-state--disabled);
+			--🥝Switch-thumb-color: var(--stratakit-color-icon-neutral-disabled);
 			cursor: not-allowed;
 			-webkit-tap-highlight-color: transparent;
 
@@ -148,30 +148,30 @@
 
 	@layer base.🌀 {
 		/* Cyclic toggles for default/hover/pressed/checked/checked+hover states. See https://kizu.dev/cyclic-toggles/ */
-		--🌀switch-state: var(--🌀switch-state--default);
-		--🌀switch-state--default: var(--🌀switch-state,);
-		--🌀switch-state--hover: var(--🌀switch-state,);
-		--🌀switch-state--pressed: var(--🌀switch-state,);
-		--🌀switch-state--checked: var(--🌀switch-state,);
-		--🌀switch-state--checked-hover: var(--🌀switch-state,);
-		--🌀switch-state--disabled: var(--🌀switch-state,);
+		--🌀Switch-state: var(--🌀Switch-state--default);
+		--🌀Switch-state--default: var(--🌀Switch-state,);
+		--🌀Switch-state--hover: var(--🌀Switch-state,);
+		--🌀Switch-state--pressed: var(--🌀Switch-state,);
+		--🌀Switch-state--checked: var(--🌀Switch-state,);
+		--🌀Switch-state--checked-hover: var(--🌀Switch-state,);
+		--🌀Switch-state--disabled: var(--🌀Switch-state,);
 	}
 }
 
 @media (forced-colors: active) {
 	.🥝Switch {
 		border-color: CanvasText;
-		--🥝switch-thumb-color: CanvasText;
+		--🥝Switch-thumb-color: CanvasText;
 
 		&:where(:checked, [aria-checked="true"]) {
 			background-color: SelectedItem;
-			--🥝switch-thumb-color: SelectedItemText;
+			--🥝Switch-thumb-color: SelectedItemText;
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {
 			background-color: Canvas;
 			border-color: GrayText;
-			--🥝switch-thumb-color: GrayText;
+			--🥝Switch-thumb-color: GrayText;
 		}
 	}
 }

--- a/packages/bricks/src/Switch.css
+++ b/packages/bricks/src/Switch.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-switch {
+.🥝Switch {
 	--✨width: 2rem;
 	--✨thumb-size: 1rem;
 
@@ -159,7 +159,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-switch {
+	.🥝Switch {
 		border-color: CanvasText;
 		--🥝switch-thumb-color: CanvasText;
 

--- a/packages/bricks/src/Switch.tsx
+++ b/packages/bricks/src/Switch.tsx
@@ -56,7 +56,7 @@ const Switch = forwardRef<"input", SwitchProps>((props, forwardedRef) => {
 		<AkCheckbox
 			accessibleWhenDisabled
 			{...props}
-			className={cx("🥝-switch", props.className)}
+			className={cx("🥝Switch", props.className)}
 			role="switch"
 			ref={forwardedRef}
 		/>

--- a/packages/bricks/src/Text.css
+++ b/packages/bricks/src/Text.css
@@ -4,47 +4,47 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝Text {
 	@layer modifiers {
-		&:where([data-kiwi-text-variant="display-lg"]) {
+		&:where([data-_sk-text-variant="display-lg"]) {
 			@apply --typography("display-lg");
 		}
-		&:where([data-kiwi-text-variant="display-md"]) {
+		&:where([data-_sk-text-variant="display-md"]) {
 			@apply --typography("display-md");
 		}
-		&:where([data-kiwi-text-variant="display-sm"]) {
+		&:where([data-_sk-text-variant="display-sm"]) {
 			@apply --typography("display-sm");
 		}
 
-		&:where([data-kiwi-text-variant="headline-lg"]) {
+		&:where([data-_sk-text-variant="headline-lg"]) {
 			@apply --typography("headline-lg");
 		}
-		&:where([data-kiwi-text-variant="headline-md"]) {
+		&:where([data-_sk-text-variant="headline-md"]) {
 			@apply --typography("headline-md");
 		}
-		&:where([data-kiwi-text-variant="headline-sm"]) {
+		&:where([data-_sk-text-variant="headline-sm"]) {
 			@apply --typography("headline-sm");
 		}
 
-		&:where([data-kiwi-text-variant="body-lg"]) {
+		&:where([data-_sk-text-variant="body-lg"]) {
 			@apply --typography("body-lg");
 		}
-		&:where([data-kiwi-text-variant="body-md"]) {
+		&:where([data-_sk-text-variant="body-md"]) {
 			@apply --typography("body-md");
 		}
-		&:where([data-kiwi-text-variant="body-sm"]) {
+		&:where([data-_sk-text-variant="body-sm"]) {
 			@apply --typography("body-sm");
 		}
 
-		&:where([data-kiwi-text-variant="caption-lg"]) {
+		&:where([data-_sk-text-variant="caption-lg"]) {
 			@apply --typography("caption-lg");
 		}
-		&:where([data-kiwi-text-variant="caption-md"]) {
+		&:where([data-_sk-text-variant="caption-md"]) {
 			@apply --typography("caption-md");
 		}
-		&:where([data-kiwi-text-variant="caption-sm"]) {
+		&:where([data-_sk-text-variant="caption-sm"]) {
 			@apply --typography("caption-sm");
 		}
 
-		&:where([data-kiwi-text-variant="mono-sm"]) {
+		&:where([data-_sk-text-variant="mono-sm"]) {
 			@apply --typography("mono-sm");
 		}
 	}

--- a/packages/bricks/src/Text.css
+++ b/packages/bricks/src/Text.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-text {
+.🥝Text {
 	@layer modifiers {
 		&:where([data-kiwi-text-variant="display-lg"]) {
 			@apply --typography("display-lg");

--- a/packages/bricks/src/Text.tsx
+++ b/packages/bricks/src/Text.tsx
@@ -49,7 +49,7 @@ const Text = forwardRef<"div", TextProps>((props, forwardedRef) => {
 		<Role
 			{...rest}
 			className={cx("🥝Text", props.className)}
-			data-kiwi-text-variant={variant}
+			data-_sk-text-variant={variant}
 			ref={forwardedRef}
 		/>
 	);

--- a/packages/bricks/src/Text.tsx
+++ b/packages/bricks/src/Text.tsx
@@ -48,7 +48,7 @@ const Text = forwardRef<"div", TextProps>((props, forwardedRef) => {
 	return (
 		<Role
 			{...rest}
-			className={cx("🥝-text", props.className)}
+			className={cx("🥝Text", props.className)}
 			data-kiwi-text-variant={variant}
 			ref={forwardedRef}
 		/>

--- a/packages/bricks/src/TextBox.css
+++ b/packages/bricks/src/TextBox.css
@@ -28,7 +28,7 @@
 	--✨gap: var(--stratakit-space-x1);
 
 	@layer base {
-		cursor: var(--🥝text-box-cursor);
+		cursor: var(--🥝TextBox-cursor);
 		font-size: var(--stratakit-font-size-12);
 		min-inline-size: 0;
 
@@ -36,20 +36,20 @@
 		padding-inline: var(--✨padding-inline);
 		border-radius: 4px;
 
-		background-color: var(--🥝text-box-background-color);
+		background-color: var(--🥝TextBox-background-color);
 		box-shadow: var(--stratakit-shadow-input-base);
 		color: var(--✨color--default);
 		transition: all 150ms ease-out;
 		transition-property: background-color, border-color;
 		-webkit-tap-highlight-color: transparent;
 
-		--🥝text-box-cursor: text;
-		--🥝text-box-background-color: var(--🌀text-box-state--default, var(--✨bg--default))
-			var(--🌀text-box-state--hover, var(--✨bg--hover))
-			var(--🌀text-box-state--disabled, var(--✨bg--disabled));
-		--🥝text-box-border-color: var(--🌀text-box-state--default, var(--✨border--default))
-			var(--🌀text-box-state--hover, var(--✨border--hover))
-			var(--🌀text-box-state--disabled, var(--✨border--disabled));
+		--🥝TextBox-cursor: text;
+		--🥝TextBox-background-color: var(--🌀TextBox-state--default, var(--✨bg--default))
+			var(--🌀TextBox-state--hover, var(--✨bg--hover))
+			var(--🌀TextBox-state--disabled, var(--✨bg--disabled));
+		--🥝TextBox-border-color: var(--🌀TextBox-state--default, var(--✨border--default))
+			var(--🌀TextBox-state--hover, var(--✨border--hover))
+			var(--🌀TextBox-state--disabled, var(--✨border--disabled));
 
 		/* Styles specific to wrapper ("root") */
 		&:where(:not(input, textarea)) {
@@ -65,7 +65,7 @@
 				inset: 0;
 				border-radius: inherit;
 				pointer-events: none;
-				border: 1px solid var(--🥝text-box-border-color);
+				border: 1px solid var(--🥝TextBox-border-color);
 				transition: border-color 150ms ease-out;
 			}
 
@@ -94,8 +94,8 @@
 			appearance: none;
 			line-height: 1.3; /* This is a safe value for Inter — lower values will be ignored. */
 			min-inline-size: 0;
-			border: 1px solid var(--🥝text-box-border-color);
-			cursor: var(--🥝text-box-cursor);
+			border: 1px solid var(--🥝TextBox-border-color);
+			cursor: var(--🥝TextBox-cursor);
 			padding-block: var(--✨padding-block);
 
 			&::placeholder {
@@ -115,7 +115,7 @@
 		/* Styles specific to input/textarea (nested only, "invisible") */
 		:where(input, textarea) {
 			border: none;
-			background-color: var(--🥝text-box-background-color);
+			background-color: var(--🥝TextBox-background-color);
 			outline: unset;
 			flex: 999;
 			align-self: stretch;
@@ -127,23 +127,23 @@
 	@layer states {
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀text-box-state: var(--🌀text-box-state--hover);
+				--🌀TextBox-state: var(--🌀TextBox-state--hover);
 			}
 		}
 
 		&:where(:has(:is(input, textarea):focus-visible), :is(input, textarea):focus-visible) {
 			outline: var(--🥝focus-outline);
 			outline-offset: var(--🥝focus-outline-offset);
-			--🥝text-box-border-color: var(--✨border--focus);
-			--🥝icon-color: var(--stratakit-color-icon-accent-strong);
+			--🥝TextBox-border-color: var(--✨border--focus);
+			--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
 		}
 
 		@supports not selector(:has(+ *)) {
 			&:where(:not(input, textarea):focus-within) {
 				outline: var(--🥝focus-outline);
 				outline-offset: var(--🥝focus-outline-offset);
-				--🥝text-box-border-color: var(--✨border--focus);
-				--🥝icon-color: var(--stratakit-color-icon-accent-strong);
+				--🥝TextBox-border-color: var(--✨border--focus);
+				--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
 			}
 		}
 
@@ -153,19 +153,19 @@
 				[data-kiwi-disabled="true"],
 				:has(:is(input, textarea):is(:disabled, [aria-disabled="true"]))
 			) {
-			--🌀text-box-state: var(--🌀text-box-state--disabled);
+			--🌀TextBox-state: var(--🌀TextBox-state--disabled);
 			box-shadow: none;
 			color: var(--✨color--disabled);
-			--🥝text-box-cursor: not-allowed;
+			--🥝TextBox-cursor: not-allowed;
 		}
 	}
 
 	@layer base.🌀 {
 		/* Cyclic toggles for default/hover/disabled states. See https://kizu.dev/cyclic-toggles/ */
-		--🌀text-box-state: var(--🌀text-box-state--default);
-		--🌀text-box-state--default: var(--🌀text-box-state,);
-		--🌀text-box-state--hover: var(--🌀text-box-state,);
-		--🌀text-box-state--disabled: var(--🌀text-box-state,);
+		--🌀TextBox-state: var(--🌀TextBox-state--default);
+		--🌀TextBox-state--default: var(--🌀TextBox-state,);
+		--🌀TextBox-state--hover: var(--🌀TextBox-state,);
+		--🌀TextBox-state--disabled: var(--🌀TextBox-state,);
 	}
 }
 
@@ -177,8 +177,8 @@
 
 @media (forced-colors: active) {
 	.🥝TextBox {
-		--🥝text-box-background-color: Field;
-		--🥝text-box-border-color: CanvasText;
+		--🥝TextBox-background-color: Field;
+		--🥝TextBox-border-color: CanvasText;
 		color: FieldText;
 
 		&:where(
@@ -187,7 +187,7 @@
 				[data-kiwi-disabled="true"],
 				:has(:is(input, textarea):is(:disabled, [aria-disabled="true"]))
 			) {
-			--🥝text-box-border-color: GrayText;
+			--🥝TextBox-border-color: GrayText;
 			color: GrayText;
 		}
 	}

--- a/packages/bricks/src/TextBox.css
+++ b/packages/bricks/src/TextBox.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-text-box {
+.🥝TextBox {
 	--✨bg--default: var(--stratakit-color-bg-page-base);
 	--✨bg--hover: color-mix(
 		in oklch,
@@ -70,7 +70,7 @@
 			}
 
 			/* Propagate padding-inline-start to the nested input/textarea when there is no decoration _before_ it. */
-			&:where(:not(:has(.🥝-text-box-decoration ~ :is(input, textarea)))) {
+			&:where(:not(:has(.🥝TextBoxDecoration ~ :is(input, textarea)))) {
 				padding-inline-start: 0;
 
 				:where(input, textarea) {
@@ -79,7 +79,7 @@
 			}
 
 			/* Propagate padding-inline-end to the nested input/textarea when there is no decoration _after_ it. */
-			&:where(:not(:has(:is(input, textarea) ~ .🥝-text-box-decoration))) {
+			&:where(:not(:has(:is(input, textarea) ~ .🥝TextBoxDecoration))) {
 				padding-inline-end: 0;
 
 				:where(input, textarea) {
@@ -169,14 +169,14 @@
 	}
 }
 
-.🥝-text-box-decoration {
+.🥝TextBoxDecoration {
 	@layer base {
 		flex-shrink: 0;
 	}
 }
 
 @media (forced-colors: active) {
-	.🥝-text-box {
+	.🥝TextBox {
 		--🥝text-box-background-color: Field;
 		--🥝text-box-border-color: CanvasText;
 		color: FieldText;

--- a/packages/bricks/src/TextBox.css
+++ b/packages/bricks/src/TextBox.css
@@ -150,7 +150,7 @@
 		&:where(
 				:disabled,
 				[aria-disabled="true"],
-				[data-kiwi-disabled="true"],
+				[data-_sk-disabled="true"],
 				:has(:is(input, textarea):is(:disabled, [aria-disabled="true"]))
 			) {
 			--🌀TextBox-state: var(--🌀TextBox-state--disabled);
@@ -184,7 +184,7 @@
 		&:where(
 				:disabled,
 				[aria-disabled="true"],
-				[data-kiwi-disabled="true"],
+				[data-_sk-disabled="true"],
 				:has(:is(input, textarea):is(:disabled, [aria-disabled="true"]))
 			) {
 			--🥝TextBox-border-color: GrayText;

--- a/packages/bricks/src/TextBox.tsx
+++ b/packages/bricks/src/TextBox.tsx
@@ -202,7 +202,7 @@ const TextBoxRoot = forwardRef<"div", TextBoxRootProps>(
 			>
 				<Role.div
 					{...props}
-					data-kiwi-disabled={disabled}
+					data-_sk-disabled={disabled}
 					className={cx("🥝TextBox", props.className)}
 					onPointerDown={useEventHandlers(props.onPointerDown, (e) => {
 						if (disabled) return;

--- a/packages/bricks/src/TextBox.tsx
+++ b/packages/bricks/src/TextBox.tsx
@@ -83,7 +83,7 @@ const TextBoxInput = forwardRef<"input", TextBoxInputProps>(
 			<Role.input
 				readOnly={props.disabled}
 				{...props}
-				className={cx({ "🥝-text-box": !rootContext }, props.className)}
+				className={cx({ "🥝TextBox": !rootContext }, props.className)}
 				/**
 				 * Use an empty string as a placeholder to fix baseline alignment in Safari.
 				 * @see https://bugs.webkit.org/show_bug.cgi?id=142968
@@ -142,7 +142,7 @@ const TextBoxTextarea = forwardRef<"textarea", TextareaProps>(
 			<Role.textarea
 				readOnly={props.disabled}
 				{...props}
-				className={cx({ "🥝-text-box": !rootContext }, props.className)}
+				className={cx({ "🥝TextBox": !rootContext }, props.className)}
 				/**
 				 * Use an empty string as a placeholder to fix baseline alignment in Safari.
 				 * @see https://bugs.webkit.org/show_bug.cgi?id=142968
@@ -203,7 +203,7 @@ const TextBoxRoot = forwardRef<"div", TextBoxRootProps>(
 				<Role.div
 					{...props}
 					data-kiwi-disabled={disabled}
-					className={cx("🥝-text-box", props.className)}
+					className={cx("🥝TextBox", props.className)}
 					onPointerDown={useEventHandlers(props.onPointerDown, (e) => {
 						if (disabled) return;
 
@@ -232,7 +232,7 @@ const TextBoxIcon = forwardRef<"svg", TextBoxIconProps>(
 		return (
 			<Icon
 				{...props}
-				className={cx("🥝-text-box-decoration", props.className)}
+				className={cx("🥝TextBoxDecoration", props.className)}
 				ref={forwardedRef}
 			/>
 		);
@@ -252,7 +252,7 @@ const TextBoxText = forwardRef<"span", TextBoxTextProps>(
 		return (
 			<Role.span
 				{...props}
-				className={cx("🥝-text-box-decoration", props.className)}
+				className={cx("🥝TextBoxDecoration", props.className)}
 				ref={forwardedRef}
 			/>
 		);

--- a/packages/bricks/src/Tooltip.css
+++ b/packages/bricks/src/Tooltip.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-tooltip {
+.🥝Tooltip {
 	--✨bg: var(--stratakit-color-bg-elevation-emphasis);
 	--✨color: var(--stratakit-color-text-neutral-emphasis);
 	--✨border: var(--stratakit-color-border-elevation-base);

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -113,7 +113,7 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, forwardedRef) => {
 				portal
 				{...rest}
 				unmountOnHide={unmountOnHide}
-				className={cx("🥝-tooltip", props.className)}
+				className={cx("🥝Tooltip", props.className)}
 				ref={forwardedRef}
 				id={id}
 				style={{ ...popoverProps.style, ...props.style }}

--- a/packages/bricks/src/VisuallyHidden.css
+++ b/packages/bricks/src/VisuallyHidden.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-visually-hidden {
+.🥝VisuallyHidden {
 	@layer base {
 		&:where(:not(:active, :focus-within)) {
 			clip-path: inset(50%) !important;

--- a/packages/bricks/src/VisuallyHidden.tsx
+++ b/packages/bricks/src/VisuallyHidden.tsx
@@ -29,7 +29,7 @@ const VisuallyHidden = forwardRef<"span", VisuallyHiddenProps>(
 		return (
 			<Role.span
 				{...props}
-				className={cx("🥝-visually-hidden", props.className)}
+				className={cx("🥝VisuallyHidden", props.className)}
 				ref={forwardedRef}
 			/>
 		);

--- a/packages/bricks/src/~utils.Dot.css
+++ b/packages/bricks/src/~utils.Dot.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-dot {
+.🥝Dot {
 	@layer base {
 		display: inline-block;
 		inline-size: var(--🥝dot-size, 4px);
@@ -15,7 +15,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-dot {
+	.🥝Dot {
 		background-color: CanvasText;
 	}
 }

--- a/packages/bricks/src/~utils.Dot.css
+++ b/packages/bricks/src/~utils.Dot.css
@@ -5,8 +5,8 @@
 .🥝Dot {
 	@layer base {
 		display: inline-block;
-		inline-size: var(--🥝dot-size, 4px);
-		block-size: var(--🥝dot-size, 4px);
+		inline-size: var(--🥝Dot-size, 4px);
+		block-size: var(--🥝Dot-size, 4px);
 
 		border-radius: 9999px;
 		background-color: var(--stratakit-color-bg-accent-base);

--- a/packages/bricks/src/~utils.Dot.tsx
+++ b/packages/bricks/src/~utils.Dot.tsx
@@ -26,7 +26,7 @@ export const Dot = forwardRef<"span", DotProps>((props, forwardedRef) => {
 		<Role.span
 			aria-hidden="true"
 			{...rest}
-			className={cx("🥝-dot", props.className)}
+			className={cx("🥝Dot", props.className)}
 			ref={forwardedRef}
 		>
 			<VisuallyHidden>{children}</VisuallyHidden>

--- a/packages/bricks/src/~utils.GhostAligner.css
+++ b/packages/bricks/src/~utils.GhostAligner.css
@@ -5,27 +5,27 @@
 .🥝GhostAligner {
 	@layer base {
 		&:where([data-kiwi-ghost-align="inline"]) {
-			margin-inline: calc(-1 * var(--🥝ghost-inline-offset));
+			margin-inline: calc(-1 * var(--🥝GhostAligner-inline-offset));
 		}
 
 		&:where([data-kiwi-ghost-align="inline-start"]) {
-			margin-inline-start: calc(-1 * var(--🥝ghost-inline-offset));
+			margin-inline-start: calc(-1 * var(--🥝GhostAligner-inline-offset));
 		}
 
 		&:where([data-kiwi-ghost-align="inline-end"]) {
-			margin-inline-end: calc(-1 * var(--🥝ghost-inline-offset));
+			margin-inline-end: calc(-1 * var(--🥝GhostAligner-inline-offset));
 		}
 
 		&:where([data-kiwi-ghost-align="block"]) {
-			margin-block: calc(-1 * var(--🥝ghost-block-offset));
+			margin-block: calc(-1 * var(--🥝GhostAligner-block-offset));
 		}
 
 		&:where([data-kiwi-ghost-align="block-start"]) {
-			margin-block-start: calc(-1 * var(--🥝ghost-block-offset));
+			margin-block-start: calc(-1 * var(--🥝GhostAligner-block-offset));
 		}
 
 		&:where([data-kiwi-ghost-align="block-end"]) {
-			margin-block-end: calc(-1 * var(--🥝ghost-block-offset));
+			margin-block-end: calc(-1 * var(--🥝GhostAligner-block-offset));
 		}
 	}
 }

--- a/packages/bricks/src/~utils.GhostAligner.css
+++ b/packages/bricks/src/~utils.GhostAligner.css
@@ -4,27 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝GhostAligner {
 	@layer base {
-		&:where([data-kiwi-ghost-align="inline"]) {
+		&:where([data-_sk-ghost-align="inline"]) {
 			margin-inline: calc(-1 * var(--🥝GhostAligner-inline-offset));
 		}
 
-		&:where([data-kiwi-ghost-align="inline-start"]) {
+		&:where([data-_sk-ghost-align="inline-start"]) {
 			margin-inline-start: calc(-1 * var(--🥝GhostAligner-inline-offset));
 		}
 
-		&:where([data-kiwi-ghost-align="inline-end"]) {
+		&:where([data-_sk-ghost-align="inline-end"]) {
 			margin-inline-end: calc(-1 * var(--🥝GhostAligner-inline-offset));
 		}
 
-		&:where([data-kiwi-ghost-align="block"]) {
+		&:where([data-_sk-ghost-align="block"]) {
 			margin-block: calc(-1 * var(--🥝GhostAligner-block-offset));
 		}
 
-		&:where([data-kiwi-ghost-align="block-start"]) {
+		&:where([data-_sk-ghost-align="block-start"]) {
 			margin-block-start: calc(-1 * var(--🥝GhostAligner-block-offset));
 		}
 
-		&:where([data-kiwi-ghost-align="block-end"]) {
+		&:where([data-_sk-ghost-align="block-end"]) {
 			margin-block-end: calc(-1 * var(--🥝GhostAligner-block-offset));
 		}
 	}

--- a/packages/bricks/src/~utils.GhostAligner.css
+++ b/packages/bricks/src/~utils.GhostAligner.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-ghost-aligner {
+.🥝GhostAligner {
 	@layer base {
 		&:where([data-kiwi-ghost-align="inline"]) {
 			margin-inline: calc(-1 * var(--🥝ghost-inline-offset));

--- a/packages/bricks/src/~utils.GhostAligner.tsx
+++ b/packages/bricks/src/~utils.GhostAligner.tsx
@@ -38,8 +38,8 @@ export function GhostAligner(
  * Returns the value of the nearest `GhostAligner`.
  *
  * This should be used together with the CSS API:
- * - `🥝-ghost-aligner` class.
- * - `data-kiwi-ghost-align` attribute.
+ * - `🥝GhostAligner` class.
+ * - `data-_sk-ghost-align` attribute.
  * - `--🥝ghost-block-offset` and `--🥝ghost-inline-offset` variables.
  *
  * @private

--- a/packages/bricks/src/~utils.GhostAligner.tsx
+++ b/packages/bricks/src/~utils.GhostAligner.tsx
@@ -40,7 +40,7 @@ export function GhostAligner(
  * This should be used together with the CSS API:
  * - `🥝GhostAligner` class.
  * - `data-_sk-ghost-align` attribute.
- * - `--🥝ghost-block-offset` and `--🥝ghost-inline-offset` variables.
+ * - `--🥝GhostAligner-block-offset` and `--🥝GhostAligner-inline-offset` variables.
  *
  * @private
  */

--- a/packages/bricks/src/~utils.icons.tsx
+++ b/packages/bricks/src/~utils.icons.tsx
@@ -40,7 +40,7 @@ export const DisclosureArrow = forwardRef<"svg", DisclosureArrowProps>(
 		return (
 			<Element
 				{...rest}
-				className={cx("🥝-disclosure-arrow", props.className)}
+				className={cx("🥝DisclosureArrow", props.className)}
 				ref={forwardedRef}
 			/>
 		);

--- a/packages/foundations/src/Icon.css
+++ b/packages/foundations/src/Icon.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-icon {
+.🥝Icon {
 	@layer base {
 		width: var(--🥝icon-size, 1rem);
 		height: var(--🥝icon-size, 1rem);
@@ -22,7 +22,7 @@
 	}
 }
 
-.🥝-disclosure-arrow {
+.🥝DisclosureArrow {
 	@layer base {
 		margin-inline-end: calc(var(--stratakit-space-x2) * -1);
 		rotate: var(--🥝disclosure-arrow-rotate);
@@ -33,7 +33,7 @@
 	}
 }
 
-.🥝-chevron-down {
+.🥝ChevronDown {
 	@layer base {
 		rotate: var(--🥝chevron-down-rotate);
 
@@ -44,7 +44,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-icon {
+	.🥝Icon {
 		--🥝icon-color: currentColor;
 	}
 }

--- a/packages/foundations/src/Icon.css
+++ b/packages/foundations/src/Icon.css
@@ -12,11 +12,11 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-size="regular"]) {
+		&:where([data-_sk-size="regular"]) {
 			--🥝Icon-size: 1rem;
 		}
 
-		&:where([data-kiwi-size="large"]) {
+		&:where([data-_sk-size="large"]) {
 			--🥝Icon-size: 1.5rem;
 		}
 	}

--- a/packages/foundations/src/Icon.css
+++ b/packages/foundations/src/Icon.css
@@ -4,20 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝Icon {
 	@layer base {
-		width: var(--🥝icon-size, 1rem);
-		height: var(--🥝icon-size, 1rem);
+		width: var(--🥝Icon-size, 1rem);
+		height: var(--🥝Icon-size, 1rem);
 		flex-shrink: 0;
-		color: var(--🥝icon-color);
+		color: var(--🥝Icon-color);
 		transition: color 150ms ease-out;
 	}
 
 	@layer modifiers {
 		&:where([data-kiwi-size="regular"]) {
-			--🥝icon-size: 1rem;
+			--🥝Icon-size: 1rem;
 		}
 
 		&:where([data-kiwi-size="large"]) {
-			--🥝icon-size: 1.5rem;
+			--🥝Icon-size: 1.5rem;
 		}
 	}
 }
@@ -25,7 +25,7 @@
 .🥝DisclosureArrow {
 	@layer base {
 		margin-inline-end: calc(var(--stratakit-space-x2) * -1);
-		rotate: var(--🥝disclosure-arrow-rotate);
+		rotate: var(--🥝DisclosureArrow-rotate);
 
 		@media (prefers-reduced-motion: no-preference) {
 			transition: rotate 150ms ease-in-out;
@@ -35,7 +35,7 @@
 
 .🥝ChevronDown {
 	@layer base {
-		rotate: var(--🥝chevron-down-rotate);
+		rotate: var(--🥝ChevronDown-rotate);
 
 		@media (prefers-reduced-motion: no-preference) {
 			transition: rotate 150ms ease-in-out;
@@ -45,6 +45,6 @@
 
 @media (forced-colors: active) {
 	.🥝Icon {
-		--🥝icon-color: currentColor;
+		--🥝Icon-color: currentColor;
 	}
 }

--- a/packages/foundations/src/Icon.tsx
+++ b/packages/foundations/src/Icon.tsx
@@ -95,7 +95,7 @@ export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
 			role={isDecorative ? undefined : "img"}
 			aria-label={isDecorative ? undefined : alt}
 			{...rest}
-			data-kiwi-size={size}
+			data-_sk-size={size}
 			className={cx("🥝Icon", props.className)}
 			ref={forwardedRef}
 		>

--- a/packages/foundations/src/Icon.tsx
+++ b/packages/foundations/src/Icon.tsx
@@ -96,7 +96,7 @@ export const Icon = forwardRef<"svg", IconProps>((props, forwardedRef) => {
 			aria-label={isDecorative ? undefined : alt}
 			{...rest}
 			data-kiwi-size={size}
-			className={cx("🥝-icon", props.className)}
+			className={cx("🥝Icon", props.className)}
 			ref={forwardedRef}
 		>
 			{hrefBase ? <use href={toIconHref(hrefBase)} /> : null}

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -70,7 +70,7 @@ interface RootProps extends BaseProps {
 }
 
 /**
- * Component to be used at the root of your application. It ensures that kiwi styles and fonts are loaded
+ * Component to be used at the root of your application. It ensures that StrataKit styles and fonts are loaded
  * and automatically applied to the current page or the encompassing shadow-root.
  *
  * Make sure to specify the `colorScheme` and `density` props.
@@ -147,8 +147,8 @@ const RootInternal = forwardRef<"div", RootInternalProps>(
 			<Role
 				{...rest}
 				className={cx("🥝Root", props.className)}
-				data-kiwi-theme={colorScheme}
-				data-kiwi-density={density}
+				data-_sk-theme={colorScheme}
+				data-_sk-density={density}
 				ref={useMergedRefs(forwardedRef, findRootNodeFromRef)}
 			>
 				<RootNodeContext.Provider value={rootNode}>
@@ -205,8 +205,8 @@ const PortalContainer = forwardRef<
 	return ReactDOM.createPortal(
 		<div
 			className="🥝Root"
-			data-kiwi-theme={props.colorScheme}
-			data-kiwi-density={props.density}
+			data-_sk-theme={props.colorScheme}
+			data-_sk-density={props.density}
 			style={{ display: "contents" }}
 			ref={forwardedRef}
 		/>,

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -146,7 +146,7 @@ const RootInternal = forwardRef<"div", RootInternalProps>(
 		return (
 			<Role
 				{...rest}
-				className={cx("🥝-root", props.className)}
+				className={cx("🥝Root", props.className)}
 				data-kiwi-theme={colorScheme}
 				data-kiwi-density={density}
 				ref={useMergedRefs(forwardedRef, findRootNodeFromRef)}
@@ -204,7 +204,7 @@ const PortalContainer = forwardRef<
 
 	return ReactDOM.createPortal(
 		<div
-			className="🥝-root"
+			className="🥝Root"
 			data-kiwi-theme={props.colorScheme}
 			data-kiwi-density={props.density}
 			style={{ display: "contents" }}

--- a/packages/foundations/src/styles.internal.ts
+++ b/packages/foundations/src/styles.internal.ts
@@ -40,10 +40,10 @@ export function loadStyles(
 		// Inject <style> elements if `adoptedStyleSheets` is not supported.
 		if (
 			!supportsAdoptedStylesheets &&
-			!rootNode.querySelector(`style[data-kiwi="${key}"]`)
+			!rootNode.querySelector(`style[data-_sk="${key}"]`)
 		) {
 			const styleElement = ownerDocument.createElement("style");
-			styleElement.dataset.kiwi = key;
+			styleElement.dataset._sk = key;
 			styleElement.textContent = css;
 			((rootNode as Document).head || rootNode).appendChild(styleElement);
 			cleanup = () => styleElement.remove();

--- a/packages/foundations/src/~global.css
+++ b/packages/foundations/src/~global.css
@@ -12,7 +12,7 @@ body {
 	@apply --typography("body-md");
 }
 
-:is(body, .🥝-root) {
+:is(body, .🥝Root) {
 	font-family: var(--stratakit-font-family-sans);
 	font-variant-alternates: character-variant(alt-1, alt-3, lc-l-with-tail, uc-i-with-serif);
 	color: var(--stratakit-color-text-neutral-primary);

--- a/packages/foundations/src/~space.css
+++ b/packages/foundations/src/~space.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 html,
 :host,
-.🥝-root {
+.🥝Root {
 	--stratakit-space-x05: 2px;
 	--stratakit-space-x1: 4px;
 	--stratakit-space-x2: 8px;

--- a/packages/foundations/src/~theme.css
+++ b/packages/foundations/src/~theme.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 html:where([data-color-scheme="light"]),
 :host([data-color-scheme="light"]),
-.🥝Root:where([data-kiwi-theme="light"]) {
+.🥝Root:where([data-_sk-theme="light"]) {
 	@apply --theme("light");
 	color-scheme: light;
 
@@ -19,7 +19,7 @@ html:where([data-color-scheme="light"]),
 
 html:where([data-color-scheme="dark"]),
 :host([data-color-scheme="dark"]),
-.🥝Root:where([data-kiwi-theme="dark"]) {
+.🥝Root:where([data-_sk-theme="dark"]) {
 	@apply --theme("dark");
 	color-scheme: dark;
 

--- a/packages/foundations/src/~theme.css
+++ b/packages/foundations/src/~theme.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 html:where([data-color-scheme="light"]),
 :host([data-color-scheme="light"]),
-.🥝-root:where([data-kiwi-theme="light"]) {
+.🥝Root:where([data-kiwi-theme="light"]) {
 	@apply --theme("light");
 	color-scheme: light;
 
@@ -19,7 +19,7 @@ html:where([data-color-scheme="light"]),
 
 html:where([data-color-scheme="dark"]),
 :host([data-color-scheme="dark"]),
-.🥝-root:where([data-kiwi-theme="dark"]) {
+.🥝Root:where([data-kiwi-theme="dark"]) {
 	@apply --theme("dark");
 	color-scheme: dark;
 

--- a/packages/foundations/src/~typography.css
+++ b/packages/foundations/src/~typography.css
@@ -11,7 +11,7 @@
 	@apply --typography-tokens;
 }
 
-.🥝Root:where([data-kiwi-density="dense"]) {
+.🥝Root:where([data-_sk-density="dense"]) {
 	@apply --typography("body-sm");
 }
 

--- a/packages/foundations/src/~typography.css
+++ b/packages/foundations/src/~typography.css
@@ -11,7 +11,7 @@
 	@apply --typography-tokens;
 }
 
-.🥝-root:where([data-kiwi-density="dense"]) {
+.🥝Root:where([data-kiwi-density="dense"]) {
 	@apply --typography("body-sm");
 }
 

--- a/packages/structures/src/AccordionItem.css
+++ b/packages/structures/src/AccordionItem.css
@@ -22,7 +22,7 @@
 	}
 
 	@layer states {
-		&:where([data-kiwi-open="true"]) {
+		&:where([data-_sk-open="true"]) {
 			--🥝ChevronDown-rotate: -0.5turn;
 		}
 	}

--- a/packages/structures/src/AccordionItem.css
+++ b/packages/structures/src/AccordionItem.css
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 .🥝AccordionItem {
-	--🥝accordion-item-gap: var(--stratakit-space-x3);
-	--🥝accordion-item-padding: var(--stratakit-space-x3);
+	--🥝AccordionItem-gap: var(--stratakit-space-x3);
+	--🥝AccordionItem-padding: var(--stratakit-space-x3);
 
 	@layer base {
 		contain: paint;
@@ -23,7 +23,7 @@
 
 	@layer states {
 		&:where([data-kiwi-open="true"]) {
-			--🥝chevron-down-rotate: -0.5turn;
+			--🥝ChevronDown-rotate: -0.5turn;
 		}
 	}
 }
@@ -37,19 +37,19 @@
 		grid-row: header;
 		grid-column: marker-before-start / marker-after-end;
 
-		background-color: var(--🥝accordion-item-header-background-color);
+		background-color: var(--🥝AccordionItemHeader-background-color);
 		transition: background-color 150ms ease-out;
 		position: relative;
 		display: grid;
 		align-items: center;
-		padding: var(--🥝accordion-item-padding);
+		padding: var(--🥝AccordionItem-padding);
 
-		--🥝accordion-item-header-background-color: var(
-				--🌀accordion-item-header-state--default,
+		--🥝AccordionItemHeader-background-color: var(
+				--🌀AccordionItemHeader-state--default,
 				var(--✨header-bg--default)
 			)
-			var(--🌀accordion-item-header-state--hover, var(--✨header-bg--hover))
-			var(--🌀accordion-item-header-state--pressed, var(--✨header-bg--pressed));
+			var(--🌀AccordionItemHeader-state--hover, var(--✨header-bg--hover))
+			var(--🌀AccordionItemHeader-state--pressed, var(--✨header-bg--pressed));
 
 		/* TODO: improve the layout for the fallback (i.e. content doesn’t align with the label if there’s a decoration) */
 		grid-template-columns: inherit;
@@ -62,21 +62,21 @@
 	@layer states {
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀accordion-item-header-state: var(--🌀accordion-item-header-state--hover);
+				--🌀AccordionItemHeader-state: var(--🌀AccordionItemHeader-state--hover);
 			}
 		}
 
 		&:where(:active) {
-			--🌀accordion-item-header-state: var(--🌀accordion-item-header-state--pressed);
+			--🌀AccordionItemHeader-state: var(--🌀AccordionItemHeader-state--pressed);
 		}
 	}
 
 	@layer base.🌀 {
 		/* Cyclic toggles for default/hover/pressed states. See https://kizu.dev/cyclic-toggles/ */
-		--🌀accordion-item-header-state: var(--🌀accordion-item-header-state--default);
-		--🌀accordion-item-header-state--default: var(--🌀accordion-item-header-state,);
-		--🌀accordion-item-header-state--hover: var(--🌀accordion-item-header-state,);
-		--🌀accordion-item-header-state--pressed: var(--🌀accordion-item-header-state,);
+		--🌀AccordionItemHeader-state: var(--🌀AccordionItemHeader-state--default);
+		--🌀AccordionItemHeader-state--default: var(--🌀AccordionItemHeader-state,);
+		--🌀AccordionItemHeader-state--hover: var(--🌀AccordionItemHeader-state,);
+		--🌀AccordionItemHeader-state--pressed: var(--🌀AccordionItemHeader-state,);
 	}
 }
 
@@ -84,15 +84,15 @@
 	@layer base {
 		grid-row: 1;
 		grid-column: marker-before;
-		margin-inline-end: var(--🥝accordion-item-gap);
+		margin-inline-end: var(--🥝AccordionItem-gap);
 		/* TODO: We can only use GhostAligner to apply alignment to block or inline, so we’re manually applying it here. */
-		margin-inline-start: calc(-1 * var(--🥝ghost-inline-offset));
+		margin-inline-start: calc(-1 * var(--🥝GhostAligner-inline-offset));
 		pointer-events: none;
 
 		:where(.🥝AccordionItemHeading, .🥝AccordionItemButton) ~ & {
 			grid-column: marker-after;
-			margin-inline-start: var(--🥝accordion-item-gap);
-			margin-inline-end: calc(-1 * var(--🥝ghost-inline-offset));
+			margin-inline-start: var(--🥝AccordionItem-gap);
+			margin-inline-end: calc(-1 * var(--🥝GhostAligner-inline-offset));
 		}
 	}
 }
@@ -138,7 +138,7 @@
 	@layer base {
 		grid-row: content;
 		grid-column: body-content;
-		padding-block: var(--🥝accordion-item-padding);
+		padding-block: var(--🥝AccordionItem-padding);
 		text-box: cap alphabetic;
 		color: var(--stratakit-color-text-neutral-secondary);
 	}
@@ -147,14 +147,14 @@
 .🥝AccordionItemDecoration {
 	@layer base {
 		grid-column: decoration-before;
-		margin-inline-end: var(--🥝accordion-item-gap);
+		margin-inline-end: var(--🥝AccordionItem-gap);
 		display: flex;
 		align-items: center;
 		gap: var(--stratakit-space-x1);
 
 		:where(.🥝AccordionItemHeading, .🥝AccordionItemButton) ~ & {
 			grid-column: decoration-after;
-			margin-inline-start: var(--🥝accordion-item-gap);
+			margin-inline-start: var(--🥝AccordionItem-gap);
 			margin-inline-end: 0;
 		}
 	}

--- a/packages/structures/src/AccordionItem.css
+++ b/packages/structures/src/AccordionItem.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-accordion-item {
+.🥝AccordionItem {
 	--🥝accordion-item-gap: var(--stratakit-space-x3);
 	--🥝accordion-item-padding: var(--stratakit-space-x3);
 
@@ -28,7 +28,7 @@
 	}
 }
 
-.🥝-accordion-item-header {
+.🥝AccordionItemHeader {
 	--✨header-bg--hover: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
 	--✨header-bg--pressed: var(--stratakit-color-bg-glow-on-surface-neutral-pressed);
 	--✨header-bg--default: transparent;
@@ -80,7 +80,7 @@
 	}
 }
 
-.🥝-accordion-item-marker {
+.🥝AccordionItemMarker {
 	@layer base {
 		grid-row: 1;
 		grid-column: marker-before;
@@ -89,7 +89,7 @@
 		margin-inline-start: calc(-1 * var(--🥝ghost-inline-offset));
 		pointer-events: none;
 
-		:where(.🥝-accordion-item-heading, .🥝-accordion-item-button) ~ & {
+		:where(.🥝AccordionItemHeading, .🥝AccordionItemButton) ~ & {
 			grid-column: marker-after;
 			margin-inline-start: var(--🥝accordion-item-gap);
 			margin-inline-end: calc(-1 * var(--🥝ghost-inline-offset));
@@ -97,7 +97,7 @@
 	}
 }
 
-.🥝-accordion-item-label:is(.🥝-text) {
+.🥝AccordionItemLabel:is(.🥝Text) {
 	@layer base {
 		display: inline-block;
 		hyphens: auto;
@@ -107,7 +107,7 @@
 	}
 }
 
-.🥝-accordion-item-button {
+.🥝AccordionItemButton {
 	@layer base {
 		grid-column: header-content;
 		cursor: pointer;
@@ -134,7 +134,7 @@
 	}
 }
 
-.🥝-accordion-item-content {
+.🥝AccordionItemContent {
 	@layer base {
 		grid-row: content;
 		grid-column: body-content;
@@ -144,7 +144,7 @@
 	}
 }
 
-.🥝-accordion-item-decoration {
+.🥝AccordionItemDecoration {
 	@layer base {
 		grid-column: decoration-before;
 		margin-inline-end: var(--🥝accordion-item-gap);
@@ -152,7 +152,7 @@
 		align-items: center;
 		gap: var(--stratakit-space-x1);
 
-		:where(.🥝-accordion-item-heading, .🥝-accordion-item-button) ~ & {
+		:where(.🥝AccordionItemHeading, .🥝AccordionItemButton) ~ & {
 			grid-column: decoration-after;
 			margin-inline-start: var(--🥝accordion-item-gap);
 			margin-inline-end: 0;
@@ -160,7 +160,7 @@
 	}
 }
 
-.🥝-accordion-item-heading {
+.🥝AccordionItemHeading {
 	@layer base {
 		grid-column: header-content;
 		margin-block: 0;

--- a/packages/structures/src/AccordionItem.tsx
+++ b/packages/structures/src/AccordionItem.tsx
@@ -118,7 +118,7 @@ const AccordionItemRoot = forwardRef<"div", AccordionItemProps>(
 			>
 				<Role
 					{...rest}
-					className={cx("🥝-accordion-item", props.className)}
+					className={cx("🥝AccordionItem", props.className)}
 					data-kiwi-open={open}
 					ref={forwardedRef}
 				/>
@@ -152,7 +152,7 @@ const AccordionItemHeader = forwardRef<"div", BaseProps>(
 		<GhostAligner align="block">
 			<Role
 				{...props}
-				className={cx("🥝-accordion-item-header", props.className)}
+				className={cx("🥝AccordionItemHeader", props.className)}
 				ref={forwardedRef}
 			/>
 		</GhostAligner>
@@ -179,7 +179,7 @@ const AccordionItemButton = forwardRef<"button", BaseProps<"button">>(
 	(props, forwardedRef) => (
 		<Disclosure
 			{...props}
-			className={cx("🥝-accordion-item-button", props.className)}
+			className={cx("🥝AccordionItemButton", props.className)}
 			ref={forwardedRef}
 		/>
 	),
@@ -203,7 +203,7 @@ const AccordionItemLabel = forwardRef<"div", BaseProps>(
 		<Text
 			{...props}
 			variant="body-sm"
-			className={cx("🥝-accordion-item-label", props.className)}
+			className={cx("🥝AccordionItemLabel", props.className)}
 			ref={forwardedRef}
 		/>
 	),
@@ -265,7 +265,7 @@ const AccordionItemDecoration = forwardRef<"div", BaseProps>(
 	(props, forwardedRef) => (
 		<Role
 			{...props}
-			className={cx("🥝-accordion-item-decoration", props.className)}
+			className={cx("🥝AccordionItemDecoration", props.className)}
 			ref={forwardedRef}
 		/>
 	),
@@ -317,13 +317,13 @@ const AccordionItemMarker = forwardRef<"div", BaseProps>(
 		<IconButtonPresentation
 			{...props}
 			variant="ghost"
-			className={cx("🥝-accordion-item-marker", props.className)}
+			className={cx("🥝AccordionItemMarker", props.className)}
 			ref={forwardedRef}
 		>
 			{props.children ?? (
 				<ChevronDown
 					aria-hidden="true"
-					className="🥝-accordion-item-marker-chevron"
+					className="🥝AccordionItemMarkerChevron"
 				/>
 			)}
 		</IconButtonPresentation>
@@ -351,7 +351,7 @@ const AccordionItemContent = forwardRef<"div", BaseProps>(
 	(props, forwardedRef) => (
 		<DisclosureContent
 			{...props}
-			className={cx("🥝-accordion-item-content", props.className)}
+			className={cx("🥝AccordionItemContent", props.className)}
 			ref={forwardedRef}
 		/>
 	),
@@ -383,7 +383,7 @@ const AccordionItemHeading = forwardRef<"div", AccordionItemHeadingProps>(
 		<Text
 			{...props}
 			variant="body-sm"
-			className={cx("🥝-accordion-item-heading", props.className)}
+			className={cx("🥝AccordionItemHeading", props.className)}
 			ref={forwardedRef}
 		/>
 	),

--- a/packages/structures/src/AccordionItem.tsx
+++ b/packages/structures/src/AccordionItem.tsx
@@ -119,7 +119,7 @@ const AccordionItemRoot = forwardRef<"div", AccordionItemProps>(
 				<Role
 					{...rest}
 					className={cx("🥝AccordionItem", props.className)}
-					data-kiwi-open={open}
+					data-_sk-open={open}
 					ref={forwardedRef}
 				/>
 			</DisclosureProvider>

--- a/packages/structures/src/Banner.css
+++ b/packages/structures/src/Banner.css
@@ -7,8 +7,8 @@
 	@layer base {
 		display: grid;
 		grid-template-columns: [start] auto [content] minmax(0, 1fr) [end] auto;
-		background-color: var(--🥝banner-color-background);
-		border: 1px solid var(--🥝banner-color-border);
+		background-color: var(--🥝Banner-color-background);
+		border: 1px solid var(--🥝Banner-color-border);
 		border-radius: 8px;
 		padding: var(--stratakit-space-x3);
 		align-items: center;
@@ -17,31 +17,31 @@
 
 	@layer modifiers {
 		&:where([data-kiwi-variant="outline"]) {
-			--🥝banner-color-background: var(--stratakit-color-bg-elevation-base);
+			--🥝Banner-color-background: var(--stratakit-color-bg-elevation-base);
 
 			&:where([data-kiwi-tone="neutral"]) {
-				--🥝banner-color-border: var(--stratakit-color-border-neutral-base);
+				--🥝Banner-color-border: var(--stratakit-color-border-neutral-base);
 			}
 		}
 
 		&:where([data-kiwi-tone="info"]) {
-			--🥝banner-color-border: var(--stratakit-color-border-info-base);
-			--🥝icon-color: var(--stratakit-color-icon-info-base);
+			--🥝Banner-color-border: var(--stratakit-color-border-info-base);
+			--🥝Icon-color: var(--stratakit-color-icon-info-base);
 		}
 
 		&:where([data-kiwi-tone="positive"]) {
-			--🥝banner-color-border: var(--stratakit-color-border-positive-base);
-			--🥝icon-color: var(--stratakit-color-icon-positive-base);
+			--🥝Banner-color-border: var(--stratakit-color-border-positive-base);
+			--🥝Icon-color: var(--stratakit-color-icon-positive-base);
 		}
 
 		&:where([data-kiwi-tone="attention"]) {
-			--🥝banner-color-border: var(--stratakit-color-border-attention-base);
-			--🥝icon-color: var(--stratakit-color-icon-attention-base);
+			--🥝Banner-color-border: var(--stratakit-color-border-attention-base);
+			--🥝Icon-color: var(--stratakit-color-icon-attention-base);
 		}
 
 		&:where([data-kiwi-tone="critical"]) {
-			--🥝banner-color-border: var(--stratakit-color-border-critical-base);
-			--🥝icon-color: var(--stratakit-color-icon-critical-base);
+			--🥝Banner-color-border: var(--stratakit-color-border-critical-base);
+			--🥝Icon-color: var(--stratakit-color-icon-critical-base);
 		}
 	}
 }
@@ -96,6 +96,6 @@
 
 @media (forced-colors: active) {
 	.🥝Banner {
-		--🥝icon-color: CanvasText;
+		--🥝Icon-color: CanvasText;
 	}
 }

--- a/packages/structures/src/Banner.css
+++ b/packages/structures/src/Banner.css
@@ -16,30 +16,30 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-variant="outline"]) {
+		&:where([data-_sk-variant="outline"]) {
 			--🥝Banner-color-background: var(--stratakit-color-bg-elevation-base);
 
-			&:where([data-kiwi-tone="neutral"]) {
+			&:where([data-_sk-tone="neutral"]) {
 				--🥝Banner-color-border: var(--stratakit-color-border-neutral-base);
 			}
 		}
 
-		&:where([data-kiwi-tone="info"]) {
+		&:where([data-_sk-tone="info"]) {
 			--🥝Banner-color-border: var(--stratakit-color-border-info-base);
 			--🥝Icon-color: var(--stratakit-color-icon-info-base);
 		}
 
-		&:where([data-kiwi-tone="positive"]) {
+		&:where([data-_sk-tone="positive"]) {
 			--🥝Banner-color-border: var(--stratakit-color-border-positive-base);
 			--🥝Icon-color: var(--stratakit-color-icon-positive-base);
 		}
 
-		&:where([data-kiwi-tone="attention"]) {
+		&:where([data-_sk-tone="attention"]) {
 			--🥝Banner-color-border: var(--stratakit-color-border-attention-base);
 			--🥝Icon-color: var(--stratakit-color-icon-attention-base);
 		}
 
-		&:where([data-kiwi-tone="critical"]) {
+		&:where([data-_sk-tone="critical"]) {
 			--🥝Banner-color-border: var(--stratakit-color-border-critical-base);
 			--🥝Icon-color: var(--stratakit-color-icon-critical-base);
 		}

--- a/packages/structures/src/Banner.css
+++ b/packages/structures/src/Banner.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-banner {
+.🥝Banner {
 	@layer base {
 		display: grid;
 		grid-template-columns: [start] auto [content] minmax(0, 1fr) [end] auto;
@@ -46,7 +46,7 @@
 	}
 }
 
-.🥝-banner-icon {
+.🥝BannerIcon {
 	@layer base {
 		grid-column: start;
 		grid-row: 1;
@@ -55,7 +55,7 @@
 	}
 }
 
-.🥝-banner-label {
+.🥝BannerLabel {
 	@layer base {
 		grid-column: content;
 		font-weight: 500;
@@ -64,7 +64,7 @@
 	}
 }
 
-.🥝-banner-message {
+.🥝BannerMessage {
 	@layer base {
 		grid-column: content;
 		overflow: hidden;
@@ -73,7 +73,7 @@
 	}
 }
 
-.🥝-banner-actions {
+.🥝BannerActions {
 	@layer base {
 		grid-column: content;
 		justify-self: start;
@@ -85,7 +85,7 @@
 	}
 }
 
-.🥝-banner-dismiss-button {
+.🥝BannerDismissButton {
 	@layer base {
 		grid-column: end;
 		grid-row: 1;
@@ -95,7 +95,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-banner {
+	.🥝Banner {
 		--🥝icon-color: CanvasText;
 	}
 }

--- a/packages/structures/src/Banner.tsx
+++ b/packages/structures/src/Banner.tsx
@@ -104,7 +104,7 @@ const BannerRoot = forwardRef<"div", BannerRootProps>((props, forwardedRef) => {
 				{...rest}
 				data-kiwi-tone={tone}
 				data-kiwi-variant={variant}
-				className={cx("🥝-banner", props.className)}
+				className={cx("🥝Banner", props.className)}
 				ref={forwardedRef}
 			/>
 		</BannerProvider>
@@ -150,7 +150,7 @@ const BannerIcon = forwardRef<"svg", BannerIconProps>((props, forwardedRef) => {
 		<Icon
 			{...rest}
 			render={render}
-			className={cx("🥝-banner-icon", props.className)}
+			className={cx("🥝BannerIcon", props.className)}
 			ref={forwardedRef}
 		/>
 	);
@@ -199,7 +199,7 @@ const BannerLabel = forwardRef<"span", BannerLabelProps>(
 				id={labelId}
 				render={<span />}
 				{...props}
-				className={cx("🥝-banner-label", props.className)}
+				className={cx("🥝BannerLabel", props.className)}
 				variant="body-sm"
 				ref={forwardedRef}
 			/>
@@ -228,7 +228,7 @@ const BannerMessage = forwardRef<"span", BannerMessageProps>(
 			<Text
 				{...props}
 				variant="body-sm"
-				className={cx("🥝-banner-message", props.className)}
+				className={cx("🥝BannerMessage", props.className)}
 				ref={forwardedRef}
 			/>
 		);
@@ -277,7 +277,7 @@ const BannerActions = forwardRef<"div", BannerActionsProps>(
 		return (
 			<Role.div
 				{...props}
-				className={cx("🥝-banner-actions", props.className)}
+				className={cx("🥝BannerActions", props.className)}
 				ref={forwardedRef}
 			/>
 		);
@@ -323,7 +323,7 @@ const BannerDismissButton = forwardRef<"button", BannerDismissButtonProps>(
 				<IconButton
 					{...rest}
 					id={id}
-					className={cx("🥝-banner-dismiss-button", props.className)}
+					className={cx("🥝BannerDismissButton", props.className)}
 					variant="ghost"
 					label={label}
 					aria-labelledby={`${id} ${labelId || ""}`}

--- a/packages/structures/src/Banner.tsx
+++ b/packages/structures/src/Banner.tsx
@@ -102,8 +102,8 @@ const BannerRoot = forwardRef<"div", BannerRootProps>((props, forwardedRef) => {
 		<BannerProvider tone={tone}>
 			<Role
 				{...rest}
-				data-kiwi-tone={tone}
-				data-kiwi-variant={variant}
+				data-_sk-tone={tone}
+				data-_sk-variant={variant}
 				className={cx("🥝Banner", props.className)}
 				ref={forwardedRef}
 			/>

--- a/packages/structures/src/Chip.css
+++ b/packages/structures/src/Chip.css
@@ -10,8 +10,8 @@
 		align-items: center;
 		position: relative;
 
-		--🥝chip-padding-inline: var(--stratakit-space-x2);
-		padding-inline: var(--🥝chip-padding-inline);
+		--🥝Chip-padding-inline: var(--stratakit-space-x2);
+		padding-inline: var(--🥝Chip-padding-inline);
 
 		min-block-size: 1.5rem;
 
@@ -59,6 +59,6 @@
 	@layer base {
 		position: relative;
 		border-radius: inherit;
-		margin-inline-end: calc(-1 * var(--🥝chip-padding-inline));
+		margin-inline-end: calc(-1 * var(--🥝Chip-padding-inline));
 	}
 }

--- a/packages/structures/src/Chip.css
+++ b/packages/structures/src/Chip.css
@@ -30,11 +30,11 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-variant="solid"]) {
+		&:where([data-_sk-variant="solid"]) {
 			background-color: var(--stratakit-color-bg-neutral-base);
 		}
 
-		&:where([data-kiwi-variant="outline"]) {
+		&:where([data-_sk-variant="outline"]) {
 			background-color: var(--stratakit-color-bg-page-base);
 		}
 	}

--- a/packages/structures/src/Chip.css
+++ b/packages/structures/src/Chip.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-chip {
+.🥝Chip {
 	@layer base {
 		isolation: isolate;
 
@@ -40,7 +40,7 @@
 	}
 }
 
-.🥝-chip-label {
+.🥝ChipLabel {
 	@layer base {
 		&:where(button) {
 			border-radius: inherit;
@@ -55,7 +55,7 @@
 	}
 }
 
-.🥝-chip-dismiss-button:is(.🥝-icon-button) {
+.🥝ChipDismissButton:is(.🥝IconButton) {
 	@layer base {
 		position: relative;
 		border-radius: inherit;

--- a/packages/structures/src/Chip.tsx
+++ b/packages/structures/src/Chip.tsx
@@ -83,7 +83,7 @@ const ChipRoot = forwardRef<"div", ChipRootProps>((props, forwardedRef) => {
 			<Role.div
 				data-kiwi-variant={variant}
 				{...rest}
-				className={cx("🥝-chip", props.className)}
+				className={cx("🥝Chip", props.className)}
 				ref={forwardedRef}
 			/>
 		</ChipProvider>
@@ -110,7 +110,7 @@ const ChipLabel = forwardRef<"span", ChipLabelProps>((props, forwardedRef) => {
 		<Role.span
 			id={labelId}
 			{...props}
-			className={cx("🥝-chip-label", props.className)}
+			className={cx("🥝ChipLabel", props.className)}
 			ref={forwardedRef}
 		/>
 	);
@@ -146,7 +146,7 @@ const ChipDismissButton = forwardRef<"button", ChipDismissButtonProps>(
 				aria-labelledby={`${id} ${labelId}`}
 				{...rest}
 				label={label}
-				className={cx("🥝-chip-dismiss-button", props.className)}
+				className={cx("🥝ChipDismissButton", props.className)}
 				variant="ghost"
 				labelVariant="visually-hidden"
 				icon={<Dismiss />}

--- a/packages/structures/src/Chip.tsx
+++ b/packages/structures/src/Chip.tsx
@@ -81,7 +81,7 @@ const ChipRoot = forwardRef<"div", ChipRootProps>((props, forwardedRef) => {
 	return (
 		<ChipProvider>
 			<Role.div
-				data-kiwi-variant={variant}
+				data-_sk-variant={variant}
 				{...rest}
 				className={cx("🥝Chip", props.className)}
 				ref={forwardedRef}

--- a/packages/structures/src/DropdownMenu.css
+++ b/packages/structures/src/DropdownMenu.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-dropdown-menu {
+.🥝DropdownMenu {
 	--✨bg: var(--stratakit-color-bg-elevation-level-1);
 	--✨padding: var(--stratakit-space-x1);
 
@@ -19,7 +19,7 @@
 	}
 }
 
-.🥝-dropdown-menu-button {
+.🥝DropdownMenuButton {
 	@layer states {
 		&:where([aria-expanded="true"]) {
 			--🥝disclosure-arrow-rotate: 0.5turn;
@@ -27,7 +27,7 @@
 	}
 }
 
-.🥝-dropdown-menu-item:is(.🥝-list-item) {
+.🥝DropdownMenuItem:is(.🥝ListItem) {
 	@layer base {
 		border-radius: 4px;
 	}
@@ -39,26 +39,26 @@
 	}
 }
 
-.🥝-dropdown-menu-item-dot:is(.🥝-dot) {
+.🥝DropdownMenuItemDot:is(.🥝Dot) {
 	@layer base {
 		align-self: center;
 	}
 }
 
-.🥝-dropdown-menu-checkmark {
+.🥝DropdownMenuCheckmark {
 	@layer base {
 		visibility: var(--🥝dropdown-menu-checkmark-visibility);
 	}
 }
 
-.🥝-dropdown-menu-item-shortcuts {
+.🥝DropdownMenuItemShortcuts {
 	@layer base {
 		margin-inline-start: var(--stratakit-space-x2);
 	}
 }
 
 @media (forced-colors: active) {
-	.🥝-dropdown-menu {
+	.🥝DropdownMenu {
 		border: 1px solid;
 	}
 }

--- a/packages/structures/src/DropdownMenu.css
+++ b/packages/structures/src/DropdownMenu.css
@@ -22,7 +22,7 @@
 .🥝DropdownMenuButton {
 	@layer states {
 		&:where([aria-expanded="true"]) {
-			--🥝disclosure-arrow-rotate: 0.5turn;
+			--🥝DisclosureArrow-rotate: 0.5turn;
 		}
 	}
 }
@@ -34,7 +34,7 @@
 
 	@layer states {
 		&:where([role="menuitemcheckbox"]:not([aria-checked="true"])) {
-			--🥝dropdown-menu-checkmark-visibility: hidden;
+			--🥝DropdownMenuCheckmark-visibility: hidden;
 		}
 	}
 }
@@ -47,7 +47,7 @@
 
 .🥝DropdownMenuCheckmark {
 	@layer base {
-		visibility: var(--🥝dropdown-menu-checkmark-visibility);
+		visibility: var(--🥝DropdownMenuCheckmark-visibility);
 	}
 }
 

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -116,7 +116,7 @@ const DropdownMenuContent = forwardRef<"div", DropdownMenuContentProps>(
 				gutter={4}
 				style={{ ...popoverProps.style, ...props.style }}
 				wrapperProps={{ popover: popoverProps.popover }}
-				className={cx("🥝-dropdown-menu", props.className)}
+				className={cx("🥝DropdownMenu", props.className)}
 				ref={forwardedRef}
 			/>
 		);
@@ -163,7 +163,7 @@ const DropdownMenuButton = forwardRef<"button", DropdownMenuButtonProps>(
 						</Button>
 					)
 				}
-				className={cx("🥝-dropdown-menu-button", props.className)}
+				className={cx("🥝DropdownMenuButton", props.className)}
 				data-has-popover-open={open || undefined}
 				ref={forwardedRef}
 			/>
@@ -212,7 +212,7 @@ const DropdownMenuItem = forwardRef<"button", DropdownMenuItemProps>(
 								accessibleWhenDisabled
 								aria-describedby={dotId}
 								{...rest}
-								className={cx("🥝-dropdown-menu-item", props.className)}
+								className={cx("🥝DropdownMenuItem", props.className)}
 								ref={forwardedRef}
 							/>
 						}
@@ -225,7 +225,7 @@ const DropdownMenuItem = forwardRef<"button", DropdownMenuItemProps>(
 				{unstable_dot ? (
 					<ListItem.Decoration
 						render={
-							<Dot id={dotId} className="🥝-dropdown-menu-item-dot">
+							<Dot id={dotId} className="🥝DropdownMenuItemDot">
 								{unstable_dot}
 							</Dot>
 						}
@@ -275,7 +275,7 @@ const DropdownMenuItemShortcuts = forwardRef<
 		<ListItem.Decoration
 			render={<span />}
 			{...rest}
-			className={cx("🥝-dropdown-menu-item-shortcuts", props.className)}
+			className={cx("🥝DropdownMenuItemShortcuts", props.className)}
 			ref={forwardedRef}
 		>
 			{shortcutKeys.map(({ key, isSymbol }, index) => {
@@ -380,7 +380,7 @@ const DropdownMenuCheckboxItem = forwardRef<
 						<ButtonAk
 							accessibleWhenDisabled
 							{...rest}
-							className={cx("🥝-dropdown-menu-item", props.className)}
+							className={cx("🥝DropdownMenuItem", props.className)}
 							ref={forwardedRef}
 						/>
 					}
@@ -390,7 +390,7 @@ const DropdownMenuCheckboxItem = forwardRef<
 			{icon ? <DropdownMenuIcon icon={icon} /> : null}
 			<ListItem.Content render={<span />}>{label}</ListItem.Content>
 			<ListItem.Decoration
-				render={<Checkmark className="🥝-dropdown-menu-checkmark" />}
+				render={<Checkmark className="🥝DropdownMenuCheckmark" />}
 			/>
 		</MenuItemCheckbox>
 	);

--- a/packages/structures/src/ErrorRegion.css
+++ b/packages/structures/src/ErrorRegion.css
@@ -11,19 +11,19 @@
 	}
 
 	@layer states {
-		&:where([data-kiwi-expanded="true"]) {
+		&:where([data-_sk-expanded="true"]) {
 			--🥝ChevronDown-rotate: -0.5turn;
 			--🥝ErrorRegionHeader-border-end-radius: 0;
 		}
 
-		&:where([data-kiwi-visible="true"]) {
+		&:where([data-_sk-visible="true"]) {
 			padding-inline: var(--✨padding);
 			padding-block: var(--✨padding);
 
 			block-size: 2.625rem;
 		}
 
-		&:where([data-kiwi-visible="false"]) {
+		&:where([data-_sk-visible="false"]) {
 			--🥝ErrorRegionContainer-display: none;
 		}
 	}

--- a/packages/structures/src/ErrorRegion.css
+++ b/packages/structures/src/ErrorRegion.css
@@ -12,8 +12,8 @@
 
 	@layer states {
 		&:where([data-kiwi-expanded="true"]) {
-			--🥝chevron-down-rotate: -0.5turn;
-			--🥝error-region-header-border-end-radius: 0;
+			--🥝ChevronDown-rotate: -0.5turn;
+			--🥝ErrorRegionHeader-border-end-radius: 0;
 		}
 
 		&:where([data-kiwi-visible="true"]) {
@@ -24,7 +24,7 @@
 		}
 
 		&:where([data-kiwi-visible="false"]) {
-			--🥝error-region-container-display: none;
+			--🥝ErrorRegionContainer-display: none;
 		}
 	}
 }
@@ -34,7 +34,7 @@
 		isolation: isolate;
 
 		position: relative;
-		display: var(--🥝error-region-container-display, flex);
+		display: var(--🥝ErrorRegionContainer-display, flex);
 		flex-direction: column;
 
 		border: 1px solid var(--stratakit-color-border-attention-base);
@@ -67,15 +67,15 @@
 		font-weight: 400;
 		border-start-start-radius: var(--✨border-radius);
 		border-start-end-radius: var(--✨border-radius);
-		border-end-start-radius: var(--🥝error-region-header-border-end-radius, var(--✨border-radius));
-		border-end-end-radius: var(--🥝error-region-header-border-end-radius, var(--✨border-radius));
+		border-end-start-radius: var(--🥝ErrorRegionHeader-border-end-radius, var(--✨border-radius));
+		border-end-end-radius: var(--🥝ErrorRegionHeader-border-end-radius, var(--✨border-radius));
 		transition: border-radius 0s linear 150ms; /* Delay border-radius to match dialog transition. */
 	}
 }
 
 .🥝ErrorRegionIcon {
 	@layer base {
-		--🥝icon-color: var(--stratakit-color-icon-attention-base);
+		--🥝Icon-color: var(--stratakit-color-icon-attention-base);
 	}
 }
 

--- a/packages/structures/src/ErrorRegion.css
+++ b/packages/structures/src/ErrorRegion.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-error-region {
+.🥝ErrorRegion {
 	--✨padding: var(--stratakit-space-x1);
 
 	@layer base {
@@ -29,7 +29,7 @@
 	}
 }
 
-.🥝-error-region-container {
+.🥝ErrorRegionContainer {
 	@layer base {
 		isolation: isolate;
 
@@ -54,7 +54,7 @@
 	}
 }
 
-.🥝-error-region-header {
+.🥝ErrorRegionHeader {
 	--✨container-border-radius: 8px;
 	--✨container-border-width: 1px;
 	--✨border-radius: calc(var(--✨container-border-radius) - var(--✨container-border-width));
@@ -73,13 +73,13 @@
 	}
 }
 
-.🥝-error-region-icon {
+.🥝ErrorRegionIcon {
 	@layer base {
 		--🥝icon-color: var(--stratakit-color-icon-attention-base);
 	}
 }
 
-.🥝-error-region-label {
+.🥝ErrorRegionLabel {
 	@layer base {
 		flex: 1;
 		text-align: start;
@@ -88,7 +88,7 @@
 	}
 }
 
-.🥝-error-region-dialog {
+.🥝ErrorRegionDialog {
 	--✨container-max-size: 350px;
 	--✨container-border-size: 2px;
 	--✨header-size: 2rem;
@@ -126,7 +126,7 @@
 	}
 }
 
-.🥝-error-region-items {
+.🥝ErrorRegionItems {
 	--✨container-max-size: 350px;
 	--✨container-border-size: 2px;
 	--✨header-size: 2rem;
@@ -143,7 +143,7 @@
 	}
 }
 
-.🥝-error-region-item {
+.🥝ErrorRegionItem {
 	--✨container-padding: var(--stratakit-space-x2);
 	--✨icon-size: 1rem;
 	--✨gap: var(--stratakit-space-x1);
@@ -164,7 +164,7 @@
 	}
 }
 
-.🥝-error-region-item-actions {
+.🥝ErrorRegionItemActions {
 	@layer base {
 		margin-block-start: var(--stratakit-space-x2);
 	}

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -98,7 +98,7 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 			const el = containerRef.current;
 			if (!el) return;
 
-			const id = "--🥝error-region-pulse";
+			const id = "--🥝ErrorRegion-pulse";
 			const animations = el.getAnimations({ subtree: true });
 			if (animations.find((animation) => animation.id === id)) return;
 

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -153,21 +153,21 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 					<Role.section
 						{...rest}
 						aria-labelledby={sectionLabelledBy}
-						className={cx("🥝-error-region", props.className)}
+						className={cx("🥝ErrorRegion", props.className)}
 						data-kiwi-visible={!!label}
 						data-kiwi-expanded={open}
 						ref={forwardedRef}
 					>
-						<div className="🥝-error-region-container" ref={containerRef}>
+						<div className="🥝ErrorRegionContainer" ref={containerRef}>
 							<DialogDisclosure
-								className="🥝-error-region-header"
+								className="🥝ErrorRegionHeader"
 								render={<Button variant="ghost" />}
 							>
-								<StatusIcon tone="attention" className="🥝-error-region-icon" />
+								<StatusIcon tone="attention" className="🥝ErrorRegionIcon" />
 								<Text
 									render={<span />}
 									id={labelId}
-									className="🥝-error-region-label"
+									className="🥝ErrorRegionLabel"
 									variant="body-sm"
 								>
 									{label}
@@ -177,7 +177,7 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 								</IconButtonPresentation>
 							</DialogDisclosure>
 							<Dialog
-								className="🥝-error-region-dialog"
+								className="🥝ErrorRegionDialog"
 								portal={false}
 								modal={false}
 								autoFocusOnShow={false}
@@ -185,7 +185,7 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 							>
 								<Collection
 									store={store}
-									className="🥝-error-region-items"
+									className="🥝ErrorRegionItems"
 									role="list"
 								>
 									{items}
@@ -252,13 +252,13 @@ const ErrorRegionItem = forwardRef<"div", ErrorRegionItemProps>(
 			<CollectionItem
 				{...rest}
 				role="listitem"
-				className={cx("🥝-error-region-item", props.className)}
+				className={cx("🥝ErrorRegionItem", props.className)}
 				ref={forwardedRef}
 			>
 				<Text id={messageId} variant="body-sm">
 					{message}
 				</Text>
-				<div className="🥝-error-region-item-actions">{actions}</div>
+				<div className="🥝ErrorRegionItemActions">{actions}</div>
 			</CollectionItem>
 		);
 	},

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -154,8 +154,8 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 						{...rest}
 						aria-labelledby={sectionLabelledBy}
 						className={cx("🥝ErrorRegion", props.className)}
-						data-kiwi-visible={!!label}
-						data-kiwi-expanded={open}
+						data-_sk-visible={!!label}
+						data-_sk-expanded={open}
 						ref={forwardedRef}
 					>
 						<div className="🥝ErrorRegionContainer" ref={containerRef}>

--- a/packages/structures/src/Table.css
+++ b/packages/structures/src/Table.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-table {
+.🥝Table {
 	@layer base {
 		&:where(table) {
 			table-layout: fixed;
@@ -14,13 +14,13 @@
 	}
 }
 
-.🥝-table-header {
+.🥝TableHeader {
 	@layer base {
 		color: var(--stratakit-color-text-neutral-secondary);
 	}
 }
 
-.🥝-table-row {
+.🥝TableRow {
 	@layer base {
 		&:where([role="row"]) {
 			display: flex;
@@ -28,8 +28,8 @@
 	}
 }
 
-.🥝-table-caption,
-.🥝-table-cell {
+.🥝TableCaption,
+.🥝TableCell {
 	--✨cell-padding-block: var(--stratakit-space-x2);
 	--✨cell-padding-inline-start: var(--stratakit-space-x4);
 	--✨cell-padding-inline-end: var(--stratakit-space-x3);
@@ -50,7 +50,7 @@
 	}
 }
 
-.🥝-table-cell {
+.🥝TableCell {
 	--✨glow--bg-hover: var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%);
 	--✨glow--bg-active-hover: var(--stratakit-color-glow-hue)
 		var(--stratakit-color-bg-glow-strong-hover-\%);
@@ -114,7 +114,7 @@
 			}
 
 			&:where([role="cell"], td) {
-				:where(.🥝-table-row:hover) & {
+				:where(.🥝TableRow:hover) & {
 					--🌀table-cell-state: var(--🌀table-cell-state--hover);
 				}
 			}
@@ -122,7 +122,7 @@
 
 		&:where([role="cell"], td) {
 			:where(
-					.🥝-table-row:has(input[type="checkbox"]:checked, [role="checkbox"][aria-checked="true"])
+					.🥝TableRow:has(input[type="checkbox"]:checked, [role="checkbox"][aria-checked="true"])
 				)
 				& {
 				--🌀table-cell-state: var(--🌀table-cell-state--active);
@@ -132,7 +132,7 @@
 		@media (any-hover: hover) {
 			&:where([role="cell"], td) {
 				:where(
-						.🥝-table-row:hover:has(
+						.🥝TableRow:hover:has(
 								input[type="checkbox"]:checked,
 								[role="checkbox"][aria-checked="true"]
 							)

--- a/packages/structures/src/Table.css
+++ b/packages/structures/src/Table.css
@@ -68,17 +68,17 @@
 
 	@layer base {
 		min-inline-size: 4rem;
-		background-color: var(--🌀table-cell-state--default, var(--✨cell-bg--default))
-			var(--🌀table-cell-state--hover, var(--✨cell-bg--hover))
-			var(--🌀table-cell-state--active, var(--✨cell-bg--active))
-			var(--🌀table-cell-state--active-hover, var(--✨cell-bg--active-hover));
+		background-color: var(--🌀TableCell-state--default, var(--✨cell-bg--default))
+			var(--🌀TableCell-state--hover, var(--✨cell-bg--hover))
+			var(--🌀TableCell-state--active, var(--✨cell-bg--active))
+			var(--🌀TableCell-state--active-hover, var(--✨cell-bg--active-hover));
 
-		--🥝table-cell-border-color--active: var(--✨cell-border--active);
+		--🥝TableCell-border-color--active: var(--✨cell-border--active);
 		border-block-end: var(--✨cell-border-width) solid
-			var(--🌀table-cell-state--default, var(--✨cell-border--default))
-			var(--🌀table-cell-state--hover, var(--✨cell-border--default))
-			var(--🌀table-cell-state--active, var(--🥝table-cell-border-color--active))
-			var(--🌀table-cell-state--active-hover, var(--🥝table-cell-border-color--active));
+			var(--🌀TableCell-state--default, var(--✨cell-border--default))
+			var(--🌀TableCell-state--hover, var(--✨cell-border--default))
+			var(--🌀TableCell-state--active, var(--🥝TableCell-border-color--active))
+			var(--🌀TableCell-state--active-hover, var(--🥝TableCell-border-color--active));
 
 		/* Would be great to remove. Needed by ::before pseudo-element to support row selection visuals. */
 		position: relative;
@@ -100,22 +100,21 @@
 			inset: calc(-1 * var(--✨cell-border-width)) 0 0 0;
 			pointer-events: none;
 			border-block-start: var(--✨cell-border-width) solid
-				var(--🌀table-cell-state--default, transparent)
-				var(--🌀table-cell-state--hover, transparent)
-				var(--🌀table-cell-state--active, var(--🥝table-cell-border-color--active))
-				var(--🌀table-cell-state--active-hover, var(--🥝table-cell-border-color--active));
+				var(--🌀TableCell-state--default, transparent) var(--🌀TableCell-state--hover, transparent)
+				var(--🌀TableCell-state--active, var(--🥝TableCell-border-color--active))
+				var(--🌀TableCell-state--active-hover, var(--🥝TableCell-border-color--active));
 		}
 	}
 
 	@layer states {
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀table-cell-state: var(--🌀table-cell-state--hover);
+				--🌀TableCell-state: var(--🌀TableCell-state--hover);
 			}
 
 			&:where([role="cell"], td) {
 				:where(.🥝TableRow:hover) & {
-					--🌀table-cell-state: var(--🌀table-cell-state--hover);
+					--🌀TableCell-state: var(--🌀TableCell-state--hover);
 				}
 			}
 		}
@@ -125,7 +124,7 @@
 					.🥝TableRow:has(input[type="checkbox"]:checked, [role="checkbox"][aria-checked="true"])
 				)
 				& {
-				--🌀table-cell-state: var(--🌀table-cell-state--active);
+				--🌀TableCell-state: var(--🌀TableCell-state--active);
 			}
 		}
 
@@ -138,7 +137,7 @@
 							)
 					)
 					& {
-					--🌀table-cell-state: var(--🌀table-cell-state--active-hover);
+					--🌀TableCell-state: var(--🌀TableCell-state--active-hover);
 				}
 			}
 		}
@@ -146,10 +145,10 @@
 
 	@layer base.🌀 {
 		/* Cyclic toggles for default/hover states. See https://kizu.dev/cyclic-toggles/ */
-		--🌀table-cell-state: var(--🌀table-cell-state--default);
-		--🌀table-cell-state--default: var(--🌀table-cell-state,);
-		--🌀table-cell-state--hover: var(--🌀table-cell-state,);
-		--🌀table-cell-state--active: var(--🌀table-cell-state,);
-		--🌀table-cell-state--active-hover: var(--🌀table-cell-state,);
+		--🌀TableCell-state: var(--🌀TableCell-state--default);
+		--🌀TableCell-state--default: var(--🌀TableCell-state,);
+		--🌀TableCell-state--hover: var(--🌀TableCell-state,);
+		--🌀TableCell-state--active: var(--🌀TableCell-state,);
+		--🌀TableCell-state--active-hover: var(--🌀TableCell-state,);
 	}
 }

--- a/packages/structures/src/Table.tsx
+++ b/packages/structures/src/Table.tsx
@@ -77,7 +77,7 @@ const HtmlTable = forwardRef<"table", HtmlTableProps>((props, forwardedRef) => {
 				render={<table />}
 				{...props}
 				ref={forwardedRef}
-				className={cx("🥝-table", props.className)}
+				className={cx("🥝Table", props.className)}
 			/>
 		</TableContext.Provider>
 	);
@@ -140,7 +140,7 @@ const CustomTable = forwardRef<"div", CustomTableProps>(
 					aria-labelledby={captionId}
 					{...props}
 					ref={forwardedRef}
-					className={cx("🥝-table", props.className)}
+					className={cx("🥝Table", props.className)}
 				/>
 			</TableContext.Provider>
 		);
@@ -183,7 +183,7 @@ const TableHeader = forwardRef<"div", TableHeaderProps>(
 					role={role}
 					{...props}
 					ref={forwardedRef}
-					className={cx("🥝-table-header", props.className)}
+					className={cx("🥝TableHeader", props.className)}
 				/>
 			</TableHeaderContext.Provider>
 		);
@@ -227,7 +227,7 @@ const TableBody = forwardRef<"div", TableBodyProps>((props, forwardedRef) => {
 			role={undefined} // Intentionally not using "rowgroup" https://github.com/iTwin/design-system/pull/243#discussion_r1947045668
 			{...props}
 			ref={forwardedRef}
-			className={cx("🥝-table-body", props.className)}
+			className={cx("🥝TableBody", props.className)}
 		/>
 	);
 });
@@ -275,7 +275,7 @@ const TableRow = forwardRef<"div", TableRowProps>((props, forwardedRef) => {
 			role={role}
 			{...props}
 			ref={forwardedRef}
-			className={cx("🥝-table-row", props.className)}
+			className={cx("🥝TableRow", props.className)}
 		/>
 	);
 });
@@ -321,7 +321,7 @@ const TableCaption = forwardRef<"div", TableCaptionProps>(
 				{...rest}
 				id={id}
 				ref={useMergedRefs(forwardedRef, captionIdRef)}
-				className={cx("🥝-table-caption", props.className)}
+				className={cx("🥝TableCaption", props.className)}
 			/>
 		);
 	},
@@ -362,7 +362,7 @@ const TableCell = forwardRef<"div", TableCellProps>((props, forwardedRef) => {
 			role={role}
 			{...props}
 			ref={forwardedRef}
-			className={cx("🥝-table-cell", props.className)}
+			className={cx("🥝TableCell", props.className)}
 		/>
 	);
 });

--- a/packages/structures/src/Tabs.css
+++ b/packages/structures/src/Tabs.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝-tab-list {
+.🥝TabList {
 	@layer base {
 		--🥝tab-active-stripe-gap: var(--stratakit-space-x2);
 		--🥝tab-active-stripe-size: var(--stratakit-space-x05);
@@ -43,7 +43,7 @@
 	}
 }
 
-.🥝-tab {
+.🥝Tab {
 	--✨height: 1.25rem;
 	--✨gap: var(--stratakit-space-x1);
 
@@ -90,7 +90,7 @@
 	}
 
 	@layer modifiers {
-		:where(.🥝-tab-list[data-kiwi-tone="neutral"]) & {
+		:where(.🥝TabList[data-kiwi-tone="neutral"]) & {
 			--🥝tab-background-color: var(--🌀tab-state--default, var(--✨bg--default))
 				var(--🌀tab-state--hover, var(--✨bg--hover-neutral))
 				var(--🌀tab-state--selected, var(--✨bg--selected))
@@ -102,7 +102,7 @@
 			-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-neutral-pressed);
 		}
 
-		:where(.🥝-tab-list[data-kiwi-tone="accent"]) & {
+		:where(.🥝TabList[data-kiwi-tone="accent"]) & {
 			--🥝tab-background-color: var(--🌀tab-state--default, var(--✨bg--default))
 				var(--🌀tab-state--hover, var(--✨bg--hover-accent))
 				var(--🌀tab-state--selected, var(--✨bg--selected))
@@ -157,7 +157,7 @@
 	}
 }
 
-.🥝-tab-panel {
+.🥝TabPanel {
 	@layer base {
 		--🥝focus-outline-offset: calc(var(--stratakit-space-x05) * -1);
 
@@ -169,12 +169,12 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-tab-list,
-	.🥝-tab {
+	.🥝TabList,
+	.🥝Tab {
 		--🥝tab-active-stripe-color: CanvasText;
 	}
 
-	.🥝-tab {
+	.🥝Tab {
 		--🥝tab-color: CanvasText;
 
 		&:where([aria-selected="true"]) {

--- a/packages/structures/src/Tabs.css
+++ b/packages/structures/src/Tabs.css
@@ -33,11 +33,11 @@
 			padding-block-end: var(--🥝Tab-active-stripe-gap);
 		}
 
-		&:where([data-kiwi-tone="neutral"]) {
+		&:where([data-_sk-tone="neutral"]) {
 			--🥝Tab-active-stripe-color: var(--stratakit-color-border-neutral-inverse);
 		}
 
-		&:where([data-kiwi-tone="accent"]) {
+		&:where([data-_sk-tone="accent"]) {
 			--🥝Tab-active-stripe-color: var(--stratakit-color-border-accent-strong);
 		}
 	}
@@ -90,7 +90,7 @@
 	}
 
 	@layer modifiers {
-		:where(.🥝TabList[data-kiwi-tone="neutral"]) & {
+		:where(.🥝TabList[data-_sk-tone="neutral"]) & {
 			--🥝Tab-background-color: var(--🌀Tab-state--default, var(--✨bg--default))
 				var(--🌀Tab-state--hover, var(--✨bg--hover-neutral))
 				var(--🌀Tab-state--selected, var(--✨bg--selected))
@@ -102,7 +102,7 @@
 			-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-neutral-pressed);
 		}
 
-		:where(.🥝TabList[data-kiwi-tone="accent"]) & {
+		:where(.🥝TabList[data-_sk-tone="accent"]) & {
 			--🥝Tab-background-color: var(--🌀Tab-state--default, var(--✨bg--default))
 				var(--🌀Tab-state--hover, var(--✨bg--hover-accent))
 				var(--🌀Tab-state--selected, var(--✨bg--selected))

--- a/packages/structures/src/Tabs.css
+++ b/packages/structures/src/Tabs.css
@@ -5,9 +5,9 @@
 
 .🥝TabList {
 	@layer base {
-		--🥝tab-active-stripe-gap: var(--stratakit-space-x2);
-		--🥝tab-active-stripe-size: var(--stratakit-space-x05);
-		--🥝tab-padding-inline: var(--stratakit-space-x1);
+		--🥝Tab-active-stripe-gap: var(--stratakit-space-x2);
+		--🥝Tab-active-stripe-size: var(--stratakit-space-x05);
+		--🥝Tab-padding-inline: var(--stratakit-space-x1);
 
 		display: flex;
 		gap: var(--stratakit-space-x2);
@@ -17,12 +17,12 @@
 			&::after {
 				content: "";
 				position: absolute;
-				position-anchor: --🥝active-tab;
-				inset-inline-start: calc(anchor(start) + var(--🥝tab-padding-inline));
-				inset-block-end: calc(anchor(end) - var(--🥝tab-active-stripe-gap));
-				inline-size: calc(anchor-size(inline) - 2 * var(--🥝tab-padding-inline));
-				block-size: var(--🥝tab-active-stripe-size);
-				background-color: var(--🥝tab-active-stripe-color);
+				position-anchor: --🥝Tab-active-tab;
+				inset-inline-start: calc(anchor(start) + var(--🥝Tab-padding-inline));
+				inset-block-end: calc(anchor(end) - var(--🥝Tab-active-stripe-gap));
+				inline-size: calc(anchor-size(inline) - 2 * var(--🥝Tab-padding-inline));
+				block-size: var(--🥝Tab-active-stripe-size);
+				background-color: var(--🥝Tab-active-stripe-color);
 				will-change: transform;
 			}
 		}
@@ -30,15 +30,15 @@
 
 	@layer modifiers {
 		&[aria-orientation="horizontal"] {
-			padding-block-end: var(--🥝tab-active-stripe-gap);
+			padding-block-end: var(--🥝Tab-active-stripe-gap);
 		}
 
 		&:where([data-kiwi-tone="neutral"]) {
-			--🥝tab-active-stripe-color: var(--stratakit-color-border-neutral-inverse);
+			--🥝Tab-active-stripe-color: var(--stratakit-color-border-neutral-inverse);
 		}
 
 		&:where([data-kiwi-tone="accent"]) {
-			--🥝tab-active-stripe-color: var(--stratakit-color-border-accent-strong);
+			--🥝Tab-active-stripe-color: var(--stratakit-color-border-accent-strong);
 		}
 	}
 }
@@ -62,12 +62,12 @@
 
 	@layer base {
 		font-size: var(--stratakit-font-size-12);
-		color: var(--🥝tab-color);
-		background-color: var(--🥝tab-background-color);
+		color: var(--🥝Tab-color);
+		background-color: var(--🥝Tab-background-color);
 		border: none;
 		border-radius: 4px;
 		block-size: var(--✨height);
-		padding-inline: var(--🥝tab-padding-inline);
+		padding-inline: var(--🥝Tab-padding-inline);
 		position: relative;
 		user-select: none;
 		white-space: nowrap;
@@ -85,63 +85,63 @@
 			content: "";
 			position: absolute;
 			inset-inline: 0;
-			inset-block: 0 calc(var(--🥝tab-active-stripe-gap) * -1);
+			inset-block: 0 calc(var(--🥝Tab-active-stripe-gap) * -1);
 		}
 	}
 
 	@layer modifiers {
 		:where(.🥝TabList[data-kiwi-tone="neutral"]) & {
-			--🥝tab-background-color: var(--🌀tab-state--default, var(--✨bg--default))
-				var(--🌀tab-state--hover, var(--✨bg--hover-neutral))
-				var(--🌀tab-state--selected, var(--✨bg--selected))
-				var(--🌀tab-state--disabled, var(--✨bg--disabled));
-			--🥝tab-color: var(--🌀tab-state--default, var(--✨color--default))
-				var(--🌀tab-state--hover, var(--✨color--hover-neutral))
-				var(--🌀tab-state--selected, var(--✨color--selected-neutral))
-				var(--🌀tab-state--disabled, var(--✨color--disabled));
+			--🥝Tab-background-color: var(--🌀Tab-state--default, var(--✨bg--default))
+				var(--🌀Tab-state--hover, var(--✨bg--hover-neutral))
+				var(--🌀Tab-state--selected, var(--✨bg--selected))
+				var(--🌀Tab-state--disabled, var(--✨bg--disabled));
+			--🥝Tab-color: var(--🌀Tab-state--default, var(--✨color--default))
+				var(--🌀Tab-state--hover, var(--✨color--hover-neutral))
+				var(--🌀Tab-state--selected, var(--✨color--selected-neutral))
+				var(--🌀Tab-state--disabled, var(--✨color--disabled));
 			-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-neutral-pressed);
 		}
 
 		:where(.🥝TabList[data-kiwi-tone="accent"]) & {
-			--🥝tab-background-color: var(--🌀tab-state--default, var(--✨bg--default))
-				var(--🌀tab-state--hover, var(--✨bg--hover-accent))
-				var(--🌀tab-state--selected, var(--✨bg--selected))
-				var(--🌀tab-state--disabled, var(--✨bg--disabled));
-			--🥝tab-color: var(--🌀tab-state--default, var(--✨color--default))
-				var(--🌀tab-state--hover, var(--✨color--hover-accent))
-				var(--🌀tab-state--selected, var(--✨color--selected-accent))
-				var(--🌀tab-state--disabled, var(--✨color--disabled));
+			--🥝Tab-background-color: var(--🌀Tab-state--default, var(--✨bg--default))
+				var(--🌀Tab-state--hover, var(--✨bg--hover-accent))
+				var(--🌀Tab-state--selected, var(--✨bg--selected))
+				var(--🌀Tab-state--disabled, var(--✨bg--disabled));
+			--🥝Tab-color: var(--🌀Tab-state--default, var(--✨color--default))
+				var(--🌀Tab-state--hover, var(--✨color--hover-accent))
+				var(--🌀Tab-state--selected, var(--✨color--selected-accent))
+				var(--🌀Tab-state--disabled, var(--✨color--disabled));
 			-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 		}
 	}
 
 	@layer states {
 		&:where([aria-selected="true"]) {
-			--🌀tab-state: var(--🌀tab-state--selected);
+			--🌀Tab-state: var(--🌀Tab-state--selected);
 
-			anchor-name: --🥝active-tab;
+			anchor-name: --🥝Tab-active-tab;
 
 			@supports not (anchor-name: --foo) {
 				&::after {
 					content: "";
 					position: absolute;
-					background-color: var(--🥝tab-active-stripe-color);
-					block-size: var(--🥝tab-active-stripe-size);
-					inset-inline: var(--🥝tab-padding-inline);
-					inset-block: auto calc(var(--🥝tab-active-stripe-gap) * -1);
+					background-color: var(--🥝Tab-active-stripe-color);
+					block-size: var(--🥝Tab-active-stripe-size);
+					inset-inline: var(--🥝Tab-padding-inline);
+					inset-block: auto calc(var(--🥝Tab-active-stripe-gap) * -1);
 				}
 			}
 		}
 
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀tab-state: var(--🌀tab-state--hover);
+				--🌀Tab-state: var(--🌀Tab-state--hover);
 			}
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {
-			--🌀tab-state: var(--🌀tab-state--disabled);
-			--🥝tab-active-stripe-color: var(--stratakit-color-border-neutral-disabled);
+			--🌀Tab-state: var(--🌀Tab-state--disabled);
+			--🥝Tab-active-stripe-color: var(--stratakit-color-border-neutral-disabled);
 			cursor: not-allowed;
 			-webkit-tap-highlight-color: transparent;
 		}
@@ -149,11 +149,11 @@
 
 	@layer base.🌀 {
 		/* Cyclic toggles for default/hover/selected/disabled states. See https://kizu.dev/cyclic-toggles/ */
-		--🌀tab-state: var(--🌀tab-state--default);
-		--🌀tab-state--default: var(--🌀tab-state,);
-		--🌀tab-state--hover: var(--🌀tab-state,);
-		--🌀tab-state--selected: var(--🌀tab-state,);
-		--🌀tab-state--disabled: var(--🌀tab-state,);
+		--🌀Tab-state: var(--🌀Tab-state--default);
+		--🌀Tab-state--default: var(--🌀Tab-state,);
+		--🌀Tab-state--hover: var(--🌀Tab-state,);
+		--🌀Tab-state--selected: var(--🌀Tab-state,);
+		--🌀Tab-state--disabled: var(--🌀Tab-state,);
 	}
 }
 
@@ -171,20 +171,20 @@
 @media (forced-colors: active) {
 	.🥝TabList,
 	.🥝Tab {
-		--🥝tab-active-stripe-color: CanvasText;
+		--🥝Tab-active-stripe-color: CanvasText;
 	}
 
 	.🥝Tab {
-		--🥝tab-color: CanvasText;
+		--🥝Tab-color: CanvasText;
 
 		&:where([aria-selected="true"]) {
 			forced-color-adjust: none;
-			--🥝tab-background-color: SelectedItem;
-			--🥝tab-color: SelectedItemText;
+			--🥝Tab-background-color: SelectedItem;
+			--🥝Tab-color: SelectedItemText;
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {
-			--🥝tab-color: GrayText;
+			--🥝Tab-color: GrayText;
 		}
 	}
 }

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -158,7 +158,7 @@ const TabList = forwardRef<"div", TabListProps>((props, forwardedRef) => {
 		<AkTab.TabList
 			{...rest}
 			data-kiwi-tone={tone}
-			className={cx("🥝-tab-list", props.className)}
+			className={cx("🥝TabList", props.className)}
 			ref={forwardedRef}
 		/>
 	);
@@ -203,7 +203,7 @@ const Tab = forwardRef<"button", TabProps>((props, forwardedRef) => {
 		<AkTab.Tab
 			accessibleWhenDisabled
 			{...props}
-			className={cx("🥝-tab", props.className)}
+			className={cx("🥝Tab", props.className)}
 			ref={forwardedRef}
 		/>
 	);
@@ -230,7 +230,7 @@ const TabPanel = forwardRef<"div", TabPanelProps>((props, forwardedRef) => {
 	return (
 		<AkTab.TabPanel
 			{...props}
-			className={cx("🥝-tab-panel", props.className)}
+			className={cx("🥝TabPanel", props.className)}
 			ref={forwardedRef}
 		/>
 	);

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -157,7 +157,7 @@ const TabList = forwardRef<"div", TabListProps>((props, forwardedRef) => {
 	return (
 		<AkTab.TabList
 			{...rest}
-			data-kiwi-tone={tone}
+			data-_sk-tone={tone}
 			className={cx("🥝TabList", props.className)}
 			ref={forwardedRef}
 		/>

--- a/packages/structures/src/Toolbar.css
+++ b/packages/structures/src/Toolbar.css
@@ -26,7 +26,7 @@
 
 .🥝ToolbarItem:is(.🥝IconButton) {
 	@layer modifiers {
-		&:where([data-kiwi-variant="ghost"]) {
+		&:where([data-_sk-variant="ghost"]) {
 			--🥝Button-background-color: var(--🌀Button-state--default, transparent)
 				var(--🌀Button-state--hover, var(--stratakit-color-bg-glow-on-surface-neutral-hover))
 				var(--🌀Button-state--pressed, var(--stratakit-color-bg-glow-on-surface-neutral-pressed))

--- a/packages/structures/src/Toolbar.css
+++ b/packages/structures/src/Toolbar.css
@@ -13,8 +13,8 @@
 		border-radius: 8px;
 		padding: var(--stratakit-space-x1);
 
-		--🥝divider-main-axis-margin: var(--stratakit-space-x2);
-		--🥝divider-cross-axis-margin: var(--stratakit-space-x1);
+		--🥝Divider-main-axis-margin: var(--stratakit-space-x2);
+		--🥝Divider-cross-axis-margin: var(--stratakit-space-x1);
 	}
 
 	@layer modifiers {
@@ -27,19 +27,19 @@
 .🥝ToolbarItem:is(.🥝IconButton) {
 	@layer modifiers {
 		&:where([data-kiwi-variant="ghost"]) {
-			--🥝button-background-color: var(--🌀button-state--default, transparent)
-				var(--🌀button-state--hover, var(--stratakit-color-bg-glow-on-surface-neutral-hover))
-				var(--🌀button-state--pressed, var(--stratakit-color-bg-glow-on-surface-neutral-pressed))
-				var(--🌀button-state--active, var(--stratakit-color-bg-accent-base))
-				var(--🌀button-state--disabled, var(--stratakit-color-bg-glow-on-surface-disabled));
-			--🥝icon-color: var(--🌀button-state--default, var(--stratakit-color-icon-neutral-base))
-				var(--🌀button-state--hover, var(--stratakit-color-icon-neutral-hover))
-				var(--🌀button-state--pressed, var(--stratakit-color-icon-neutral-hover))
-				var(--🌀button-state--active, var(--stratakit-color-icon-neutral-emphasis));
-			--🥝button-border-color: var(--🌀button-state--default, transparent)
-				var(--🌀button-state--hover, transparent) var(--🌀button-state--pressed, transparent)
-				var(--🌀button-state--active, var(--stratakit-color-border-accent-base))
-				var(--🌀button-state--disabled, transparent);
+			--🥝Button-background-color: var(--🌀Button-state--default, transparent)
+				var(--🌀Button-state--hover, var(--stratakit-color-bg-glow-on-surface-neutral-hover))
+				var(--🌀Button-state--pressed, var(--stratakit-color-bg-glow-on-surface-neutral-pressed))
+				var(--🌀Button-state--active, var(--stratakit-color-bg-accent-base))
+				var(--🌀Button-state--disabled, var(--stratakit-color-bg-glow-on-surface-disabled));
+			--🥝Icon-color: var(--🌀Button-state--default, var(--stratakit-color-icon-neutral-base))
+				var(--🌀Button-state--hover, var(--stratakit-color-icon-neutral-hover))
+				var(--🌀Button-state--pressed, var(--stratakit-color-icon-neutral-hover))
+				var(--🌀Button-state--active, var(--stratakit-color-icon-neutral-emphasis));
+			--🥝Button-border-color: var(--🌀Button-state--default, transparent)
+				var(--🌀Button-state--hover, transparent) var(--🌀Button-state--pressed, transparent)
+				var(--🌀Button-state--active, var(--stratakit-color-border-accent-base))
+				var(--🌀Button-state--disabled, transparent);
 		}
 	}
 }

--- a/packages/structures/src/Toolbar.css
+++ b/packages/structures/src/Toolbar.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-toolbar {
+.🥝Toolbar {
 	@layer base {
 		display: inline-flex;
 		gap: var(--stratakit-space-x1);
@@ -24,7 +24,7 @@
 	}
 }
 
-.🥝-toolbar-item:is(.🥝-icon-button) {
+.🥝ToolbarItem:is(.🥝IconButton) {
 	@layer modifiers {
 		&:where([data-kiwi-variant="ghost"]) {
 			--🥝button-background-color: var(--🌀button-state--default, transparent)
@@ -45,7 +45,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-toolbar {
+	.🥝Toolbar {
 		border: 1px solid;
 	}
 }

--- a/packages/structures/src/Toolbar.tsx
+++ b/packages/structures/src/Toolbar.tsx
@@ -67,7 +67,7 @@ const ToolbarGroup = forwardRef<"div", ToolbarGroupProps>(
 				>
 					<Toolbar.Toolbar
 						{...props}
-						className={cx("🥝-toolbar", props.className)}
+						className={cx("🥝Toolbar", props.className)}
 						ref={forwardedRef}
 					/>
 				</TooltipContext.Provider>
@@ -101,7 +101,7 @@ const ToolbarItem = forwardRef<"button", ToolbarItemProps>(
 		return (
 			<Toolbar.ToolbarItem
 				{...props}
-				className={cx("🥝-toolbar-item", props.className)}
+				className={cx("🥝ToolbarItem", props.className)}
 				ref={forwardedRef}
 			/>
 		);

--- a/packages/structures/src/Tree.css
+++ b/packages/structures/src/Tree.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-tree {
+.🥝Tree {
 	@layer base {
 		display: grid;
 		align-content: start;

--- a/packages/structures/src/Tree.tsx
+++ b/packages/structures/src/Tree.tsx
@@ -39,7 +39,7 @@ const Tree = forwardRef<"div", TreeProps>((props, forwardedRef) => {
 			role="tree"
 			{...props}
 			render={<Composite store={composite} />}
-			className={cx("🥝-tree", props.className)}
+			className={cx("🥝Tree", props.className)}
 			ref={forwardedRef}
 		>
 			{props.children}

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -27,12 +27,12 @@
 		@media (any-hover: hover) {
 			&:where(:not(:hover, :focus-visible, :has(:focus-visible), :has([data-has-popover-open]))) {
 				/** Hide every action unless one of these conditions match. */
-				--🥝tree-item-action-visibility: hidden;
+				--🥝TreeItem-action-visibility: hidden;
 			}
 
 			/* Without :has, we can't easily detect complex conditions, so unconditionally show actions. */
 			@supports not selector(:has(+ *)) {
-				--🥝tree-item-action-visibility: visible;
+				--🥝TreeItem-action-visibility: visible;
 			}
 		}
 	}
@@ -49,37 +49,37 @@
 		padding-inline-start: calc(
 			var(--✨first-level-indent) +
 			var(--✨subsequent-level-indent) *
-			(var(--🥝tree-item-level) - 1)
+			(var(--🥝TreeItem-level) - 1)
 		);
 		padding-inline-end: 0;
 
-		--🥝list-item-color: var(--🥝tree-item-color);
+		--🥝ListItem-color: var(--🥝TreeItem-color);
 	}
 
 	@layer modifiers {
 		&:where([data-kiwi-error="true"]) {
-			--🥝icon-color: var(--stratakit-color-icon-attention-base);
-			--🥝tree-item-color: var(--stratakit-color-text-attention-base);
+			--🥝Icon-color: var(--stratakit-color-icon-attention-base);
+			--🥝TreeItem-color: var(--stratakit-color-text-attention-base);
 		}
 	}
 
 	@layer states {
 		&:where([data-kiwi-selected="true"]) {
-			--🌀list-item-state: var(--🌀list-item-state--active);
+			--🌀ListItem-state: var(--🌀ListItem-state--active);
 		}
 
 		@media (any-hover: hover) {
 			&:where(:hover[data-kiwi-selected="true"]) {
-				--🌀list-item-state: var(--🌀list-item-state--active-hover);
+				--🌀ListItem-state: var(--🌀ListItem-state--active-hover);
 			}
 		}
 
 		&:where([data-kiwi-expanded="false"]) {
-			--🥝chevron-down-rotate: -0.25turn;
+			--🥝ChevronDown-rotate: -0.25turn;
 		}
 
 		&:where(:not([data-kiwi-expanded])) {
-			--🥝tree-item-expander-visibility: hidden;
+			--🥝TreeItem-expander-visibility: hidden;
 		}
 	}
 }
@@ -93,8 +93,8 @@
 .🥝TreeItemDescription:is(.🥝ListItemContent) {
 	@layer base {
 		color: var(
-			--🥝tree-item-color,
-			var(--🌀list-item-state--default, var(--stratakit-color-text-neutral-secondary))
+			--🥝TreeItem-color,
+			var(--🌀ListItem-state--default, var(--stratakit-color-text-neutral-secondary))
 		);
 	}
 }
@@ -108,16 +108,13 @@
 		background-color: var(--stratakit-color-bg-page-base);
 		display: inline-flex;
 		/** If actions are made visible (by a parent), the actions container should also become visible. */
-		visibility: var(
-			--🥝tree-item-actions-container-visibility,
-			var(--🥝tree-item-action-visibility)
-		);
+		visibility: var(--🥝TreeItem-actions-container-visibility, var(--🥝TreeItem-action-visibility));
 
 		&::before {
 			position: absolute;
 			content: "";
 			inset: 0;
-			background-color: var(--🥝list-item-background-color);
+			background-color: var(--🥝ListItem-background-color);
 			z-index: -1;
 		}
 	}
@@ -125,31 +122,31 @@
 	@layer modifiers {
 		/* Actions container should be additionally made visible when any individual action is forcibly visible. */
 		&:where(:has(.🥝TreeItemAction[data-kiwi-visible="true"])) {
-			--🥝tree-item-actions-container-visibility: visible;
+			--🥝TreeItem-actions-container-visibility: visible;
 		}
 	}
 }
 
 .🥝TreeItemAction:is(.🥝IconButton) {
 	@layer base {
-		visibility: var(--🥝tree-item-action-visibility);
+		visibility: var(--🥝TreeItem-action-visibility);
 		transition: visibility 16ms; /* This allows some time focus to "settle" before determining final visibility. */
 	}
 
 	@layer modifiers {
 		&:where([data-kiwi-visible="false"]) {
-			--🥝tree-item-action-visibility: hidden;
+			--🥝TreeItem-action-visibility: hidden;
 		}
 
 		&:where([data-kiwi-visible="true"]) {
-			--🥝tree-item-action-visibility: visible;
+			--🥝TreeItem-action-visibility: visible;
 		}
 	}
 }
 
 .🥝TreeItemExpander:is(.🥝IconButton) {
 	@layer base {
-		visibility: var(--🥝tree-item-expander-visibility);
+		visibility: var(--🥝TreeItem-expander-visibility);
 		z-index: 1; /* Ensure the expander is above the invisible content button */
 	}
 }
@@ -164,8 +161,8 @@
 
 @media (forced-colors: active) {
 	.🥝TreeItemNode:is(.🥝ListItem) {
-		--🥝list-item-background-color: Canvas;
-		--🥝tree-item-color: CanvasText;
+		--🥝ListItem-background-color: Canvas;
+		--🥝TreeItem-color: CanvasText;
 
 		&:where([data-kiwi-error="true"], [data-kiwi-selected="true"]) {
 			forced-color-adjust: none;
@@ -180,8 +177,8 @@
 		}
 
 		&:where([data-kiwi-selected="true"]) {
-			--🥝list-item-background-color: SelectedItem;
-			--🥝tree-item-color: SelectedItemText;
+			--🥝ListItem-background-color: SelectedItem;
+			--🥝TreeItem-color: SelectedItemText;
 		}
 	}
 }

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -57,28 +57,28 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-error="true"]) {
+		&:where([data-_sk-error="true"]) {
 			--🥝Icon-color: var(--stratakit-color-icon-attention-base);
 			--🥝TreeItem-color: var(--stratakit-color-text-attention-base);
 		}
 	}
 
 	@layer states {
-		&:where([data-kiwi-selected="true"]) {
+		&:where([data-_sk-selected="true"]) {
 			--🌀ListItem-state: var(--🌀ListItem-state--active);
 		}
 
 		@media (any-hover: hover) {
-			&:where(:hover[data-kiwi-selected="true"]) {
+			&:where(:hover[data-_sk-selected="true"]) {
 				--🌀ListItem-state: var(--🌀ListItem-state--active-hover);
 			}
 		}
 
-		&:where([data-kiwi-expanded="false"]) {
+		&:where([data-_sk-expanded="false"]) {
 			--🥝ChevronDown-rotate: -0.25turn;
 		}
 
-		&:where(:not([data-kiwi-expanded])) {
+		&:where(:not([data-_sk-expanded])) {
 			--🥝TreeItem-expander-visibility: hidden;
 		}
 	}
@@ -121,7 +121,7 @@
 
 	@layer modifiers {
 		/* Actions container should be additionally made visible when any individual action is forcibly visible. */
-		&:where(:has(.🥝TreeItemAction[data-kiwi-visible="true"])) {
+		&:where(:has(.🥝TreeItemAction[data-_sk-visible="true"])) {
 			--🥝TreeItem-actions-container-visibility: visible;
 		}
 	}
@@ -134,11 +134,11 @@
 	}
 
 	@layer modifiers {
-		&:where([data-kiwi-visible="false"]) {
+		&:where([data-_sk-visible="false"]) {
 			--🥝TreeItem-action-visibility: hidden;
 		}
 
-		&:where([data-kiwi-visible="true"]) {
+		&:where([data-_sk-visible="true"]) {
 			--🥝TreeItem-action-visibility: visible;
 		}
 	}
@@ -164,11 +164,11 @@
 		--🥝ListItem-background-color: Canvas;
 		--🥝TreeItem-color: CanvasText;
 
-		&:where([data-kiwi-error="true"], [data-kiwi-selected="true"]) {
+		&:where([data-_sk-error="true"], [data-_sk-selected="true"]) {
 			forced-color-adjust: none;
 		}
 
-		&:where([data-kiwi-error="true"]) {
+		&:where([data-_sk-error="true"]) {
 			.🥝TreeItemContent,
 			.🥝TreeItemDecoration {
 				background-color: Mark;
@@ -176,7 +176,7 @@
 			}
 		}
 
-		&:where([data-kiwi-selected="true"]) {
+		&:where([data-_sk-selected="true"]) {
 			--🥝ListItem-background-color: SelectedItem;
 			--🥝TreeItem-color: SelectedItemText;
 		}

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-tree-item {
+.🥝TreeItem {
 	@layer base {
 		position: relative;
 		min-inline-size: max-content;
@@ -38,7 +38,7 @@
 	}
 }
 
-.🥝-tree-item-node:is(.🥝-list-item) {
+.🥝TreeItemNode:is(.🥝ListItem) {
 	--✨first-level-indent: var(--stratakit-space-x2);
 	--✨subsequent-level-indent: calc(var(--stratakit-space-x1) + var(--stratakit-space-x05));
 
@@ -84,13 +84,13 @@
 	}
 }
 
-.🥝-tree-item-content:is(.🥝-list-item-content) {
+.🥝TreeItemContent:is(.🥝ListItemContent) {
 	@layer base {
 		white-space: nowrap;
 	}
 }
 
-.🥝-tree-item-description:is(.🥝-list-item-content) {
+.🥝TreeItemDescription:is(.🥝ListItemContent) {
 	@layer base {
 		color: var(
 			--🥝tree-item-color,
@@ -99,7 +99,7 @@
 	}
 }
 
-.🥝-tree-item-actions-container:is(.🥝-list-item-decoration) {
+.🥝TreeItemActionsContainer:is(.🥝ListItemDecoration) {
 	@layer base {
 		align-self: stretch;
 		position: sticky;
@@ -124,13 +124,13 @@
 
 	@layer modifiers {
 		/* Actions container should be additionally made visible when any individual action is forcibly visible. */
-		&:where(:has(.🥝-tree-item-action[data-kiwi-visible="true"])) {
+		&:where(:has(.🥝TreeItemAction[data-kiwi-visible="true"])) {
 			--🥝tree-item-actions-container-visibility: visible;
 		}
 	}
 }
 
-.🥝-tree-item-action:is(.🥝-icon-button) {
+.🥝TreeItemAction:is(.🥝IconButton) {
 	@layer base {
 		visibility: var(--🥝tree-item-action-visibility);
 		transition: visibility 16ms; /* This allows some time focus to "settle" before determining final visibility. */
@@ -147,14 +147,14 @@
 	}
 }
 
-.🥝-tree-item-expander:is(.🥝-icon-button) {
+.🥝TreeItemExpander:is(.🥝IconButton) {
 	@layer base {
 		visibility: var(--🥝tree-item-expander-visibility);
 		z-index: 1; /* Ensure the expander is above the invisible content button */
 	}
 }
 
-.🥝-tree-item-decoration {
+.🥝TreeItemDecoration {
 	@layer base {
 		display: flex;
 		align-items: center;
@@ -163,7 +163,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-tree-item-node:is(.🥝-list-item) {
+	.🥝TreeItemNode:is(.🥝ListItem) {
 		--🥝list-item-background-color: Canvas;
 		--🥝tree-item-color: CanvasText;
 
@@ -172,8 +172,8 @@
 		}
 
 		&:where([data-kiwi-error="true"]) {
-			.🥝-tree-item-content,
-			.🥝-tree-item-decoration {
+			.🥝TreeItemContent,
+			.🥝TreeItemDecoration {
 				background-color: Mark;
 				color: MarkText;
 			}

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -360,7 +360,7 @@ const TreeItemRoot = React.memo(
 			() =>
 				({
 					...styleProp,
-					"--🥝tree-item-level": level,
+					"--🥝TreeItem-level": level,
 				}) as React.CSSProperties,
 			[styleProp, level],
 		);

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -375,7 +375,7 @@ const TreeItemRoot = React.memo(
 						aria-labelledby={labelId}
 						aria-describedby={describedBy}
 						aria-level={level}
-						className={cx("🥝-tree-item", props.className)}
+						className={cx("🥝TreeItem", props.className)}
 						style={style}
 						ref={forwardedRef}
 					/>
@@ -431,7 +431,7 @@ const TreeItemNode = React.memo((props: TreeItemNodeProps) => {
 			data-kiwi-expanded={expanded}
 			data-kiwi-selected={selected}
 			data-kiwi-error={error ? true : undefined}
-			className="🥝-tree-item-node"
+			className="🥝TreeItemNode"
 			role={undefined}
 			ref={ref}
 		>
@@ -478,7 +478,7 @@ function TreeItemDecoration() {
 	const icon = React.useContext(TreeItemIconContext);
 	return icon || decorations ? (
 		<Role
-			className="🥝-tree-item-decoration"
+			className="🥝TreeItemDecoration"
 			id={decorationId}
 			render={
 				React.isValidElement(icon) ? (
@@ -504,7 +504,7 @@ const TreeItemContent = React.memo(() => {
 	const labelId = React.useContext(TreeItemLabelIdContext);
 	const label = React.useContext(TreeItemLabelContext);
 	return (
-		<ListItem.Content id={labelId} className="🥝-tree-item-content">
+		<ListItem.Content id={labelId} className="🥝TreeItemContent">
 			{label}
 		</ListItem.Content>
 	);
@@ -521,7 +521,7 @@ const TreeItemDescription = React.memo(() => {
 	const description = React.useContext(TreeItemDescriptionContext);
 	const descriptionId = React.useContext(TreeItemDescriptionIdContext);
 	return description ? (
-		<ListItem.Content id={descriptionId} className="🥝-tree-item-description">
+		<ListItem.Content id={descriptionId} className="🥝TreeItemDescription">
 			{description}
 		</ListItem.Content>
 	) : undefined;
@@ -546,7 +546,7 @@ const TreeItemActions = React.memo(
 				onKeyDown={useEventHandlers(props.onKeyDown, (e) =>
 					e.stopPropagation(),
 				)}
-				className={cx("🥝-tree-item-actions-container", props.className)}
+				className={cx("🥝TreeItemActionsContainer", props.className)}
 				ref={forwardedRef}
 				render={<Toolbar focusLoop={false} />}
 			>
@@ -755,7 +755,7 @@ const TreeItemInlineAction = React.memo(
 				render={<ToolbarItem render={props.render} />}
 				dot={dot}
 				variant="ghost"
-				className={cx("🥝-tree-item-action", props.className)}
+				className={cx("🥝TreeItemAction", props.className)}
 				data-kiwi-visible={visible}
 				ref={forwardedRef}
 			/>
@@ -777,7 +777,7 @@ const TreeItemExpander = forwardRef<"button", TreeItemExpanderProps>(
 					aria-hidden="true"
 					{...props}
 					onClick={useEventHandlers(props.onClick, (e) => e.stopPropagation())}
-					className={cx("🥝-tree-item-expander", props.className)}
+					className={cx("🥝TreeItemExpander", props.className)}
 					variant="ghost"
 					ref={forwardedRef}
 				>

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -428,9 +428,9 @@ const TreeItemNode = React.memo((props: TreeItemNodeProps) => {
 	const [ref, renderActions] = useRenderActions();
 	return (
 		<ListItem.Root
-			data-kiwi-expanded={expanded}
-			data-kiwi-selected={selected}
-			data-kiwi-error={error ? true : undefined}
+			data-_sk-expanded={expanded}
+			data-_sk-selected={selected}
+			data-_sk-error={error ? true : undefined}
 			className="🥝TreeItemNode"
 			role={undefined}
 			ref={ref}
@@ -756,7 +756,7 @@ const TreeItemInlineAction = React.memo(
 				dot={dot}
 				variant="ghost"
 				className={cx("🥝TreeItemAction", props.className)}
-				data-kiwi-visible={visible}
+				data-_sk-visible={visible}
 				ref={forwardedRef}
 			/>
 		);

--- a/packages/structures/src/~utils.ListItem.css
+++ b/packages/structures/src/~utils.ListItem.css
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.🥝-list-item {
+.🥝ListItem {
 	--✨height--default: 1.75rem;
 	--✨height--large: 2.75rem;
 	--✨padding-inline: var(--stratakit-space-x2);
@@ -81,7 +81,7 @@
 	}
 
 	@layer modifiers {
-		&:where(:has(> :nth-child(2 of .🥝-list-item-content))) {
+		&:where(:has(> :nth-child(2 of .🥝ListItemContent))) {
 			--🥝list-item-height: var(--✨height--large);
 			grid-template-rows: repeat(auto-fit, minmax(0, auto));
 		}
@@ -99,13 +99,13 @@
 	}
 }
 
-.🥝-list-item-content {
+.🥝ListItemContent {
 	@layer base {
 		grid-column: content;
 	}
 }
 
-.🥝-list-item-decoration {
+.🥝ListItemDecoration {
 	--✨gap: var(--stratakit-space-x1);
 
 	@layer base {
@@ -117,7 +117,7 @@
 		align-items: center;
 		margin-inline-end: var(--✨gap);
 
-		:where(.🥝-list-item-content) ~ & {
+		:where(.🥝ListItemContent) ~ & {
 			grid-column: decoration-after;
 			margin-inline: var(--✨gap) 0;
 		}
@@ -125,7 +125,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝-list-item:where(:disabled, [aria-disabled="true"]) {
+	.🥝ListItem:where(:disabled, [aria-disabled="true"]) {
 		color: GrayText;
 	}
 }

--- a/packages/structures/src/~utils.ListItem.css
+++ b/packages/structures/src/~utils.ListItem.css
@@ -36,66 +36,66 @@
 			content-start] minmax(0, 1fr) [content-end
 			decoration-after-start] auto [decoration-after-end];
 
-		min-block-size: var(--🥝list-item-height, var(--✨height--default));
+		min-block-size: var(--🥝ListItem-height, var(--✨height--default));
 		padding-inline: var(--✨padding-inline);
-		background-color: var(--🥝list-item-background-color);
+		background-color: var(--🥝ListItem-background-color);
 
-		--🥝list-item-background-color: var(--🌀list-item-state--default, var(--✨bg--default))
-			var(--🌀list-item-state--hover, var(--✨bg--hover))
-			var(--🌀list-item-state--pressed, var(--✨bg--pressed))
-			var(--🌀list-item-state--active, var(--✨bg--active))
-			var(--🌀list-item-state--active-hover, var(--✨bg--active-hover))
-			var(--🌀list-item-state--disabled, var(--✨bg--default));
+		--🥝ListItem-background-color: var(--🌀ListItem-state--default, var(--✨bg--default))
+			var(--🌀ListItem-state--hover, var(--✨bg--hover))
+			var(--🌀ListItem-state--pressed, var(--✨bg--pressed))
+			var(--🌀ListItem-state--active, var(--✨bg--active))
+			var(--🌀ListItem-state--active-hover, var(--✨bg--active-hover))
+			var(--🌀ListItem-state--disabled, var(--✨bg--default));
 		color: var(
-			--🥝list-item-color,
-			var(--🌀list-item-state--default, var(--✨color--default))
-				var(--🌀list-item-state--hover, var(--✨color--default))
-				var(--🌀list-item-state--pressed, var(--✨color--default))
-				var(--🌀list-item-state--active, var(--✨color--active))
-				var(--🌀list-item-state--active-hover, var(--✨color--active))
-				var(--🌀list-item-state--disabled, var(--✨color--disabled))
+			--🥝ListItem-color,
+			var(--🌀ListItem-state--default, var(--✨color--default))
+				var(--🌀ListItem-state--hover, var(--✨color--default))
+				var(--🌀ListItem-state--pressed, var(--✨color--default))
+				var(--🌀ListItem-state--active, var(--✨color--active))
+				var(--🌀ListItem-state--active-hover, var(--✨color--active))
+				var(--🌀ListItem-state--disabled, var(--✨color--disabled))
 		);
-		--🥝icon-color: var(--🌀list-item-state--default, var(--stratakit-color-icon-neutral-base))
-			var(--🌀list-item-state--hover, var(--stratakit-color-icon-neutral-hover))
-			var(--🌀list-item-state--pressed, var(--stratakit-color-icon-neutral-hover))
-			var(--🌀list-item-state--active, var(--stratakit-color-icon-accent-strong))
-			var(--🌀list-item-state--active-hover, var(--stratakit-color-icon-accent-strong))
-			var(--🌀list-item-state--disabled, var(--stratakit-color-icon-neutral-disabled));
+		--🥝Icon-color: var(--🌀ListItem-state--default, var(--stratakit-color-icon-neutral-base))
+			var(--🌀ListItem-state--hover, var(--stratakit-color-icon-neutral-hover))
+			var(--🌀ListItem-state--pressed, var(--stratakit-color-icon-neutral-hover))
+			var(--🌀ListItem-state--active, var(--stratakit-color-icon-accent-strong))
+			var(--🌀ListItem-state--active-hover, var(--stratakit-color-icon-accent-strong))
+			var(--🌀ListItem-state--disabled, var(--stratakit-color-icon-neutral-disabled));
 	}
 
 	@layer states {
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--🌀list-item-state: var(--🌀list-item-state--hover);
+				--🌀ListItem-state: var(--🌀ListItem-state--hover);
 			}
 		}
 
 		&:where(:active) {
-			--🌀list-item-state: var(--🌀list-item-state--pressed);
+			--🌀ListItem-state: var(--🌀ListItem-state--pressed);
 		}
 
 		&:where(:disabled, [aria-disabled="true"]) {
-			--🌀list-item-state: var(--🌀list-item-state--disabled);
+			--🌀ListItem-state: var(--🌀ListItem-state--disabled);
 			cursor: not-allowed;
 		}
 	}
 
 	@layer modifiers {
 		&:where(:has(> :nth-child(2 of .🥝ListItemContent))) {
-			--🥝list-item-height: var(--✨height--large);
+			--🥝ListItem-height: var(--✨height--large);
 			grid-template-rows: repeat(auto-fit, minmax(0, auto));
 		}
 	}
 
 	@layer base.🌀 {
 		/* See https://kizu.dev/cyclic-toggles/ */
-		--🌀list-item-state: var(--🌀list-item-state--default);
-		--🌀list-item-state--default: var(--🌀list-item-state,);
-		--🌀list-item-state--hover: var(--🌀list-item-state,);
-		--🌀list-item-state--pressed: var(--🌀list-item-state,);
-		--🌀list-item-state--active: var(--🌀list-item-state,);
-		--🌀list-item-state--active-hover: var(--🌀list-item-state,);
-		--🌀list-item-state--disabled: var(--🌀list-item-state,);
+		--🌀ListItem-state: var(--🌀ListItem-state--default);
+		--🌀ListItem-state--default: var(--🌀ListItem-state,);
+		--🌀ListItem-state--hover: var(--🌀ListItem-state,);
+		--🌀ListItem-state--pressed: var(--🌀ListItem-state,);
+		--🌀ListItem-state--active: var(--🌀ListItem-state,);
+		--🌀ListItem-state--active-hover: var(--🌀ListItem-state,);
+		--🌀ListItem-state--disabled: var(--🌀ListItem-state,);
 	}
 }
 

--- a/packages/structures/src/~utils.ListItem.tsx
+++ b/packages/structures/src/~utils.ListItem.tsx
@@ -20,7 +20,7 @@ const ListItem = forwardRef<"div", ListItemProps>((props, forwardedRef) => {
 		<Role.div
 			role="listitem"
 			{...props}
-			className={cx("🥝-list-item", props.className)}
+			className={cx("🥝ListItem", props.className)}
 			ref={forwardedRef}
 		/>
 	);
@@ -38,7 +38,7 @@ const ListItemContent = forwardRef<"div", ListItemContentProps>(
 			<Text
 				{...props}
 				variant="body-sm"
-				className={cx("🥝-list-item-content", props.className)}
+				className={cx("🥝ListItemContent", props.className)}
 				ref={forwardedRef}
 			/>
 		);
@@ -56,7 +56,7 @@ const ListItemDecoration = forwardRef<"div", ListItemDecorationProps>(
 		return (
 			<Role.div
 				{...props}
-				className={cx("🥝-list-item-decoration", props.className)}
+				className={cx("🥝ListItemDecoration", props.className)}
 				ref={forwardedRef}
 			/>
 		);

--- a/packages/structures/src/~utils.icons.tsx
+++ b/packages/structures/src/~utils.icons.tsx
@@ -76,7 +76,7 @@ export const ChevronDown = forwardRef<
 	return (
 		<ChevronDownBase
 			{...props}
-			className={cx("🥝-chevron-down", props.className)}
+			className={cx("🥝ChevronDown", props.className)}
 			ref={forwardedRef}
 		/>
 	);


### PR DESCRIPTION
This PR addresses https://github.com/iTwin/design-system/issues/826#issuecomment-3140980543 by changing the convention used for CSS selectors (including classes and attributes) and custom idents (including CSS variables and keyframes).

_⚠️ 82 files changed. This looks scary but is entirely find-and-replace. No other code changes._

### Changes

**First three commits in order:**

1. All class names are now PascalCase (or UpperCamelCase) instead of kebab-case. This makes them consistent with the React component names and will help with making CSS modules easier to use.
2. All CSS variables and keyframes now use the PascalCase component name as the prefix. This makes them consistent with the classes and component names.
3. All `data-kiwi-` attributes have been renamed to `data-_sk-`. This has been long overdue.

Tests that were relying on classes have been changed to use other locators. (Classes should be considered implementation detail.)

**Interesting notes:**

Originally I was going to remove the "🥝" prefix from classes, because that's what we ultimately want when we use CSS modules scoping. However, I decided not to change that in this PR, because the prefix helps with namespacing and avoiding clashes (e.g. a consumer might have a `className="Button"` in their own components). The prefix could be temporarily added during the build step, but that would introduce more complexity into this already large PR.