### PR TITLE
test-app: add github link to demo pages

### DIFF
--- a/apps/test-app/app/tests/tests.module.css
+++ b/apps/test-app/app/tests/tests.module.css
@@ -30,3 +30,8 @@
 .pushRight {
 	margin-inline-start: auto;
 }
+
+.actions {
+	display: flex;
+	gap: var(--stratakit-space-x1);
+}

--- a/apps/test-app/app/tests/tests.tsx
+++ b/apps/test-app/app/tests/tests.tsx
@@ -6,7 +6,9 @@
 import * as React from "react";
 import { Link, Outlet, useMatches } from "react-router";
 import { Anchor, IconButton, Text, VisuallyHidden } from "@stratakit/bricks";
+import cx from "classnames";
 import {
+	GitHubLink,
 	RightSidebar,
 	ThemeSwitcher,
 	useLocalStorage,
@@ -61,7 +63,10 @@ export default function Page() {
 
 							<Text variant="body-md">{title}</Text>
 
-							<ThemeSwitcher className={styles.pushRight} />
+							<div className={cx(styles.actions, styles.pushRight)}>
+								<GitHubLink path={matches.at(-1)?.id ?? ""} />
+								<ThemeSwitcher />
+							</div>
 						</>
 					}
 				>

--- a/apps/test-app/app/~utils.tsx
+++ b/apps/test-app/app/~utils.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Link, useSearchParams } from "react-router";
 import { Anchor, IconButton } from "@stratakit/bricks";
+import { Icon } from "@stratakit/foundations";
 import cx from "classnames";
 import * as ListItem from "../node_modules/@stratakit/structures/src/~utils.ListItem.tsx";
 
@@ -293,6 +294,36 @@ export function ThemeSwitcher(props: React.ComponentProps<"button">) {
 			onClick={() => setColorScheme(colorScheme === "dark" ? "light" : "dark")}
 			variant="outline"
 			{...props}
+		/>
+	);
+}
+
+// ----------------------------------------------------------------------------
+
+export function GitHubLink(
+	props: React.ComponentProps<"a"> & { path: string },
+) {
+	const { path, ...rest } = props;
+	const url = `https://github.com/iTwin/design-system/blob/main/apps/test-app/app/${path ? `${path}.tsx` : ""}`;
+
+	const githubIcon = (
+		// from https://github.com/logos
+		<svg viewBox="0 0 98 96">
+			<path
+				fill-rule="evenodd"
+				clip-rule="evenodd"
+				d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+				fill="currentColor"
+			/>
+		</svg>
+	);
+
+	return (
+		<IconButton
+			label="View page source"
+			icon={<Icon render={githubIcon} />}
+			variant="outline"
+			render={<a href={url} {...rest} />}
 		/>
 	);
 }


### PR DESCRIPTION
This PR adds a link back to the source of the demo pages. This will be useful for consumers in absence of proper docs.

<img width="265" height="132" alt="Screenshot of the right sidebar showing an iconButton containing the github logo." src="https://github.com/user-attachments/assets/c4ae8af8-b725-44eb-a6ff-dac42c7239de" />

[Deploy preview](https://itwin.github.io/design-system/918/)