### PR TITLE
Add `portalContainer` prop to the `<Root />`

### DIFF
--- a/.changeset/dirty-bananas-talk.md
+++ b/.changeset/dirty-bananas-talk.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/foundations": patch
+---
+
+Added `portalContainer` prop to the `Root` component.

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -199,7 +199,7 @@ function SynchronizeColorScheme({
 
 interface PortalContainerProps
 	extends Pick<RootProps, "colorScheme" | "density">,
-		BaseProps {}
+		Omit<BaseProps, "children"> {}
 
 /** A separate root rendered at the end of root node, to be used as the container for all portals. */
 const PortalContainer = forwardRef<"div", PortalContainerProps>(

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -198,8 +198,7 @@ function SynchronizeColorScheme({
 // ----------------------------------------------------------------------------
 
 interface PortalContainerProps
-	extends Pick<RootProps, "colorScheme" | "density">,
-		Omit<BaseProps, "children"> {}
+	extends Pick<RootProps, "colorScheme" | "density" | "render"> {}
 
 /** A separate root rendered at the end of root node, to be used as the container for all portals. */
 const PortalContainer = forwardRef<"div", PortalContainerProps>(
@@ -212,11 +211,11 @@ const PortalContainer = forwardRef<"div", PortalContainerProps>(
 
 		return ReactDOM.createPortal(
 			<Role
-				{...props}
-				className={cx("🥝Root", props.className)}
+				render={props.render}
+				className="🥝Root"
 				data-_sk-theme={props.colorScheme}
 				data-_sk-density={props.density}
-				style={{ display: "contents", ...props.style }}
+				style={{ display: "contents" }}
 				ref={forwardedRef}
 			/>,
 			destination,

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -67,6 +67,11 @@ interface RootProps extends BaseProps {
 	 * ```
 	 */
 	unstable_htmlSanitizer?: (html: string) => string;
+
+	/**
+	 * Allows to customize the root portal container element.
+	 */
+	portalContainer?: React.ReactElement;
 }
 
 /**
@@ -109,6 +114,7 @@ export const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 				colorScheme={props.colorScheme}
 				density={props.density}
 				ref={setPortalContainer}
+				render={props.portalContainer}
 			/>
 
 			<PortalContext.Provider value={portalContainer}>
@@ -191,28 +197,32 @@ function SynchronizeColorScheme({
 
 // ----------------------------------------------------------------------------
 
+interface PortalContainerProps
+	extends Pick<RootProps, "colorScheme" | "density">,
+		BaseProps {}
+
 /** A separate root rendered at the end of root node, to be used as the container for all portals. */
-const PortalContainer = forwardRef<
-	"div",
-	Pick<RootProps, "colorScheme" | "density">
->((props, forwardedRef) => {
-	const rootNode = useRootNode();
-	if (!rootNode) return null;
+const PortalContainer = forwardRef<"div", PortalContainerProps>(
+	(props, forwardedRef) => {
+		const rootNode = useRootNode();
+		if (!rootNode) return null;
 
-	const destination = isDocument(rootNode) ? rootNode.body : rootNode;
-	if (!destination) return null;
+		const destination = isDocument(rootNode) ? rootNode.body : rootNode;
+		if (!destination) return null;
 
-	return ReactDOM.createPortal(
-		<div
-			className="🥝Root"
-			data-_sk-theme={props.colorScheme}
-			data-_sk-density={props.density}
-			style={{ display: "contents" }}
-			ref={forwardedRef}
-		/>,
-		destination,
-	);
-});
+		return ReactDOM.createPortal(
+			<Role
+				{...props}
+				className={cx("🥝Root", props.className)}
+				data-_sk-theme={props.colorScheme}
+				data-_sk-density={props.density}
+				style={{ display: "contents", ...props.style }}
+				ref={forwardedRef}
+			/>,
+			destination,
+		);
+	},
+);
 
 // ----------------------------------------------------------------------------
 

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -94,6 +94,7 @@ export const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 		children,
 		synchronizeColorScheme = false,
 		unstable_htmlSanitizer = identity,
+		portalContainer: portalContainerProp,
 		...rest
 	} = props;
 
@@ -114,7 +115,7 @@ export const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 				colorScheme={props.colorScheme}
 				density={props.density}
 				ref={setPortalContainer}
-				render={props.portalContainer}
+				render={portalContainerProp}
 			/>
 
 			<PortalContext.Provider value={portalContainer}>


### PR DESCRIPTION
_Extracted from #922_

This PR adds `portalContainer` prop to the `Root` component to allow customization of the root portal container element.