### PR TITLE
`IconButton`: rename `isActive` prop to `active`

### DIFF
--- a/.changeset/free-mangos-shout.md
+++ b/.changeset/free-mangos-shout.md
@@ -1,0 +1,7 @@
+---
+"@stratakit/bricks": patch
+---
+
+Added new `active` prop to `IconButton` and deprecated the existing `isActive` prop.
+
+The `active` prop is consistent with the naming convention followed by other boolean props in StrataKit.

--- a/apps/test-app/app/tests/toolbar/index.tsx
+++ b/apps/test-app/app/tests/toolbar/index.tsx
@@ -24,7 +24,7 @@ export default definePage(
 							icon={`${placeholderIcon}#icon-large`}
 							label="Click me"
 							variant="ghost"
-							isActive={active === "1"}
+							active={active === "1"}
 							onClick={() => setActive("1")}
 						/>
 					}
@@ -35,7 +35,7 @@ export default definePage(
 							icon={`${placeholderIcon}#icon-large`}
 							label="Click me"
 							variant="ghost"
-							isActive={active === "2"}
+							active={active === "2"}
 							onClick={() => setActive("2")}
 						/>
 					}
@@ -46,7 +46,7 @@ export default definePage(
 							icon={`${placeholderIcon}#icon-large`}
 							label="Click me"
 							variant="ghost"
-							isActive={active === "3"}
+							active={active === "3"}
 							onClick={() => setActive("3")}
 						/>
 					}

--- a/packages/bricks/src/IconButton.tsx
+++ b/packages/bricks/src/IconButton.tsx
@@ -66,6 +66,10 @@ interface IconButtonProps
 	 *
 	 * @default undefined
 	 */
+	active?: boolean;
+	/**
+	 * @deprecated Use `active` instead.
+	 */
 	isActive?: boolean;
 }
 
@@ -89,21 +93,29 @@ interface IconButtonProps
  * />
  * ```
  *
- * The `isActive` prop can be used to turn this button into a toggle button.
+ * The `active` prop can be used to turn this button into a toggle button.
  * ```tsx
- * const [isActive, setIsActive] = React.useState(false);
+ * const [active, setActive] = React.useState(false);
  *
  * <IconButton
  *   label={…}
  *   icon={…}
- *   isActive={isActive}
- *   onClick={() => setIsActive(!isActive)}
+ *   active={active}
+ *   onClick={() => setActive(!active)}
  * />
  * ```
  */
 const IconButton = forwardRef<"button", IconButtonProps>(
 	(props, forwardedRef) => {
-		const { label, icon, isActive, labelVariant, dot, ...rest } = props;
+		const {
+			label,
+			icon,
+			isActive,
+			active = isActive,
+			labelVariant,
+			dot,
+			...rest
+		} = props;
 
 		const baseId = React.useId();
 		const labelId = `${baseId}-label`;
@@ -115,7 +127,7 @@ const IconButton = forwardRef<"button", IconButtonProps>(
 			<IconButtonPresentation
 				render={
 					<Button
-						aria-pressed={isActive}
+						aria-pressed={active}
 						aria-labelledby={labelId}
 						aria-describedby={dot ? dotId : undefined}
 						{...rest}

--- a/packages/compat/src/IconButton.tsx
+++ b/packages/compat/src/IconButton.tsx
@@ -79,7 +79,7 @@ export const IconButton = React.forwardRef((props, forwardedRef) => {
 			}
 			label={label as string}
 			variant={variant}
-			isActive={isActive}
+			active={isActive}
 			accessibleWhenDisabled={accessibleWhenDisabled}
 			disabled={props.disabled || htmlDisabled}
 			ref={forwardedRef}


### PR DESCRIPTION
Deprecated `isActive` prop, to be replaced with newly added `active` prop which aligns with other naming conventions in StrataKit. ("drop the `is`")

`isActive` will be removed in a future minor release.

Originally raised in https://github.com/iTwin/design-system/pull/884#discussion_r2300341824.