### PR TITLE
prepend `@layer reset` before all stylesheets

### DIFF
--- a/.changeset/great-impalas-act.md
+++ b/.changeset/great-impalas-act.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/foundations": patch
+---
+
+Added `@layer reset` fallback to the top of `<head>` element to ensure correct layer order.

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -229,6 +229,17 @@ const PortalContainer = forwardRef<"div", PortalContainerProps>(
 function Styles() {
 	const rootNode = useRootNode();
 
+	useLayoutEffect(
+		/** Adds `@layer reset` _before_ all other styles to ensure correct layer order.  */
+		function addResetLayer() {
+			if (!rootNode) return;
+			const styleElement = document.createElement("style");
+			((rootNode as Document).head || rootNode).prepend(styleElement);
+			styleElement.textContent = "@layer reset;";
+		},
+		[rootNode],
+	);
+
 	useLayoutEffect(() => {
 		if (!rootNode) return;
 		const { cleanup } = loadStyles(rootNode, { css });


### PR DESCRIPTION
As StrataKit styles use `document.adoptedStyleSheets`, they are naturally ordered after `document.styleSheets`. Which means we currently rely on other stylesheets to add `@layer reset` for us (e.g. see [iTwinUI code](https://github.com/iTwin/iTwinUI/blob/9d6a12a7f8eabc11898edb1e1471af38d571fe9c/packages/itwinui-react/src/styles.js/styles.module.css#L6)).

This PR adds `@layer reset` in an inline style element at the top of the `<head>` (or shadow-root), before all other stylesheets. This change helps applications which do not set their own layer order.

<img width="358" height="126" alt="Screenshot showing a style element with @layer reset at the very top of the head" src="https://github.com/user-attachments/assets/92366368-6cf7-46b6-8d87-3551e14922ab" />

This will work in conjunction with https://github.com/iTwin/appui/pull/1398 to ensure correct layer order.