### PR TITLE
make `Dialog.Content` conditionally scrollable

### DIFF
--- a/.changeset/fresh-streets-act.md
+++ b/.changeset/fresh-streets-act.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+`Dialog.Content` will now only scroll past a certain viewport height. On smaller viewports, the `Dialog.Root` will be scrollable instead.

--- a/packages/structures/src/Dialog.css
+++ b/packages/structures/src/Dialog.css
@@ -78,11 +78,15 @@
 
 		color: var(--stratakit-color-text-neutral-primary);
 
-		overflow-y: auto;
-		overflow-block: auto;
-
 		padding-block-end: var(--✨padding);
 		padding-inline: var(--✨padding);
+	}
+
+	@layer modifiers {
+		@media (min-height: 15em) {
+			overflow-y: auto;
+			overflow-block: auto;
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to #851. This makes `Dialog.Content` non-scrollable on smaller viewports, so that the content doesn't become too small. The `Dialog.Root` itself will be scrollable (along with the header and footer).