### PR TITLE
use top layer for `NavigationRail.ToggleButton` and make `NavigationRail.Root` scrollable

### DIFF
--- a/packages/structures/src/NavigationRail.css
+++ b/packages/structures/src/NavigationRail.css
@@ -12,6 +12,10 @@
 		flex-direction: column;
 		gap: var(--stratakit-space-x1);
 
+		overflow: hidden;
+		overflow-y: auto;
+		overflow-block: auto;
+
 		block-size: 100%;
 		min-inline-size: var(--✨size--collapsed);
 		inline-size: var(--🥝NavigationRail-inline-size);
@@ -40,6 +44,9 @@
 		padding-block: var(--stratakit-space-x2);
 		padding-inline: var(--stratakit-space-x4);
 		min-block-size: var(--✨header-height);
+
+		anchor-scope: --🥝NavigationRailHeader;
+		anchor-name: --🥝NavigationRailHeader;
 	}
 }
 
@@ -83,9 +90,22 @@
 
 		/* Should be floating above the right edge of the header during collapsed state */
 		:where(.🥝NavigationRailHeader[data-_sk-collapsed="true"]) & {
-			position: absolute;
-			inset-inline-end: 0;
-			translate: 50%;
+			/* The `popover` attribute should be added when CSS anchor positioning is supported. */
+			&:where([popover]) {
+				position: fixed;
+				position-anchor: --🥝NavigationRailHeader;
+				position-visibility: no-overflow;
+
+				inset-inline-start: anchor(end);
+				inset-block-start: anchor(center);
+				translate: -50% -50%;
+			}
+
+			/* Fallback: Clamp to right edge instead of extending past it. */
+			&:where(:not([popover])) {
+				position: absolute;
+				inset-inline-end: 0;
+			}
 		}
 
 		&:where([aria-expanded="true"]) {
@@ -100,7 +120,6 @@
 		padding-inline: var(--stratakit-space-x2);
 
 		flex: 999;
-		overflow: auto;
 
 		display: flex;
 		flex-direction: column;
@@ -121,7 +140,7 @@
 }
 
 .🥝NavigationRailItemAction {
-	--✨height: calc(1.5rem + 2 * var(--stratakit-space-x2));
+	--✨size: calc(1.5rem + 2 * var(--stratakit-space-x2));
 
 	--✨bg--default: transparent;
 	--✨bg--hover: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
@@ -157,7 +176,8 @@
 
 		border-radius: 4px;
 		inline-size: stretch;
-		min-block-size: var(--✨height);
+		min-block-size: var(--✨size);
+		min-inline-size: var(--✨size);
 		padding: var(--stratakit-space-x2);
 		--🥝Icon-size: 1.5rem;
 		border: 1px solid;

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from "react";
+import { Button as AkButton } from "@ariakit/react/button";
 import { Role } from "@ariakit/react/role";
 import { Tooltip, VisuallyHidden } from "@stratakit/bricks";
 import { Icon } from "@stratakit/foundations";
 import {
 	forwardRef,
 	useEventHandlers,
+	useMergedRefs,
 	useSafeContext,
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
@@ -19,6 +21,11 @@ import type {
 	BaseProps,
 	FocusableProps,
 } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+const supportsCssAnchorPositioning =
+	typeof CSS !== "undefined" && CSS.supports("position-anchor: --foo");
 
 // ----------------------------------------------------------------------------
 
@@ -178,12 +185,22 @@ const NavigationRailToggleButton = forwardRef<
 	const collapsed = useNavigationRailState((state) => state.collapsed);
 	const setCollapsed = useNavigationRailState((state) => state.setCollapsed);
 
+	/** Callback ref that moves the element into the top layer. */
+	const topLayerRef = React.useCallback(
+		(element: HTMLElement | null) => {
+			if (!element?.isConnected || !element?.popover) return;
+			element.togglePopover(collapsed);
+		},
+		[collapsed],
+	);
+
 	return (
-		<Role.button
+		<AkButton
 			aria-expanded={collapsed ? "false" : "true"}
+			popover={supportsCssAnchorPositioning && collapsed ? "manual" : undefined}
 			{...rest}
 			className={cx("🥝NavigationRailToggleButton", props.className)}
-			ref={forwardedRef}
+			ref={useMergedRefs(topLayerRef, forwardedRef)}
 			onClick={useEventHandlers(props.onClick, () => setCollapsed(!collapsed))}
 		>
 			<svg width="12" height="12" fill="none" aria-hidden="true">
@@ -193,7 +210,7 @@ const NavigationRailToggleButton = forwardRef<
 				/>
 			</svg>
 			<VisuallyHidden>{label}</VisuallyHidden>
-		</Role.button>
+		</AkButton>
 	);
 });
 DEV: NavigationRailToggleButton.displayName = "NavigationRail.ToggleButton";


### PR DESCRIPTION
Follow-up to #884. This PR moves `overflow: auto` from `NavigationRail.Content` onto `NavigationRail.Root`. This required moving `NavigationRail.ToggleButton` into the top layer (to prevent it from getting clipped).

Implementation: uses `popover="manual"` and immediately calls `togglePopover(true)` on first render. Positioning is handled using CSS anchor positioning. On browsers that don't support CSS anchor positioning, top layer is not used; instead, the position is changed to _not_ protrude from the nav.