### PR TITLE
create initial `Card` component

### DIFF
--- a/apps/test-app/app/tests/card/index.tsx
+++ b/apps/test-app/app/tests/card/index.tsx
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Text } from "@stratakit/bricks";
+import { unstable_Card as Card } from "@stratakit/structures";
+import { definePage } from "~/~utils.tsx";
+
+export const handle = { title: "Card" };
+
+export default definePage(
+	function Page() {
+		return (
+			<Card.Root>
+				<Card.Title>Kiwi</Card.Title>
+				<Card.Body>
+					<Text variant="body-sm">
+						Kiwifruit (often shortened to kiwi) has a thin, fuzzy, fibrous,
+						light brown skin that is tart but edible, and light green or golden
+						flesh that contains rows of tiny black edible seeds. The fruit has a
+						soft texture with a sweet and unique flavour.
+					</Text>
+				</Card.Body>
+			</Card.Root>
+		);
+	},
+	{
+		visual: VisualTest,
+	},
+);
+
+function VisualTest() {
+	return (
+		<Card.Root>
+			<Card.Title>Title</Card.Title>
+			<Card.Body>
+				<Text variant="body-sm">Body</Text>
+			</Card.Body>
+		</Card.Root>
+	);
+}

--- a/apps/test-app/app/~meta.ts
+++ b/apps/test-app/app/~meta.ts
@@ -27,6 +27,7 @@ export const components = {
 	structures: [
 		"AccordionItem",
 		"Banner",
+		"Card",
 		"Chip",
 		"Dialog",
 		"DropdownMenu",

--- a/packages/structures/package.json
+++ b/packages/structures/package.json
@@ -25,6 +25,12 @@
 			"development": "./dist/DEV/Banner.js",
 			"default": "./dist/Banner.js"
 		},
+		"./unstable_Card": {
+			"@stratakit/source": "./src/Card.tsx",
+			"types": "./dist/Card.d.ts",
+			"development": "./dist/DEV/Card.js",
+			"default": "./dist/Card.js"
+		},
 		"./Chip": {
 			"@stratakit/source": "./src/Chip.tsx",
 			"types": "./dist/Chip.d.ts",

--- a/packages/structures/src/Card.css
+++ b/packages/structures/src/Card.css
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.🥝Card {
+	@layer base {
+		display: grid;
+
+		min-inline-size: 256px;
+		max-inline-size: 334px;
+		border-radius: 8px;
+
+		background-color: var(--stratakit-color-bg-elevation-base);
+		box-shadow: var(--stratakit-shadow-surface-xs);
+	}
+}
+
+.🥝CardTitle {
+	@layer base {
+		@apply --typography("body-sm");
+		font-weight: 500;
+
+		display: grid;
+		align-items: center;
+
+		min-block-size: var(--stratakit-space-x10);
+		padding-inline: var(--stratakit-space-x4);
+
+		border-block-end: 1px solid var(--stratakit-color-border-neutral-muted);
+	}
+}
+
+.🥝CardBody {
+	@layer base {
+		padding: var(--stratakit-space-x4);
+	}
+}
+
+@media (forced-colors: active) {
+	.🥝Card {
+		border: 1px solid;
+	}
+}

--- a/packages/structures/src/Card.tsx
+++ b/packages/structures/src/Card.tsx
@@ -1,0 +1,149 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { Role } from "@ariakit/react/role";
+import {
+	forwardRef,
+	useSafeContext,
+} from "@stratakit/foundations/secret-internals";
+import cx from "classnames";
+import { createStore, type ExtractState, useStore } from "zustand";
+import { combine } from "zustand/middleware";
+
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+type CardState = ExtractState<ReturnType<typeof createCardStore>>;
+
+function createCardStore(initialState: { titleId?: string }) {
+	return createStore(
+		combine(initialState, (set, _, store) => ({
+			setTitleId: (titleId?: string) =>
+				set({ titleId: titleId || store.getInitialState().titleId }),
+		})),
+	);
+}
+
+const CardContext = React.createContext<
+	ReturnType<typeof createCardStore> | undefined
+>(undefined);
+
+function CardProvider(props: React.PropsWithChildren) {
+	const defaultTitleId = React.useId();
+	const [store] = React.useState(() =>
+		createCardStore({ titleId: defaultTitleId }),
+	);
+
+	return (
+		<CardContext.Provider value={store}>{props.children}</CardContext.Provider>
+	);
+}
+
+function useCardState<P>(selectorFn: (state: CardState) => P): P {
+	const store = useSafeContext(CardContext);
+	return useStore(store, selectorFn);
+}
+
+// ----------------------------------------------------------------------------
+
+interface CardRootProps extends BaseProps<"div"> {}
+
+/**
+ * A Card component can be used for compactly displaying information and actions
+ * about a single subject. The Card may link to another page which contains more
+ * detailed information about the subject.
+ *
+ * Example:
+ * ```tsx
+ * <Card.Root>
+ *   <Card.Title>The subject</Card.Title>
+ *   <Card.Body>
+ *     <Text variant="body-sm">A description of the subject</Text>
+ *  </Card.Body>
+ * </Card.Root>
+ * ```
+ *
+ * Renders with role="group" by default and is labelled by the `Card.Title`.
+ */
+const CardRoot = forwardRef<"div", CardRootProps>((props, forwardedRef) => {
+	return (
+		<CardProvider>
+			<CardRootInner {...props} ref={forwardedRef} />
+		</CardProvider>
+	);
+});
+DEV: CardRoot.displayName = "Card.Root";
+
+const CardRootInner = forwardRef<"div", CardRootProps>(
+	(props, forwardedRef) => {
+		const titleId = useCardState((state) => state.titleId);
+		return (
+			<Role.div
+				role="group"
+				aria-labelledby={titleId}
+				{...props}
+				className={cx("🥝Card", props.className)}
+				ref={forwardedRef}
+			/>
+		);
+	},
+);
+DEV: CardRootInner.displayName = "Card.RootInner";
+
+// ----------------------------------------------------------------------------
+
+interface CardTitleProps extends BaseProps<"h2"> {}
+
+/**
+ * `Card.Title` is the title that identifies the Card.
+ *
+ * Renders as an h2 heading by default.
+ */
+const CardTitle = forwardRef<"h2", CardTitleProps>(
+	function CardTitle(props, forwardedRef) {
+		const titleId = useCardState((state) => state.titleId);
+		const setTitleId = useCardState((state) => state.setTitleId);
+
+		React.useEffect(() => {
+			setTitleId(props.id);
+		}, [props.id, setTitleId]);
+
+		return (
+			<Role.h2
+				id={titleId}
+				{...props}
+				className={cx("🥝CardTitle", props.className)}
+				ref={forwardedRef}
+			/>
+		);
+	},
+);
+DEV: CardTitle.displayName = "Card.Title";
+
+// ----------------------------------------------------------------------------
+
+interface CardBodyProps extends BaseProps<"div"> {}
+
+/**
+ * `Card.Body` contains the main content of the Card.
+ */
+const CardBody = forwardRef<"div", CardBodyProps>(
+	function CardBody(props, forwardedRef) {
+		return (
+			<Role.div
+				{...props}
+				className={cx("🥝CardBody", props.className)}
+				ref={forwardedRef}
+			/>
+		);
+	},
+);
+DEV: CardBody.displayName = "Card.Body";
+
+// ----------------------------------------------------------------------------
+
+export { CardRoot as Root, CardTitle as Title, CardBody as Body };

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -6,6 +6,7 @@
 
 export * as unstable_AccordionItem from "./AccordionItem.js";
 export { default as unstable_Banner } from "./Banner.js";
+export * as unstable_Card from "./Card.js";
 export { default as Chip } from "./Chip.js";
 export * as unstable_Dialog from "./Dialog.js";
 export * as DropdownMenu from "./DropdownMenu.js";

--- a/packages/structures/src/styles.css
+++ b/packages/structures/src/styles.css
@@ -7,6 +7,7 @@
 
 @import "./AccordionItem.css" layer(itwinui.components);
 @import "./Banner.css" layer(itwinui.components);
+@import "./Card.css" layer(itwinui.components);
 @import "./Chip.css" layer(itwinui.components);
 @import "./Dialog.css" layer(itwinui.components);
 @import "./DropdownMenu.css" layer(itwinui.components);


### PR DESCRIPTION
**WIP**.

Adds `unstable_Card` component.

<details>
<summary>TODOs</summary>

- [ ] Min/max widths are currently hardcoded
- [ ] Interactive (link) variant is missing
- [ ] Tests

</details>

### Public API

Subcomponents:
- `Card.Root`: renders `role="group"` with `aria-labelledby` pointing to the `<h2>` inside.
- `Card.Title`: renders `<h2>` with auto-generated or externally-specified id.
- `Card.Body`: presentational container.

Example:

```jsx
<Card.Root>
  <Card.Title>The subject</Card.Title>
  <Card.Body>
    <Text variant="body-sm">A description of the subject</Text>
 </Card.Body>
</Card.Root>
```

### Preview

[Demo page](https://supreme-barnacle-pl8jn8m.pages.github.io/937/tests/card)

<img width="453" height="221" alt="Screenshot showing a basic Card with the title Kiwi and a description of Kiwifruit" src="https://github.com/user-attachments/assets/c7d25cc5-608e-4b78-8d69-aa12d6e9bbaf" />