### PR TITLE
Explicitly set `Avatar`'s icon color

### DIFF
--- a/.changeset/curly-drinks-follow.md
+++ b/.changeset/curly-drinks-follow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Explicitly set the avatar's icon color to prevent accidentally inheritting the wrong color.

--- a/packages/bricks/src/Avatar.css
+++ b/packages/bricks/src/Avatar.css
@@ -7,6 +7,7 @@
 
 	@layer base {
 		--🥝Avatar-background-color: var(--stratakit-color-bg-mono-base);
+		--🥝Icon-color: var(--stratakit-color-icon-neutral-emphasis);
 
 		block-size: var(--🥝Avatar-size);
 		inline-size: var(--🥝Avatar-size);


### PR DESCRIPTION
In the `<NavigationRail>`, `.🥝NavigationRailItemAction` defines the `--🥝Icon-color`.  This causes the `<Avatar>` to inherit the wrong icon color.  This PR explicitly sets the avatar's icon fill color similar to how it already sets the font color.  To test, try setting `--🥝Icon-color` or `color` on the parent element. Closes #936.

| Before | After |
| --- | --- |
| <img width="118" height="175" alt="Screenshot 2025-09-05 at 9 19 07 AM" src="https://github.com/user-attachments/assets/5f733756-8918-444d-a28e-25c91e3932a3" /> | <img width="118" height="175" alt="Screenshot 2025-09-05 at 9 19 00 AM" src="https://github.com/user-attachments/assets/94d7c771-d0b4-407e-b18a-8d3a6a9d9b2a" /> |