### PR TITLE
print deprecation warning for `<Anchor tone="critical">`

### DIFF
--- a/.changeset/green-wombats-move.md
+++ b/.changeset/green-wombats-move.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+The `"critical"` tone value for `Anchor` has been deprecated and will be removed in a future release.

--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -16,7 +16,7 @@ import type {
 
 interface AnchorRootProps extends FocusableProps<"a"> {
 	/** @default "neutral" */
-	tone?: "neutral" | "accent" | "critical";
+	tone?: "neutral" | "accent" | (string & {});
 }
 
 /**
@@ -40,6 +40,12 @@ interface AnchorRootProps extends FocusableProps<"a"> {
  */
 const AnchorRoot = forwardRef<"a", AnchorRootProps>((props, forwardedRef) => {
 	const { tone = "neutral", ...rest } = props;
+
+	DEV: if (tone === "critical")
+		console.warn(
+			"The `critical` tone for `Anchor` has been deprecated and will be removed in a future release.",
+		);
+
 	return (
 		<Role.a
 			{...rest}
@@ -115,10 +121,9 @@ DEV: AnchorExternalMarker.displayName = "Anchor.ExternalMarker";
 
 // ----------------------------------------------------------------------------
 
-interface AnchorProps extends FocusableProps<"a"> {
-	/** @default "neutral" */
-	tone?: "neutral" | "accent" | "critical";
-}
+interface AnchorProps
+	extends FocusableProps<"a">,
+		Pick<AnchorRootProps, "tone"> {}
 
 /**
  * A styled anchor element, typically used for navigating to a different location.


### PR DESCRIPTION
In a recent update to the Figma library, the critical tone was removed from the Anchor component.

This PR simply prints a deprecation warning so that we can release it in a patch. In a future PR (slated for a _minor_ release), we can remove it fully.

### TypeScript changes

The types have been adjusted to remove `"critical"` from autocomplete, while not producing an error yet. This does allow invalid values, but should be ok for a temporary solution.

I also noticed a bit of duplication across `AnchorRootProps` and `AnchorProps`, which I fixed by using `Pick`.

**Note:** I did try using a discriminated union to only add `@deprecated` to `tone="critical"`, however this is not effective, as VSCode simply ignores it (see [screenshot](https://github.com/user-attachments/assets/551f8188-a740-442e-9642-c9d4236569c2)). 
