### PR TITLE
Move icon styles

### DIFF
--- a/packages/bricks/src/styles.css
+++ b/packages/bricks/src/styles.css
@@ -6,6 +6,7 @@
 @import "./VisuallyHidden.css" layer(itwinui.components);
 @import "./~utils.Dot.css" layer(itwinui.components);
 @import "./~utils.GhostAligner.css" layer(itwinui.components);
+@import "./~utils.icons.css" layer(itwinui.components);
 
 @import "./Anchor.css" layer(itwinui.components);
 @import "./Avatar.css" layer(itwinui.components);

--- a/packages/bricks/src/~utils.icons.css
+++ b/packages/bricks/src/~utils.icons.css
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+.🥝DisclosureArrow {
+	@layer base {
+		margin-inline-end: calc(var(--stratakit-space-x2) * -1);
+		rotate: var(--🥝DisclosureArrow-rotate);
+
+		@media (prefers-reduced-motion: no-preference) {
+			transition: rotate 150ms ease-in-out;
+		}
+	}
+}

--- a/packages/foundations/src/Icon.css
+++ b/packages/foundations/src/Icon.css
@@ -22,27 +22,6 @@
 	}
 }
 
-.🥝DisclosureArrow {
-	@layer base {
-		margin-inline-end: calc(var(--stratakit-space-x2) * -1);
-		rotate: var(--🥝DisclosureArrow-rotate);
-
-		@media (prefers-reduced-motion: no-preference) {
-			transition: rotate 150ms ease-in-out;
-		}
-	}
-}
-
-.🥝ChevronDown {
-	@layer base {
-		rotate: var(--🥝ChevronDown-rotate);
-
-		@media (prefers-reduced-motion: no-preference) {
-			transition: rotate 150ms ease-in-out;
-		}
-	}
-}
-
 @media (forced-colors: active) {
 	.🥝Icon {
 		--🥝Icon-color: currentColor;

--- a/packages/structures/src/styles.css
+++ b/packages/structures/src/styles.css
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 @import "./~utils.ListItem.css" layer(itwinui.components);
+@import "./~utils.icons.css" layer(itwinui.components);
 
 @import "./AccordionItem.css" layer(itwinui.components);
 @import "./Banner.css" layer(itwinui.components);

--- a/packages/structures/src/~utils.icons.css
+++ b/packages/structures/src/~utils.icons.css
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+.🥝ChevronDown {
+	@layer base {
+		rotate: var(--🥝ChevronDown-rotate);
+
+		@media (prefers-reduced-motion: no-preference) {
+			transition: rotate 150ms ease-in-out;
+		}
+	}
+}


### PR DESCRIPTION
Move `DisclosureArrow` and `ChevronDown` styles closer to the respective components. Based on https://github.com/iTwin/design-system/pull/933#discussion_r2334731609