### PR TITLE
`Tabs`: change `selectOnMove` default to `false`

### DIFF
--- a/.changeset/cruel-glasses-stay.md
+++ b/.changeset/cruel-glasses-stay.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Changed the default value of `Tabs.Provider`'s `selectOnMove` prop to `false`.

--- a/apps/test-app/app/tests/tabs/index.spec.ts
+++ b/apps/test-app/app/tests/tabs/index.spec.ts
@@ -36,6 +36,12 @@ test("default", async ({ page }) => {
 
 	await page.keyboard.press("ArrowRight");
 	await expect(tab1).toHaveAttribute("aria-selected", "false");
+	await expect(tab2).toHaveAttribute("aria-selected", "true");
+	await expect(tab3).toBeFocused(); // focus moves but selection does not change
+	await expect(tab3).toHaveAttribute("aria-selected", "false");
+
+	await page.keyboard.press("Enter");
+	await expect(tab1).toHaveAttribute("aria-selected", "false");
 	await expect(tab2).toHaveAttribute("aria-selected", "false");
 	await expect(tab3).toHaveAttribute("aria-selected", "true");
 

--- a/packages/compat/src/Tabs.tsx
+++ b/packages/compat/src/Tabs.tsx
@@ -262,7 +262,7 @@ const Wrapper = React.forwardRef((props, forwardedRef) => {
 		<SkTabs.Provider
 			defaultSelectedId={defaultSelectedId}
 			selectedId={selectedId}
-			selectOnMove={focusActivationMode === "manual" ? false : undefined}
+			selectOnMove={focusActivationMode !== "manual"}
 			setSelectedId={setSelectedId}
 		>
 			<WrapperContext.Provider

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -35,7 +35,10 @@ interface TabsProviderProps
 		| "setSelectedId"
 		| "selectOnMove"
 		| "children"
-	> {}
+	> {
+	/** @default false */
+	selectOnMove?: AkTab.TabProviderProps["selectOnMove"];
+}
 
 /**
  * A set of tabs that can be used to switch between different views.
@@ -70,7 +73,7 @@ function TabsProvider(props: TabsProviderProps) {
 		defaultSelectedId,
 		selectedId,
 		setSelectedId,
-		selectOnMove,
+		selectOnMove = false,
 		children,
 	} = props;
 


### PR DESCRIPTION
[`selectOnMove`](https://ariakit.org/reference/tab-provider#selectonmove) is now set to `false` by default.

This change is intended to improve the user experience, giving the user more control over when they want to actually switch tabs. This is especially important on complicated views, where the panel might take some time to load. Sometimes the user just wants to skip over to the next tab without activating any tabs in between.

As a side effect, the behavior is now also more predictable when any of the tabs are disabled (and therefore cannot be activated).

Related reading: [Deciding When to Make Selection Automatically Follow Focus](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#decidingwhentomakeselectionautomaticallyfollowfocus).

> If displaying a new panel causes a network request and possibly a page refresh, the effect of having selection automatically focus can be devastating to the experience for keyboard and screen reader users.