### PR TITLE
`IconButton`: use `aria-current` when rendered as an `active` link

### DIFF
--- a/.changeset/clear-tools-tap.md
+++ b/.changeset/clear-tools-tap.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Fixed `IconButton` active state semantics. It will now use `aria-current` instead of `aria-pressed` when rendered as an anchor.

--- a/apps/test-app/app/tests/icon-button/index.spec.ts
+++ b/apps/test-app/app/tests/icon-button/index.spec.ts
@@ -41,6 +41,14 @@ test("dot", async ({ page }) => {
 	);
 });
 
+test("active link", async ({ page }) => {
+	await page.goto("/tests/icon-button?_activeLink=true");
+
+	const link = page.getByRole("link", { name: "Click me" });
+	await expect(link).toHaveAttribute("aria-current", "true");
+	await expect(link).not.toHaveAttribute("aria-pressed");
+});
+
 test.describe("@visual", () => {
 	test("default", async ({ page }) => {
 		await page.goto("/tests/icon-button?visual=true");
@@ -65,14 +73,18 @@ test.describe("@visual", () => {
 });
 
 test.describe("@a11y", () => {
-	test("Axe Page Scan", async ({ page }) => {
-		await page.goto("/tests/icon-button");
+	const paramsSet = new Set([
+		new URLSearchParams(),
+		new URLSearchParams("?_activeLink"),
+	]);
 
-		const button = page.getByRole("button");
-		await expect(button).toBeVisible();
+	for (const params of paramsSet) {
+		test(`Axe Page Scan: ?${params}`, async ({ page }) => {
+			await page.goto(`/tests/icon-button?${params}`);
 
-		const axe = new AxeBuilder({ page });
-		const accessibilityScan = await axe.analyze();
-		expect(accessibilityScan.violations).toEqual([]);
-	});
+			const axe = new AxeBuilder({ page });
+			const accessibilityScan = await axe.analyze();
+			expect(accessibilityScan.violations).toEqual([]);
+		});
+	}
 });

--- a/apps/test-app/app/tests/icon-button/index.tsx
+++ b/apps/test-app/app/tests/icon-button/index.tsx
@@ -26,6 +26,7 @@ export default definePage(
 		visual: VisualTest,
 		customIcon: CustomIconTest,
 		dot: DotTest,
+		_activeLink: ActiveLinkTest,
 	},
 );
 
@@ -98,6 +99,17 @@ function DotTest() {
 			label="Notifications"
 			dot="You have unread notifications"
 			icon={notificationsIcon}
+		/>
+	);
+}
+
+function ActiveLinkTest() {
+	return (
+		<IconButton
+			icon={placeholderIcon}
+			label="Click me"
+			render={<a href="#" />}
+			active
 		/>
 	);
 }

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -353,7 +353,7 @@
 		border: 1px solid ButtonBorder;
 		color: ButtonText;
 
-		&:where([aria-pressed="true"]) {
+		&:where([aria-pressed="true"], [aria-current]:not([aria-current="false"])) {
 			background-color: SelectedItem;
 			color: SelectedItemText;
 		}

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -323,7 +323,7 @@
 			--🌀Button-state: var(--🌀Button-state--pressed);
 		}
 
-		&:where([aria-pressed="true"]) {
+		&:where([aria-pressed="true"], [aria-current]:not([aria-current="false"])) {
 			--🌀Button-state: var(--🌀Button-state--active);
 		}
 

--- a/packages/bricks/src/IconButton.tsx
+++ b/packages/bricks/src/IconButton.tsx
@@ -5,7 +5,10 @@
 
 import * as React from "react";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import {
+	forwardRef,
+	useMergedRefs,
+} from "@stratakit/foundations/secret-internals";
 import { Dot } from "./~utils.Dot.js";
 import Button from "./Button.js";
 import {
@@ -58,11 +61,14 @@ interface IconButtonProps
 	/**
 	 * Whether the button is in a toggled state and currently "active" (toggled on).
 	 *
-	 * Setting this prop to `true` or `false` will turn this button into a toggle button.
+	 * For regular buttons, setting this prop to `true` or `false` will turn this button into a toggle button.
 	 * The button will have an `aria-pressed` attribute and extra styling for the "active" state.
 	 * When this prop is `undefined`, the button will be a regular button (no `aria-pressed` attribute).
 	 *
+	 * When the button is rendered as an anchor (`<a>`), this prop maps to `aria-current` instead of `aria-pressed`.
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed
+	 * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current
 	 *
 	 * @default undefined
 	 */
@@ -123,15 +129,28 @@ const IconButton = forwardRef<"button", IconButtonProps>(
 
 		const { iconSize } = React.useContext(IconButtonContext);
 
+		const [elementType, setElementType] = React.useState<
+			"button" | "a" | undefined
+		>(!props.render ? "button" : undefined);
+
+		const determineTagName = React.useCallback(
+			(element: HTMLElement | null) => {
+				if (!element) return;
+				setElementType(element.tagName.toLowerCase() === "a" ? "a" : "button");
+			},
+			[],
+		);
+
 		const button = (
 			<IconButtonPresentation
 				render={
 					<Button
-						aria-pressed={active}
+						aria-pressed={elementType === "button" ? active : undefined}
+						aria-current={elementType === "a" ? active : undefined}
 						aria-labelledby={labelId}
 						aria-describedby={dot ? dotId : undefined}
 						{...rest}
-						ref={forwardedRef}
+						ref={useMergedRefs(determineTagName, forwardedRef)}
 					>
 						<VisuallyHidden id={labelId}>{label}</VisuallyHidden>
 


### PR DESCRIPTION
This fixes an edge case for when `<IconButton active>` is `render`ed as an anchor. Since [`aria-pressed`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) is only valid on buttons, we can instead use [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) for anchors.

Input:
```jsx
<IconButton render={<a href={…} />} active />
```
Output:
```html
<a href="…" aria-current="true">
```

Note: This required a bit of runtime checking, because it is not possible to introspect the `render` prop reliably.

---

[Deploy preview](https://itwin.github.io/design-system/955/tests/icon-button?_activeLink)