### PR TITLE
`IconButton`: remove deprecated `isActive` prop

### DIFF
--- a/.changeset/chatty-beans-sink.md
+++ b/.changeset/chatty-beans-sink.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": minor
+---
+
+Removed `isActive` from `IconButton` component. This has been replaced by the `active` prop.

--- a/apps/test-app/app/tests/icon-button/index.tsx
+++ b/apps/test-app/app/tests/icon-button/index.tsx
@@ -60,7 +60,7 @@ function VisualTest({ tooltip: showTooltip = false }) {
 						variant={variant}
 						label="Click me"
 						icon={placeholderIcon}
-						isActive
+						active
 					/>
 					<IconButton
 						variant={variant}

--- a/packages/bricks/src/IconButton.tsx
+++ b/packages/bricks/src/IconButton.tsx
@@ -73,10 +73,6 @@ interface IconButtonProps
 	 * @default undefined
 	 */
 	active?: boolean;
-	/**
-	 * @deprecated Use `active` instead.
-	 */
-	isActive?: boolean;
 }
 
 /**
@@ -113,15 +109,7 @@ interface IconButtonProps
  */
 const IconButton = forwardRef<"button", IconButtonProps>(
 	(props, forwardedRef) => {
-		const {
-			label,
-			icon,
-			isActive,
-			active = isActive,
-			labelVariant,
-			dot,
-			...rest
-		} = props;
+		const { label, icon, active, labelVariant, dot, ...rest } = props;
 
 		const baseId = React.useId();
 		const labelId = `${baseId}-label`;


### PR DESCRIPTION
Follow-up to https://github.com/iTwin/design-system/pull/926. Removes the deprecated `isActive` prop altogether.