### PR TITLE
internal: define `__VERSION__` constant

### DIFF
--- a/apps/test-app/vite.config.ts
+++ b/apps/test-app/vite.config.ts
@@ -78,6 +78,9 @@ export default defineConfig({
 			conditions: [customConditions, defaultServerConditions].flat(),
 		},
 	},
+	define: {
+		__VERSION__: `"development"`,
+	},
 });
 
 /** Vite plugin that bundles "*.css?inline" files using lightningcss. Only used during dev. */

--- a/packages/bricks/scripts/build.js
+++ b/packages/bricks/scripts/build.js
@@ -10,6 +10,8 @@ import {
 	reactCompilerPlugin,
 } from "internal/esbuild-plugins.js";
 
+import meta from "../package.json" with { type: "json" };
+
 const isDev = process.env.NODE_ENV === "development";
 
 const entryPoints = await fg("src/**/*.{ts,tsx}", {
@@ -26,6 +28,9 @@ await esbuild.build({
 	format: "esm",
 	jsx: "automatic",
 	target: "es2021",
+	define: {
+		__VERSION__: `"${meta.version}"`,
+	},
 	...(!isDev && { dropLabels: ["DEV"] }),
 });
 

--- a/packages/bricks/types.d.ts
+++ b/packages/bricks/types.d.ts
@@ -6,3 +6,5 @@ declare module "*.css?inline" {
 	const content: string;
 	export default content;
 }
+
+declare const __VERSION__: string;

--- a/packages/compat/scripts/build.js
+++ b/packages/compat/scripts/build.js
@@ -7,6 +7,8 @@ import * as esbuild from "esbuild";
 import fg from "fast-glob";
 import { reactCompilerPlugin } from "internal/esbuild-plugins.js";
 
+import meta from "../package.json" with { type: "json" };
+
 const isDev = process.env.NODE_ENV === "development";
 
 const entryPoints = await fg("src/**/*.{ts,tsx}", {
@@ -23,6 +25,9 @@ await esbuild.build({
 	format: "esm",
 	jsx: "automatic",
 	target: "es2021",
+	define: {
+		__VERSION__: `"${meta.version}"`,
+	},
 	...(!isDev && { dropLabels: ["DEV"] }),
 });
 

--- a/packages/foundations/scripts/build.js
+++ b/packages/foundations/scripts/build.js
@@ -10,6 +10,8 @@ import {
 	reactCompilerPlugin,
 } from "internal/esbuild-plugins.js";
 
+import meta from "../package.json" with { type: "json" };
+
 const isDev = process.env.NODE_ENV === "development";
 
 const entryPoints = await fg("src/**/*.{ts,tsx}", {
@@ -26,6 +28,9 @@ await esbuild.build({
 	format: "esm",
 	jsx: "automatic",
 	target: "es2021",
+	define: {
+		__VERSION__: `"${meta.version}"`,
+	},
 	dropLabels: ["DROP", ...(isDev ? ["DEV"] : [])],
 });
 

--- a/packages/foundations/types.d.ts
+++ b/packages/foundations/types.d.ts
@@ -6,3 +6,5 @@ declare module "*.css?inline" {
 	const content: string;
 	export default content;
 }
+
+declare const __VERSION__: string;

--- a/packages/structures/scripts/build.js
+++ b/packages/structures/scripts/build.js
@@ -10,6 +10,8 @@ import {
 	reactCompilerPlugin,
 } from "internal/esbuild-plugins.js";
 
+import meta from "../package.json" with { type: "json" };
+
 const isDev = process.env.NODE_ENV === "development";
 
 const entryPoints = await fg("src/**/*.{ts,tsx}", {
@@ -26,6 +28,9 @@ await esbuild.build({
 	format: "esm",
 	jsx: "automatic",
 	target: "es2021",
+	define: {
+		__VERSION__: `"${meta.version}"`,
+	},
 	...(!isDev && { dropLabels: ["DEV"] }),
 });
 

--- a/packages/structures/types.d.ts
+++ b/packages/structures/types.d.ts
@@ -6,3 +6,5 @@ declare module "*.css?inline" {
 	const content: string;
 	export default content;
 }
+
+declare const __VERSION__: string;


### PR DESCRIPTION
This PR defines a global `__VERSION__` constant for use in our packages.
- Prod build: uses esbuild's [`define`](https://esbuild.github.io/api/#define) feature to replace it with the `version` from `package.json`.
- Dev server: uses vite's [`define`](https://vite.dev/config/shared-options#define) feature to replace it with `"development"`.