### PR TITLE
`NavigationRail`: allow controlling expanded state

### DIFF
--- a/.changeset/sharp-seas-bow.md
+++ b/.changeset/sharp-seas-bow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Added `expanded` and `setExpanded` props to `unstable_NavigationRail` for controlling the expanded/collapsed state.

--- a/.changeset/twelve-paths-yawn.md
+++ b/.changeset/twelve-paths-yawn.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Added `defaultExpanded` prop to `unstable_NavigationRail` for specifying the initial expanded/collapsed state.

--- a/apps/test-app/app/tests/navigation-rail/index.spec.ts
+++ b/apps/test-app/app/tests/navigation-rail/index.spec.ts
@@ -19,12 +19,29 @@ test.describe("expansion", () => {
 			const params = type === "controlled" ? "?_controlled" : "";
 			await page.goto(`/tests/navigation-rail${params}`);
 
-			const toggleButton = page.getByRole("button", { name: "Expand" });
-			await expect(toggleButton).toHaveAccessibleName("Expand navigation");
+			let consoleText = "";
+			page.on("console", (msg) => {
+				consoleText += `${msg.text()}\n`;
+			});
+			expect(consoleText).not.toContain("setExpanded");
+
+			const toggleButton = page.getByRole("button", {
+				name: "Expand navigation",
+				exact: true,
+			});
 			await expect(toggleButton).toHaveAttribute("aria-expanded", "false");
 
+			// Expand
 			await toggleButton.click();
 			await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+			if (type === "controlled")
+				expect(consoleText).toContain("setExpanded: true");
+
+			// Collapse
+			await toggleButton.click();
+			await expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+			if (type === "controlled")
+				expect(consoleText).toContain("setExpanded: false");
 		});
 
 		test(`defaultExpanded (${type})`, async ({ page }) => {
@@ -32,7 +49,10 @@ test.describe("expansion", () => {
 			if (type === "controlled") params += "&_controlled";
 			await page.goto(`/tests/navigation-rail${params}`);
 
-			const toggleButton = page.getByRole("button", { name: "Expand" });
+			const toggleButton = page.getByRole("button", {
+				name: "Expand navigation",
+				exact: true,
+			});
 			await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
 		});
 	}

--- a/apps/test-app/app/tests/navigation-rail/index.spec.ts
+++ b/apps/test-app/app/tests/navigation-rail/index.spec.ts
@@ -13,15 +13,29 @@ test("default", async ({ page }) => {
 	await expect(navigationRail).toBeVisible();
 });
 
-test("expansion", async ({ page }) => {
-	await page.goto("/tests/navigation-rail");
+test.describe("expansion", () => {
+	for (const type of ["uncontrolled", "controlled"] as const) {
+		test(`expansion (${type})`, async ({ page }) => {
+			const params = type === "controlled" ? "?_controlled" : "";
+			await page.goto(`/tests/navigation-rail${params}`);
 
-	const toggleButton = page.getByRole("button", { name: "Expand" });
-	await expect(toggleButton).toHaveAccessibleName("Expand navigation");
-	await expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+			const toggleButton = page.getByRole("button", { name: "Expand" });
+			await expect(toggleButton).toHaveAccessibleName("Expand navigation");
+			await expect(toggleButton).toHaveAttribute("aria-expanded", "false");
 
-	await toggleButton.click();
-	await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+			await toggleButton.click();
+			await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+		});
+
+		test(`defaultExpanded (${type})`, async ({ page }) => {
+			let params = "?defaultExpanded";
+			if (type === "controlled") params += "&_controlled";
+			await page.goto(`/tests/navigation-rail${params}`);
+
+			const toggleButton = page.getByRole("button", { name: "Expand" });
+			await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+		});
+	}
 });
 
 test.describe("@visual", () => {

--- a/apps/test-app/app/tests/navigation-rail/index.tsx
+++ b/apps/test-app/app/tests/navigation-rail/index.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { Avatar, Divider } from "@stratakit/bricks";
 import { Icon } from "@stratakit/foundations";
 import { unstable_NavigationRail as NavigationRail } from "@stratakit/structures";
-import { definePage } from "~/~utils.tsx";
+import { definePage, type VariantProps } from "~/~utils.tsx";
 
 import bentleyIcon from "@stratakit/icons/bentley-systems.svg";
 import helpIcon from "@stratakit/icons/help.svg";
@@ -47,11 +47,11 @@ const exampleNavItems = {
 // ----------------------------------------------------------------------------
 
 export default definePage(
-	function Page() {
+	function Page({ defaultExpanded }: VariantProps) {
 		const [active, setActive] = React.useState("administration");
 
 		return (
-			<NavigationRail.Root>
+			<NavigationRail.Root defaultExpanded={!!defaultExpanded}>
 				<NavigationRail.Header>
 					<Icon
 						alt="Acme app"
@@ -117,7 +117,7 @@ export default definePage(
 			</NavigationRail.Root>
 		);
 	},
-	{ visual: VisualTest },
+	{ visual: VisualTest, _controlled: ControlledState },
 );
 
 function VisualTest() {
@@ -165,6 +165,45 @@ function VisualTest() {
 						</NavigationRail.ListItem>
 					</NavigationRail.List>
 				</NavigationRail.Footer>
+			</NavigationRail.Content>
+		</NavigationRail.Root>
+	);
+}
+
+function ControlledState({ defaultExpanded }: VariantProps) {
+	const [expanded, setExpanded] = React.useState(!!defaultExpanded);
+
+	return (
+		<NavigationRail.Root expanded={expanded} setExpanded={setExpanded}>
+			<NavigationRail.Header>
+				<Icon alt="Acme app" href={`${bentleyIcon}#icon-large`} size="large" />
+				<NavigationRail.ToggleButton />
+			</NavigationRail.Header>
+			<NavigationRail.Content>
+				<NavigationRail.List>
+					<NavigationRail.ListItem>
+						<NavigationRail.Anchor
+							href="#"
+							icon={placeholderIcon}
+							label="Item #1"
+							active
+						/>
+					</NavigationRail.ListItem>
+					<NavigationRail.ListItem>
+						<NavigationRail.Anchor
+							href="#"
+							icon={placeholderIcon}
+							label="Item #2"
+						/>
+					</NavigationRail.ListItem>
+					<NavigationRail.ListItem>
+						<NavigationRail.Anchor
+							href="#"
+							icon={placeholderIcon}
+							label="Item #3"
+						/>
+					</NavigationRail.ListItem>
+				</NavigationRail.List>
 			</NavigationRail.Content>
 		</NavigationRail.Root>
 	);

--- a/apps/test-app/app/tests/navigation-rail/index.tsx
+++ b/apps/test-app/app/tests/navigation-rail/index.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from "react";
-import { Avatar, Divider } from "@stratakit/bricks";
+import { Avatar, Button, Divider, Text } from "@stratakit/bricks";
 import { Icon } from "@stratakit/foundations";
 import { unstable_NavigationRail as NavigationRail } from "@stratakit/structures";
 import { definePage, type VariantProps } from "~/~utils.tsx";
@@ -174,43 +174,69 @@ function ControlledState({ defaultExpanded }: VariantProps) {
 	const [expanded, setExpanded] = React.useState(!!defaultExpanded);
 
 	return (
-		<NavigationRail.Root
-			expanded={expanded}
-			setExpanded={(expanded) => {
-				setExpanded(expanded);
-				console.log(`setExpanded: ${expanded}`);
+		<div
+			style={{
+				display: "flex",
+				gap: 16,
+				alignItems: "stretch",
+				blockSize: "100%",
 			}}
 		>
-			<NavigationRail.Header>
-				<Icon alt="Acme app" href={`${bentleyIcon}#icon-large`} size="large" />
-				<NavigationRail.ToggleButton />
-			</NavigationRail.Header>
-			<NavigationRail.Content>
-				<NavigationRail.List>
-					<NavigationRail.ListItem>
-						<NavigationRail.Anchor
-							href="#"
-							icon={placeholderIcon}
-							label="Item #1"
-							active
-						/>
-					</NavigationRail.ListItem>
-					<NavigationRail.ListItem>
-						<NavigationRail.Anchor
-							href="#"
-							icon={placeholderIcon}
-							label="Item #2"
-						/>
-					</NavigationRail.ListItem>
-					<NavigationRail.ListItem>
-						<NavigationRail.Anchor
-							href="#"
-							icon={placeholderIcon}
-							label="Item #3"
-						/>
-					</NavigationRail.ListItem>
-				</NavigationRail.List>
-			</NavigationRail.Content>
-		</NavigationRail.Root>
+			<NavigationRail.Root
+				expanded={expanded}
+				setExpanded={(expanded) => {
+					setExpanded(expanded);
+					console.log(`setExpanded: ${expanded}`);
+				}}
+			>
+				<NavigationRail.Header>
+					<Icon
+						alt="Acme app"
+						href={`${bentleyIcon}#icon-large`}
+						size="large"
+					/>
+					<NavigationRail.ToggleButton />
+				</NavigationRail.Header>
+				<NavigationRail.Content>
+					<NavigationRail.List>
+						<NavigationRail.ListItem>
+							<NavigationRail.Anchor
+								href="#"
+								icon={placeholderIcon}
+								label="Item #1"
+								active
+							/>
+						</NavigationRail.ListItem>
+						<NavigationRail.ListItem>
+							<NavigationRail.Anchor
+								href="#"
+								icon={placeholderIcon}
+								label="Item #2"
+							/>
+						</NavigationRail.ListItem>
+						<NavigationRail.ListItem>
+							<NavigationRail.Anchor
+								href="#"
+								icon={placeholderIcon}
+								label="Item #3"
+							/>
+						</NavigationRail.ListItem>
+					</NavigationRail.List>
+				</NavigationRail.Content>
+			</NavigationRail.Root>
+
+			<article style={{ padding: 16 }}>
+				<Text variant="headline-sm" render={<h2 />}>
+					Control panel
+				</Text>
+
+				<div style={{ display: "grid", gap: 8, marginBlockStart: 8 }}>
+					<Button onClick={() => setExpanded(true)}>Controlled expand</Button>
+					<Button onClick={() => setExpanded(false)}>
+						Controlled collapse
+					</Button>
+				</div>
+			</article>
+		</div>
 	);
 }

--- a/apps/test-app/app/tests/navigation-rail/index.tsx
+++ b/apps/test-app/app/tests/navigation-rail/index.tsx
@@ -174,7 +174,13 @@ function ControlledState({ defaultExpanded }: VariantProps) {
 	const [expanded, setExpanded] = React.useState(!!defaultExpanded);
 
 	return (
-		<NavigationRail.Root expanded={expanded} setExpanded={setExpanded}>
+		<NavigationRail.Root
+			expanded={expanded}
+			setExpanded={(expanded) => {
+				setExpanded(expanded);
+				console.log(`setExpanded: ${expanded}`);
+			}}
+		>
 			<NavigationRail.Header>
 				<Icon alt="Acme app" href={`${bentleyIcon}#icon-large`} size="large" />
 				<NavigationRail.ToggleButton />

--- a/packages/structures/src/NavigationRail.css
+++ b/packages/structures/src/NavigationRail.css
@@ -82,7 +82,7 @@
 		}
 
 		/* Should be floating above the right edge of the header during collapsed state */
-		:where(.🥝NavigationRailHeader[data-_sk-collapsed="true"]) & {
+		:where(.🥝NavigationRailHeader:not([data-_sk-expanded="true"])) & {
 			position: absolute;
 			inset-inline-end: 0;
 			translate: 50%;

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -190,7 +190,7 @@ const NavigationRailRootInner = forwardRef<"nav", NavigationRailRootInnerProps>(
 			<Role.nav
 				{...props}
 				className={cx("🥝NavigationRail", props.className)}
-				data-_sk-expanded={expanded ? "true" : "false"}
+				data-_sk-expanded={expanded ? "true" : undefined}
 				ref={forwardedRef}
 			/>
 		);
@@ -217,7 +217,7 @@ const NavigationRailHeader = forwardRef<"nav", NavigationRailHeaderProps>(
 			<Role.header
 				{...props}
 				className={cx("🥝NavigationRailHeader", props.className)}
-				data-_sk-collapsed={!expanded ? "true" : undefined}
+				data-_sk-expanded={expanded ? "true" : undefined}
 				ref={forwardedRef}
 			/>
 		);


### PR DESCRIPTION
### Summary

This PR exposes the "expanded/collapsed" state to consumers by adding three new props to `NavigationRail.Root`.

This addresses **two use cases**:
1. Persisting state across page reloads (only needs initial state)
2. Creating custom subcomponents that depend on expanded/collapsed state (e.g. _hiding custom labels_).

### Details

Added new props:

- Uncontrolled mode: `defaultExpanded`
- Controlled mode: `expanded` and `setExpanded`

I thought about `collapsed` vs `expanded` and decided to go with the latter, because the default state of the component is "collapsed" (When in doubt, boolean props should default to `false`). This required reversing the existing convention used internally.

Because `expanded` and `setExpanded` are meant to be used together, an error will be thrown when `expanded` is used without `setExpanded`. This ensures that the consumer is not discarding internal state changes. (**Note:** I believe we should do the same in other components, such as Tooltip and DropdownMenu)

### Preview

Uncontrolled mode: https://itwin.github.io/design-system/962/tests/navigation-rail?defaultExpanded
Controlled mode: https://itwin.github.io/design-system/962/tests/navigation-rail?_controlled 

### Discussion points

1. **Should it be `setExpanded` or `onExpandedChange`?** This is more than a bikeshed concern. `onExpandedChange` is a simple emitter, whereas `setExpanded` is necessarily tied to controlled state.
   
   The `onExpandedChange` use case can be approximated by passing `onClick` to `NavigationRail.ToggleButton`. However this assumes that there will not be any more ways to toggle internal state in the future (such as a keyboard shortcut or window resize).


2. Should we try to address the _"hiding custom labels" use case_ in a different way? There is an important accessibility consideration here: the label should remain in the accessibility tree even when it is hidden. This should maybe be handled automatically via something like `NavigationRail.ActionLabel`.

   Regardless of the API shape, we should probably document this use case with a clear example.

---

Interesting threads/comments:
- https://github.com/iTwin/design-system/pull/962#discussion_r2373615064
- https://github.com/iTwin/design-system/pull/962#discussion_r2395196287
- https://github.com/iTwin/design-system/pull/962#discussion_r2395010035