### PR TITLE
`Banner`: react to `tone` changes

### DIFF
--- a/.changeset/flat-forks-poke.md
+++ b/.changeset/flat-forks-poke.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fixed an issue where `unstable_Banner` would not track changes to the `tone` prop.

--- a/packages/structures/src/Banner.tsx
+++ b/packages/structures/src/Banner.tsx
@@ -46,10 +46,15 @@ function BannerProvider(
 		tone: NonNullable<BannerRootProps["tone"]>;
 	}>,
 ) {
-	const [store] = React.useState(() =>
-		createBannerStore({
-			tone: props.tone,
-		}),
+	const { tone } = props;
+
+	const [store] = React.useState(() => createBannerStore({ tone }));
+
+	React.useEffect(
+		function synchronizeWithProps() {
+			store.setState({ tone });
+		},
+		[store, tone],
 	);
 
 	return (


### PR DESCRIPTION
This fixes the issue noted in https://github.com/iTwin/design-system/pull/962#discussion_r2379430767 where `unstable_Banner`'s internal store was initialized with `props.tone` and then never updated.

<details><summary>Tested manually</summary>

```diff
diff --git a/apps/test-app/app/tests/banner/index.tsx b/apps/test-app/app/tests/banner/index.tsx
index 82aab84428..8c5863d81a 100644
--- a/apps/test-app/app/tests/banner/index.tsx
+++ b/apps/test-app/app/tests/banner/index.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import * as React from "react";
 import { Anchor, Button, VisuallyHidden } from "@stratakit/bricks";
 import { unstable_Banner as Banner } from "@stratakit/structures";
 import {
@@ -26,7 +27,15 @@ const dummyLongLabel =
 const tones = ["neutral", "info", "positive", "attention", "critical"] as const;
 
 export default definePage(
-	function Page({ icon, tone }) {
+	function Page({ icon }) {
+		const [tone, setTone] = React.useState("positive");
+
+		React.useEffect(() => {
+			setTimeout(() => {
+				setTone("info");
+			}, 2_000);
+		}, []);
+
 		return (
 			<Banner
 				className="my-banner"

```
</details> 