### PR TITLE
Remove `getLabelKey` util

### DIFF
--- a/apps/test-app/app/compat/tabs.tsx
+++ b/apps/test-app/app/compat/tabs.tsx
@@ -34,9 +34,9 @@ export default definePage(function Page() {
 
 			<Tabs
 				labels={[
-					<Tab key={1} label="Tab 1" />,
-					<Tab key={2} label="Tab 2" disabled />,
-					<Tab key={3} label="Tab 3" />,
+					<Tab key="tab-1" label="Tab 1" />,
+					<Tab key="tab-2" label="Tab 2" disabled />,
+					<Tab key="tab-3" label="Tab 3" />,
 				]}
 			>
 				Legacy Tab

--- a/packages/compat/src/Tabs.tsx
+++ b/packages/compat/src/Tabs.tsx
@@ -100,15 +100,14 @@ const LegacyTabs = React.forwardRef((props, forwardedRef) => {
 			focusActivationMode={focusActivationMode}
 		>
 			<TabList className={tabsClassName} ref={forwardedRef}>
-				{labels.map((label, index) => {
-					const key = getLabelKey(label, index);
+				{React.Children.map(labels, (label, index) => {
 					const tabValue = `${index}`;
 					return (
-						<LegacyTabProvider key={key} tabValue={tabValue}>
+						<LegacyTabProvider tabValue={tabValue}>
 							{typeof label === "string" ? <LegacyTab label={label} /> : label}
 						</LegacyTabProvider>
 					);
-				})}
+				}) ?? []}
 			</TabList>
 			<Panel value={value} className={contentClassName}>
 				{children}
@@ -117,18 +116,6 @@ const LegacyTabs = React.forwardRef((props, forwardedRef) => {
 	);
 }) as PolymorphicForwardRefComponent<"div", LegacyTabsProps>;
 DEV: LegacyTabs.displayName = "Tabs";
-
-function getLabelKey(label: React.ReactNode, index: number) {
-	if (typeof label === "string") {
-		return `${index}-${label}`;
-	}
-
-	if (React.isValidElement<React.ComponentProps<typeof Tab>>(label)) {
-		return `${index}-${label.key || ""}-${label.props.id || ""}`;
-	}
-
-	return `${index}`;
-}
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR replaces custom `getLabelKey` utility in favor of [`React.Children.map`](https://react.dev/reference/react/Children#children-map) based on https://github.com/iTwin/design-system/pull/851#discussion_r2293350925

Tested in `/compat/tabs` route of `test-app` by verifying the keys generated for `LegacyTabProvider` elements.