### PR TITLE
Print warning if `ErrorRegion` is not labelled

### DIFF
--- a/.changeset/four-garlics-send.md
+++ b/.changeset/four-garlics-send.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Log a warning in the console if `aria-label` or `aria-labelledby` is not provided for `ErrorRegion.Root` component.

--- a/apps/test-app/app/tests/error-region/index.tsx
+++ b/apps/test-app/app/tests/error-region/index.tsx
@@ -32,6 +32,7 @@ export default definePage(function Page({ items = 2, controls }) {
 				</Button>
 			) : undefined}
 			<ErrorRegion.Root
+				aria-label="Hierarchy issues"
 				label={label}
 				items={errors.map((error) => {
 					return (

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -32,7 +32,12 @@ import type { BaseProps } from "@stratakit/foundations/secret-internals";
 interface ErrorRegionRootProps extends Omit<BaseProps, "children"> {
 	/**
 	 * Label for the error header, usually indicating the number of errors displayed.
-	 * By default this is used as a name of the region navigational landmark, however an explicit `aria-label` or `aria-labelledby` is strongly suggested.
+	 *
+	 * Changes to the `label` prop will be announced communicated
+	 * using a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
+	 *
+	 * (deprecated behavior) By default this is used as a name of the region navigational landmark.
+	 * `aria-label` or `aria-labelledby` prop should be provided to explicitly label the region instead.
 	 *
 	 * Use `undefined` if you don't want to display errors rather than conditionally rendering the component.
 	 */
@@ -58,12 +63,12 @@ interface ErrorRegionRootProps extends Omit<BaseProps, "children"> {
  * component, such as `Tree`.
  *
  * This component is rendered as a [region landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/region.html)
- * and should be labelled either using `label` or `aria-label`/`aria-labelledby`. Changes to the `label` prop will be
- * announced communicated using a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
+ * and should be labelled using `aria-label` or `aria-labelledby`.
  *
  * Example:
  * ```tsx
  * <ErrorRegion.Root
+ *   aria-label="Issues"
  *   label="3 issues found"
  *   items={
  *     <>
@@ -89,6 +94,11 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 			: label
 				? labelId
 				: undefined;
+
+		DEV: if (!props["aria-label"] && !props["aria-labelledby"])
+			console.warn(
+				"`aria-label` or `aria-labelledby` prop is required for `ErrorRegion.Root` to set an accessible name of a region.",
+			);
 
 		const [open, setOpen] = useControlledState(
 			false,

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -33,7 +33,7 @@ interface ErrorRegionRootProps extends Omit<BaseProps, "children"> {
 	/**
 	 * Label for the error header, usually indicating the number of errors displayed.
 	 *
-	 * Changes to the `label` prop will be announced communicated
+	 * Changes to the `label` prop will be communicated
 	 * using a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
 	 *
 	 * (deprecated behavior) By default this is used as a name of the region navigational landmark.


### PR DESCRIPTION
Part of https://github.com/iTwin/design-system/issues/977 to log a warning if `aria-label` or `aria-labelledby` prop is not provided.

Consumers are expected to set `aria-label` or `aria-labelledby` to use the `<section>` element as a region landmark.
An upcoming breaking change will remove the warning, but require one of these props via type definitions.