### PR TITLE
Print warning if non-array `items` prop is used in `ErrorRegion`

### DIFF
--- a/.changeset/lovely-snails-relax.md
+++ b/.changeset/lovely-snails-relax.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Added `ReactNode[]` type support for `items` prop of `ErrorRegion.Root` component which is used to determine error region visibility. Previously supported `ReactNode` type is now deprecated and will be removed in a future release.

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -48,7 +48,7 @@ interface ErrorRegionRootProps extends Omit<BaseProps, "children"> {
 	 *
 	 * Set to `undefined` or empty array if you don't want to display errors rather than conditionally rendering the component.
 	 */
-	items?: React.ReactNode | React.ReactNode[];
+	items?: React.ReactNode;
 	/**
 	 * The controlled open state of the region.
 	 */

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -34,13 +34,16 @@ interface ErrorRegionRootProps extends Omit<BaseProps, "children"> {
 	 * Label for the error header, usually indicating the number of errors displayed.
 	 * By default this is used as a name of the region navigational landmark, however an explicit `aria-label` or `aria-labelledby` is strongly suggested.
 	 *
-	 * Use `undefined` if you don't want to display errors rather than conditionally rendering the component.
+	 * (deprecated behavior) Use `undefined` if you don't want to display errors rather than conditionally rendering the component.
+	 * Use `items` prop instead.
 	 */
 	label?: React.ReactNode;
 	/**
 	 * A list of error items where each item describes an individual error. Must be a list of `ErrorRegion.Item` components.
+	 *
+	 * Set to `undefined` or empty array if you don't want to display errors rather than conditionally rendering the component.
 	 */
-	items?: React.ReactNode;
+	items?: React.ReactNode | React.ReactNode[];
 	/**
 	 * The controlled open state of the region.
 	 */
@@ -61,24 +64,24 @@ interface ErrorRegionRootProps extends Omit<BaseProps, "children"> {
  * and should be labelled either using `label` or `aria-label`/`aria-labelledby`. Changes to the `label` prop will be
  * announced communicated using a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
  *
+ * This component should not be rendered conditionally, instead use the `items` prop to control the visibility.
+ *
  * Example:
  * ```tsx
  * <ErrorRegion.Root
  *   label="3 issues found"
- *   items={
- *     <>
- *       <ErrorRegion.Item message="…" />
- *       <ErrorRegion.Item message="…" />
- *       <ErrorRegion.Item message="…" />
- *     </>
- *   }
+ *   items={[
+ *     <ErrorRegion.Item key={…} message="…" />
+ *     <ErrorRegion.Item key={…} message="…" />
+ *     <ErrorRegion.Item key={…} message="…" />
+ *   ]}
  * />
  */
 const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 	(props, forwardedRef) => {
 		const {
 			label,
-			items,
+			items: itemsProp = [],
 			open: openProp,
 			setOpen: setOpenProp,
 			...rest
@@ -89,6 +92,13 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 			: label
 				? labelId
 				: undefined;
+
+		DEV: if (!Array.isArray(itemsProp))
+			console.warn(
+				"`items` prop of `ErrorRegion.Root` expects an array of React nodes. `ReactNode` support is deprecated and will be removed in a future release.",
+			);
+
+		const visible = Array.isArray(itemsProp) ? itemsProp.length > 0 : !!label;
 
 		const [open, setOpen] = useControlledState(
 			false,
@@ -157,7 +167,7 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 						aria-labelledby={sectionLabelledBy}
 						{...rest}
 						className={cx("🥝ErrorRegion", props.className)}
-						data-_sk-visible={!!label}
+						data-_sk-visible={visible}
 						data-_sk-expanded={open}
 						ref={forwardedRef}
 					>
@@ -191,7 +201,7 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 									className="🥝ErrorRegionItems"
 									role="list"
 								>
-									{items}
+									{itemsProp}
 								</Collection>
 							</Dialog>
 						</div>


### PR DESCRIPTION
Part of #977 to expand the `items` type temporarily in preparation to a breaking change, where `items` type is changed from `ReactNode` to `ReactNode[]`. Additionally, `items` prop is now used to determine visibility when an array is provided.
Warning is logged for existing consumers if non-array value is provided. 