### PR TITLE
fix circular import

### DIFF
--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -5,9 +5,9 @@
 
 import { Focusable } from "@ariakit/react/focusable";
 import { Role } from "@ariakit/react/role";
-import { VisuallyHidden } from "@stratakit/bricks";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import VisuallyHidden from "./VisuallyHidden.js";
 
 import type {
 	BaseProps,


### PR DESCRIPTION
`Anchor.tsx` was importing from `@stratakit/bricks`, leading to [this error](https://github.com/iTwin/design-system/actions/runs/18202952879/job/51826251612#step:6:57): 

> Export "default" of module "../../packages/bricks/dist/Anchor.js" was reexported through module "../../packages/bricks/dist/index.js" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.