### PR TITLE
`Anchor`: inherit font-size

### DIFF
--- a/.changeset/stupid-lies-relate.md
+++ b/.changeset/stupid-lies-relate.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+`Anchor` will now inherit the surrounding `font-size`.

--- a/apps/test-app/app/index.module.css
+++ b/apps/test-app/app/index.module.css
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 .main {
 	padding: var(--stratakit-space-x8);
+	font-size: var(--stratakit-font-size-14);
 }
 
 .list {

--- a/apps/test-app/app/index.tsx
+++ b/apps/test-app/app/index.tsx
@@ -21,7 +21,7 @@ export default function Index() {
 				<Text variant="display-md" render={<h1 />}>
 					StrataKit
 				</Text>
-				<Text variant="body-sm">
+				<Text variant="body-md">
 					The design system for building complex user interfaces.
 				</Text>
 			</hgroup>

--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -19,7 +19,6 @@
 
 	@layer base {
 		cursor: pointer;
-		font-size: var(--stratakit-font-size-12);
 		font-weight: 500;
 		text-underline-offset: var(--🌀Anchor-state--default, var(--stratakit-space-x05))
 			var(--🌀Anchor-state--hover, var(--stratakit-space-x1))


### PR DESCRIPTION
Removed hardcoded `font-size` from `Anchor`. It was causing undesirable results when the surrounding text is a different size ([example](https://github.com/iTwin/contextual-tree-control-react/pull/228#discussion_r2388227163)).

I've also updated the test-app home page to use `--stratakit-font-size-14` and verified that the links on that page are inheriting the larger size.