### PR TITLE
test-app: Fix tree `aria-posinset`

### DIFF
--- a/apps/test-app/app/tests/tree/index.tsx
+++ b/apps/test-app/app/tests/tree/index.tsx
@@ -115,7 +115,9 @@ export default definePage(
 						<Tree.Item
 							key={item.label}
 							aria-level={item.level}
-							aria-posinset={index + 1}
+							aria-posinset={
+								childIndex !== undefined ? childIndex + 1 : index + 1
+							}
 							aria-setsize={item.setSize}
 							label={item.label}
 							description={hasDescription ? description : undefined}


### PR DESCRIPTION
## Before

- Child items used `aria-posinset={index + 1}` where index was their parent's index.
- This meant "Item 1.1", "Item 1.2", "Item 1.3" all incorrectly had `aria-posinset={1}`.

## After

- Child items now use `aria-posinset={childIndex + 1}`.
- Parent items continue to use `aria-posinset={index + 1}`.
- This means:

| Item | `aria-posinset` value |
| --- | --- |
| Item 1.1 | `aria-posinset={1}` |
| Item 1.2 | `aria-posinset={2}` |
| Item 1.3 | `aria-posinset={3}` |
| Item 2.1 | `aria-posinset={1}` |