### PR TITLE
use React Compiler

### DIFF
--- a/.changeset/sweet-clocks-repair.md
+++ b/.changeset/sweet-clocks-repair.md
@@ -1,0 +1,8 @@
+---
+"@stratakit/foundations": patch
+"@stratakit/structures": patch
+"@stratakit/bricks": patch
+"@stratakit/react": patch
+---
+
+Enabled React Compiler for production build. In React 18 apps, `react-compiler-runtime` dependency will be used.

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -41,6 +41,7 @@
 		"lightningcss": "catalog:",
 		"typescript": "catalog:",
 		"vite": "^7.1.11",
+		"vite-plugin-babel": "^1.3.2",
 		"vite-plugin-devtools-json": "^1.0.0",
 		"vite-tsconfig-paths": "^5.1.4"
 	},

--- a/apps/test-app/vite.config.ts
+++ b/apps/test-app/vite.config.ts
@@ -10,6 +10,7 @@ import {
 	defaultServerConditions,
 	defineConfig,
 } from "vite";
+import babel from "vite-plugin-babel";
 import devtoolsJson from "vite-plugin-devtools-json";
 import tsconfigPaths from "vite-tsconfig-paths";
 import {
@@ -40,7 +41,19 @@ export const reactRouterConfig = {
 
 // https://vite.dev/config/
 export default defineConfig({
-	plugins: [reactRouter(), tsconfigPaths(), bundleCssPlugin(), devtoolsJson()],
+	plugins: [
+		reactRouter(),
+		babel({
+			filter: /\.[jt]sx?$/,
+			babelConfig: {
+				presets: ["@babel/preset-typescript"],
+				plugins: [["babel-plugin-react-compiler", {}]],
+			},
+		}),
+		tsconfigPaths(),
+		bundleCssPlugin(),
+		devtoolsJson(),
+	],
 	build: {
 		assetsInlineLimit: (filePath) => {
 			if (filePath.endsWith(".svg")) return false;

--- a/internal/package.json
+++ b/internal/package.json
@@ -7,9 +7,9 @@
 		"./*": "./*"
 	},
 	"dependencies": {
-		"colorjs.io": "^0.5.2"
-	},
-	"devDependencies": {
+		"@babel/core": "^7.28.4",
+		"babel-plugin-react-compiler": "~1.0.0",
+		"colorjs.io": "^0.5.2",
 		"lightningcss": "catalog:"
 	}
 }

--- a/packages/bricks/package.json
+++ b/packages/bricks/package.json
@@ -178,7 +178,8 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.19",
-		"classnames": "^2.5.1"
+		"classnames": "^2.5.1",
+		"react-compiler-runtime": "^1.0.0"
 	},
 	"devDependencies": {
 		"@stratakit/foundations": "workspace:*",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -48,7 +48,8 @@
 		"@itwin/itwinui-react": "^3.19.5",
 		"@stratakit/bricks": "^0.4.4",
 		"@stratakit/structures": "^0.4.4",
-		"classnames": "^2.5.1"
+		"classnames": "^2.5.1",
+		"react-compiler-runtime": "^1.0.0"
 	},
 	"devDependencies": {
 		"@stratakit/foundations": "workspace:*",

--- a/packages/compat/scripts/build.js
+++ b/packages/compat/scripts/build.js
@@ -5,6 +5,7 @@
 
 import * as esbuild from "esbuild";
 import fg from "fast-glob";
+import { reactCompilerPlugin } from "internal/esbuild-plugins.js";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -24,3 +25,21 @@ await esbuild.build({
 	target: "es2021",
 	...(!isDev && { dropLabels: ["DEV"] }),
 });
+
+// For production builds, run esbuild again with React Compiler.
+if (!isDev) {
+	await esbuild.build({
+		entryPoints: await fg("dist/**/*.js", {
+			onlyFiles: true,
+			ignore: ["dist/DEV"],
+		}),
+		entryNames: "[dir]/[name]",
+		outdir: "dist",
+		bundle: false,
+		format: "esm",
+		jsx: "automatic",
+		target: "es2021",
+		plugins: [reactCompilerPlugin()],
+		allowOverwrite: true,
+	});
+}

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -53,7 +53,8 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.19",
-		"classnames": "^2.5.1"
+		"classnames": "^2.5.1",
+		"react-compiler-runtime": "^1.0.0"
 	},
 	"devDependencies": {
 		"@stratakit/bricks": "workspace:*",

--- a/packages/foundations/scripts/build.js
+++ b/packages/foundations/scripts/build.js
@@ -5,7 +5,10 @@
 
 import * as esbuild from "esbuild";
 import fg from "fast-glob";
-import { inlineCssPlugin } from "internal/esbuild-plugins.js";
+import {
+	inlineCssPlugin,
+	reactCompilerPlugin,
+} from "internal/esbuild-plugins.js";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -25,6 +28,24 @@ await esbuild.build({
 	target: "es2021",
 	dropLabels: ["DROP", ...(isDev ? ["DEV"] : [])],
 });
+
+// For production builds, run esbuild again with React Compiler.
+if (!isDev) {
+	await esbuild.build({
+		entryPoints: await fg("dist/**/*.js", {
+			onlyFiles: true,
+			ignore: ["dist/DEV"],
+		}),
+		entryNames: "[dir]/[name]",
+		outdir: "dist",
+		bundle: false,
+		format: "esm",
+		jsx: "automatic",
+		target: "es2021",
+		plugins: [reactCompilerPlugin()],
+		allowOverwrite: true,
+	});
+}
 
 // Run esbuild again, only to inline bundled CSS inside `.css.ts` files
 await esbuild.build({

--- a/packages/structures/package.json
+++ b/packages/structures/package.json
@@ -114,6 +114,7 @@
 		"@ariakit/react": "^0.4.19",
 		"@stratakit/bricks": "^0.4.5",
 		"classnames": "^2.5.1",
+		"react-compiler-runtime": "^1.0.0",
 		"zustand": "^5.0.8"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       vite:
         specifier: ^7.1.11
         version: 7.1.11(@types/node@22.18.11)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.6.1)
+      vite-plugin-babel:
+        specifier: ^1.3.2
+        version: 1.3.2(@babel/core@7.28.4)(vite@7.1.11(@types/node@22.18.11)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.6.1))
       vite-plugin-devtools-json:
         specifier: ^1.0.0
         version: 1.0.0(vite@7.1.11(@types/node@22.18.11)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.6.1))
@@ -170,10 +173,15 @@ importers:
 
   internal:
     dependencies:
+      "@babel/core":
+        specifier: ^7.28.4
+        version: 7.28.4
+      babel-plugin-react-compiler:
+        specifier: ~1.0.0
+        version: 1.0.0
       colorjs.io:
         specifier: ^0.5.2
         version: 0.5.2
-    devDependencies:
       lightningcss:
         specifier: "catalog:"
         version: 1.30.1
@@ -186,6 +194,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      react-compiler-runtime:
+        specifier: ^1.0.0
+        version: 1.0.0(react@19.2.0)
     devDependencies:
       "@stratakit/foundations":
         specifier: workspace:*
@@ -226,6 +237,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      react-compiler-runtime:
+        specifier: ^1.0.0
+        version: 1.0.0(react@19.2.0)
     devDependencies:
       "@stratakit/foundations":
         specifier: workspace:*
@@ -260,6 +274,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      react-compiler-runtime:
+        specifier: ^1.0.0
+        version: 1.0.0(react@19.2.0)
     devDependencies:
       "@stratakit/bricks":
         specifier: workspace:*
@@ -302,6 +319,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      react-compiler-runtime:
+        specifier: ^1.0.0
+        version: 1.0.0(react@19.2.0)
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.2)(immer@10.1.3)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
@@ -1518,6 +1538,12 @@ packages:
         integrity: sha512-DV5bdJZTzZ0zn0DC24v3jD7Mnidh6xhKa4GfKCbq3sfW8kaWhDdZjP3i81geA8T33tdYqWKw4D3fVv0CwEgKVA==,
       }
 
+  babel-plugin-react-compiler@1.0.0:
+    resolution:
+      {
+        integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==,
+      }
+
   balanced-match@1.0.2:
     resolution:
       {
@@ -2420,6 +2446,14 @@ packages:
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
+  react-compiler-runtime@1.0.0:
+    resolution:
+      {
+        integrity: sha512-rRfjYv66HlG8896yPUDONgKzG5BxZD1nV9U6rkm+7VCuvQc903C4MjcoZR4zPw53IKSOX9wMQVpA1IAbRtzQ7w==,
+      }
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
+
   react-dom@19.2.0:
     resolution:
       {
@@ -2775,6 +2809,15 @@ packages:
       }
     engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
+
+  vite-plugin-babel@1.3.2:
+    resolution:
+      {
+        integrity: sha512-mEld4OVyuNs5+ISN+U5XyTnNcDwln/s2oER2m0PQ32YYPqPR25E3mfnhAA/RkZJxPuwFkprKWV405aZArE6kzA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+      vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   vite-plugin-devtools-json@1.0.0:
     resolution:
@@ -3654,6 +3697,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      "@babel/types": 7.28.4
+
   balanced-match@1.0.2: {}
 
   balanced-match@3.0.1: {}
@@ -4109,6 +4156,10 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-compiler-runtime@1.0.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+
   react-dom@19.2.0(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -4315,6 +4366,11 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-babel@1.3.2(@babel/core@7.28.4)(vite@7.1.11(@types/node@22.18.11)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.6.1)):
+    dependencies:
+      "@babel/core": 7.28.4
+      vite: 7.1.11(@types/node@22.18.11)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.6.1)
 
   vite-plugin-devtools-json@1.0.0(vite@7.1.11(@types/node@22.18.11)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.6.1)):
     dependencies:


### PR DESCRIPTION
As [React Compiler](https://react.dev/blog/2025/10/07/react-compiler-1) is now stable, this PR updates our packages to use the compiler for auto memoization.

While there could be theoretical performance improvements, the real benefit of this change (for us) is that we can be less strict about memoization in our code.

### Changes

React Compiler is enabled in the production build script by directly using `@babel/core` with `babel-plugin-react-compiler` (see [libraries guide](https://react.dev/reference/react-compiler/compiling-libraries)). [`react-compiler-runtime`](https://react.dev/reference/react-compiler/target#targeting-react-17-or-18) dependency has been added for React 18. **Dev build is unchanged** for easier debugging.

_Note:_ This required an additional pass of `esbuild` on the `dist/` directory. I would have liked to call the babel plugin on the source files during the first pass, but the babel plugin only works on plain JS, so the TSX needs to be transformed to JS beforehand. I didn't see a way to access the transformed code from an `esbuild` plugin.

The `test-app` has been additionally updated to use the compiler through `vite-plugin-babel` (see [docs](https://react.dev/learn/react-compiler/installation#usage-with-react-router)).

### Testing

Manually inspected the build artifacts to verify that the compiler output is present in the production build (and not in the `DEV/` build).

[Deploy preview](https://itwin.github.io/design-system/1003/). I could not notice any difference in runtime performance (similar LCP or INP numbers before/after this PR, even with CPU throttling). But I also did not notice any change in behavior anywhere, which is good.

**Bundle size impact:** A quick measurement on the `/sandbox` page shows that the final bundle size is about ~22KB larger (~9KB gzip), out of which **~9KB (4KB gzip)** is coming from outside `test-app` changes. Turning off `target:"18"` (which removes `react-compiler-runtime` runtime dep) lowers the size by ~2KB gzip. Since React 18 apps will likely already have `react-compiler-runtime`, this leads me to conclude that the _net increase_ from the additional compiler-generated code in our components is **~4KB (2KB zip)** on a moderately-sized page.

<details>
<summary>Raw bundle size numbers</summary>

Measurements taken using prod build on `/sandbox` route.

| Scenario | Size of `.js` |
| --- | --- |
| No Compiler | 738 kB (241 kB gzip) |
| With Compiler | 760 kB (250 kB gzip) |
| No target:18 | 752 kB (246 kB gzip) |
| No Compiler in test-app | 747 kB (245 kB gzip) |
| No target:"18" + No Compiler in test-app | 742 kB (243 kB gzip) |

</details>