### PR TITLE
test-app: hide `List` page

### DIFF
--- a/apps/test-app/app/index.tsx
+++ b/apps/test-app/app/index.tsx
@@ -10,6 +10,10 @@ import { toKebabCase } from "./~utils.tsx";
 
 import styles from "./index.module.css";
 
+// ----------------------------------------------------------------------------
+
+const isDev = import.meta.env.DEV;
+
 export const meta: MetaFunction = () => {
 	return [{ title: "StrataKit test app" }];
 };
@@ -100,6 +104,26 @@ export default function Index() {
 					</li>
 				))}
 			</ul>
+
+			{isDev && (
+				<>
+					<Text variant="headline-md" render={<h2 />} className={styles.h2}>
+						Private
+					</Text>
+
+					<ul className={styles.list}>
+						{components.private.map((component) => (
+							<li key={component}>
+								<Anchor
+									render={<Link to={`/tests/${toKebabCase(component)}`} />}
+								>
+									{component}
+								</Anchor>
+							</li>
+						))}
+					</ul>
+				</>
+			)}
 		</main>
 	);
 }

--- a/apps/test-app/app/routes.ts
+++ b/apps/test-app/app/routes.ts
@@ -21,6 +21,7 @@ export default [
 			...components.foundations,
 			...components.bricks,
 			...components.structures,
+			...components.private,
 		].map((component) =>
 			route(
 				toKebabCase(component),

--- a/apps/test-app/app/~meta.ts
+++ b/apps/test-app/app/~meta.ts
@@ -31,7 +31,6 @@ export const components = {
 		"Dialog",
 		"DropdownMenu",
 		"ErrorRegion",
-		"List",
 		"NavigationRail",
 		"Table",
 		"Tabs",
@@ -69,4 +68,5 @@ export const components = {
 		"Tooltip",
 		"VisuallyHidden",
 	],
+	private: ["List"],
 };


### PR DESCRIPTION
### Background

There is no "List" component in StrataKit, but there is a [`/list`](https://itwin.github.io/design-system/tests/list) page which uses the internal `ListItem` component. This is causing confusion (see https://github.com/iTwin/design-system/discussions/990).

### Changes

This PR removes the "List" page from the index page. This is done by creating a new `private` key in the `components` object in [`~meta.ts`](https://github.com/iTwin/design-system/blob/main/apps/test-app/app/~meta.ts) (which gets used by both the index page and `routes.ts`).

In development, these private pages are resurfaced at the bottom of the index page for easier discoverability. (The route can still be accessed directly the same in both dev and prod)