### PR TITLE
aria-labelledby -> aria-describedby

### DIFF
--- a/packages/bricks/src/Select.tsx
+++ b/packages/bricks/src/Select.tsx
@@ -51,7 +51,7 @@ const HtmlSelectContext = React.createContext<
  * <Label htmlFor="fruit">Fruit</Label>
  * <Description id="fruit-description">Something to include in a fruit salad.</Description>
  * <Select.Root>
- *   <Select.HtmlSelect id="fruit" aria-labelledby="fruit-description">
+ *   <Select.HtmlSelect id="fruit" aria-describedby="fruit-description">
  *     <option value="kiwi">Kiwi</option>
  *     <option value="mango">Mango</option>
  *     <option value="papaya">Papaya</option>


### PR DESCRIPTION
In the current example, the `aria-labelledby` value overrides rather than appends to the label. It needs to use `aria-describedby`. 

**Note:** where there is conflict, `aria-labelledby` always overrules `aria-label` which overrules other, non-ARIA methods such as `for`/`id`.