### PR TITLE
`Icon`: construct full URL from `href`

### DIFF
--- a/.changeset/perky-masks-fold.md
+++ b/.changeset/perky-masks-fold.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/foundations": patch
+---
+
+Updated the fallback logic of `Icon` component to correctly handle relative non-HTTP URLs.


### PR DESCRIPTION
This PR updates the `Icon` component's fallback `fetch` logic (added in #455) to correctly handle non-HTTP relative URLs by constructing a full, normalized URL before fetching and calculating hash.

### Background

This is meant to fix an issue where the icon wouldn't show up when used in Studio's own code. The previous assumption that Studio would only pass full URLs (complete with protocol) does not apply to Studio's own code.

Quote from @toddsouthenbentley:

> It's failing because the `rawHref` doesn't have a protocol. For example, it has values like: `/assets/itwin-KH20i3wr.svg#icon-large`.

**Note:** Relative URLs should normally "just work", i.e. ideally we wouldn't even need to `fetch`. But the complication comes from the non-HTTP protocols used in Electron environment. For example, the `file://` protocol is considered [opaque](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#file_origins) and will not work out-of-the-box with `<use href>`.