### PR TITLE
fix `pnpm run test` args

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"lint": "biome check --error-on-warnings --formatter-enabled=false --linter-enabled=true .",
 		"lint:copyright": "tsx internal/copyright-linter.ts",
 		"prettier": "prettier . '!**/*.{js,jsx,ts,tsx,cjs,cts,mjs,mts,css,json,jsonc}' --check",
-		"test": "pnpm --filter=@stratakit/test-app test --",
+		"test": "pnpm --filter=@stratakit/test-app test",
 		"changeset": "pnpx @changesets/cli@2.29.6",
 		"changeset:version": "pnpm run changeset version && pnpm format --write",
 		"changeset:publish": "pnpm run build && pnpm run changeset publish"


### PR DESCRIPTION
Previously, we were adding a `--` to the package.json script itself (for `wireit` #599). This was so that we wouldn't need to use `--` twice (one for `pnpm run`). However, this broke after https://github.com/iTwin/design-system/pull/949.

Pnpm now does not need the extra `--`. This was causing the underlying `wireit` command to be called with `-- --`. Looks like this was a [breaking change](https://redirect.github.com/pnpm/pnpm/pull/8619) introduced by Pnpm [10.0.0](https://github.com/pnpm/pnpm/releases/tag/v10.0.0).

So, this PR removes the redundant `--`.

### Testing

Try passing some args to `pnpm run test`. For example:

```
pnpm run test -- button --update-snapshots
```

(This is the exact format shown in [`CONTRIBUTING.md`](https://github.com/iTwin/design-system/blob/main/CONTRIBUTING.md#commands))