### PR TITLE
Require `aria-label` or `aria-labelledby` prop in `ErrorRegion.Root`

### DIFF
--- a/.changeset/orange-geckos-rescue.md
+++ b/.changeset/orange-geckos-rescue.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": minor
+---
+
+Require `aria-label` or `aria-labelledby` prop in `ErrorRegion.Root` component.

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -62,6 +62,8 @@ type ErrorRegionRootExtraProps =
 	| {
 			/**
 			 * Name of the region navigational landmark.
+			 *
+			 * This label should remain stable throughout the lifetime of the region.
 			 */
 			"aria-label": string | undefined;
 	  }

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -29,15 +29,12 @@ import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
 // ----------------------------------------------------------------------------
 
-interface ErrorRegionRootProps extends Omit<BaseProps, "children"> {
+interface ErrorRegionRootBaseProps extends Omit<BaseProps, "children"> {
 	/**
 	 * Label for the error header, usually indicating the number of errors displayed.
 	 *
 	 * Changes to the `label` prop will be communicated
 	 * using a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
-	 *
-	 * (deprecated behavior) By default this is used as a name of the region navigational landmark.
-	 * `aria-label` or `aria-labelledby` prop should be provided to explicitly label the region instead.
 	 *
 	 * (deprecated behavior) Use `undefined` if you don't want to display errors rather than conditionally rendering the component.
 	 * Use `items` prop instead.
@@ -60,6 +57,23 @@ interface ErrorRegionRootProps extends Omit<BaseProps, "children"> {
 	 */
 	setOpen?: (open: boolean) => void;
 }
+
+type ErrorRegionRootExtraProps =
+	| {
+			/**
+			 * Name of the region navigational landmark.
+			 */
+			"aria-label": string | undefined;
+	  }
+	| {
+			/**
+			 * Identifies the element that labels the region navigational landmark.
+			 */
+			"aria-labelledby": string | undefined;
+	  };
+
+type ErrorRegionRootProps = ErrorRegionRootBaseProps &
+	ErrorRegionRootExtraProps;
 
 /**
  * A collapsible region that displays a list of error messages, which might originate from another
@@ -101,11 +115,6 @@ const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 		DEV: if (!Array.isArray(itemsProp))
 			console.warn(
 				"`items` prop of `ErrorRegion.Root` expects an array of React nodes. `ReactNode` support is deprecated and will be removed in a future release.",
-			);
-
-		DEV: if (!props["aria-label"] && !props["aria-labelledby"])
-			console.warn(
-				"`aria-label` or `aria-labelledby` prop is required for `ErrorRegion.Root` to set an accessible name of a region.",
 			);
 
 		const visible = Array.isArray(itemsProp) ? itemsProp.length > 0 : !!label;

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -70,6 +70,8 @@ type ErrorRegionRootExtraProps =
 	| {
 			/**
 			 * Identifies the element that labels the region navigational landmark.
+			 *
+			 * This label should remain stable throughout the lifetime of the region.
 			 */
 			"aria-labelledby": string | undefined;
 	  };


### PR DESCRIPTION
## Breaking

Fixes part of #977 by requiring `aria-label` or `aria-labelledby` prop in `ErrorRegion.Root` component. This is a type change follow up to a runtime warning introduced by https://github.com/iTwin/design-system/pull/978
