### PR TITLE
Omit re-defined `render` prop in `AccordionItemHeadingProps`

### DIFF
--- a/packages/structures/src/AccordionItem.tsx
+++ b/packages/structures/src/AccordionItem.tsx
@@ -358,7 +358,7 @@ const AccordionItemContent = forwardRef<"div", BaseProps>(
 );
 DEV: AccordionItemContent.displayName = "AccordionItem.Content";
 
-interface AccordionItemHeadingProps extends BaseProps {
+interface AccordionItemHeadingProps extends Omit<BaseProps, "render"> {
 	render: NonNullable<BaseProps["render"]>;
 }
 


### PR DESCRIPTION
Types only change to make it easier to parse the documentation in https://github.com/iTwin/stratakit-docs/pull/33. Avoids tagging `AccordionItemHeading` component with `BaseProps` (Additional props) and an explicit `render` prop.