### PR TITLE
update tokens

### DIFF
--- a/.changeset/icy-flowers-start.md
+++ b/.changeset/icy-flowers-start.md
@@ -1,0 +1,19 @@
+---
+"@stratakit/foundations": minor
+---
+
+Renamed a few CSS variables:
+
+- `--stratakit-color-bg-page-zebra` is now `--stratakit-color-bg-control-table-zebra`.
+- `--stratakit-color-brand-logo` is now `--stratakit-color-brand-logo-fill`.
+- All component-specific shadow tokens are now prefixed with `control-`.
+  - `--stratakit-shadow-button-base-drop` → `--stratakit-shadow-control-button-base-drop`
+  - `--stratakit-shadow-button-base-inset` → `--stratakit-shadow-control-button-base-inset`
+  - `--stratakit-shadow-dialog-base` → `--stratakit-shadow-control-dialog-base`
+  - `--stratakit-shadow-dropdown-base` → `--stratakit-shadow-control-dropdown-base`
+  - `--stratakit-shadow-input-base` → `--stratakit-shadow-control-input-base`
+  - `--stratakit-shadow-table-strong` → `--stratakit-shadow-control-table-strong`
+  - `--stratakit-shadow-toolbar-base` → `--stratakit-shadow-control-toolbar-base`
+  - `--stratakit-shadow-tooltip-base` → `--stratakit-shadow-control-tooltip-base`
+
+⚠️ To handle these breaking changes, do a find-and-replace for all existing references in your code base.

--- a/.changeset/purple-cloths-crash.md
+++ b/.changeset/purple-cloths-crash.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/foundations": patch
+---
+
+Added new CSS variables: `--stratakit-color-bg-brand-logo-stroke` and `--stratakit-shadow-brand-logo-base`.

--- a/internal/theme-dark.json
+++ b/internal/theme-dark.json
@@ -171,10 +171,6 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.gray.925}"
-				},
-				"zebra": {
-					"$type": "color",
-					"$value": "{p-color.black.8}"
 				}
 			},
 			"elevation": {
@@ -297,6 +293,10 @@
 				"textbox": {
 					"$type": "color",
 					"$value": "{p-color.gray.925}"
+				},
+				"table-zebra": {
+					"$type": "color",
+					"$value": "{p-color.black.8}"
 				},
 				"scrollbar-surface": {
 					"$type": "color",
@@ -921,9 +921,13 @@
 			"$value": "{p-color.white.100}"
 		},
 		"brand": {
-			"logo": {
+			"logo-fill": {
 				"$type": "color",
 				"$value": "{p-color.gray.15}"
+			},
+			"logo-stroke": {
+				"$type": "color",
+				"$value": "{p-color.gray.5}"
 			}
 		}
 	},
@@ -983,18 +987,18 @@
 				"0px 24px 24px -12px --primitive('color.black.16')"
 			]
 		},
-		"button-base-drop": {
+		"control-button-base-drop": {
 			"$type": "shadow",
 			"$value": [
 				"0px 1px 1px -0.5px --primitive('color.black.16')",
 				"0px 3px 3px -1.5px --primitive('color.black.16')"
 			]
 		},
-		"button-base-inset": {
+		"control-button-base-inset": {
 			"$type": "shadow",
 			"$value": ["inset 0px -1px 0px 0px --primitive('color.black.8')"]
 		},
-		"dialog-base": {
+		"control-dialog-base": {
 			"$type": "shadow",
 			"$value": [
 				"0px 1px 0px 0px --primitive('color.black.8')",
@@ -1007,7 +1011,7 @@
 				"0px 24px 24px -12px --primitive('color.black.16')"
 			]
 		},
-		"dropdown-base": {
+		"control-dropdown-base": {
 			"$type": "shadow",
 			"$value": [
 				"0px 1px 0px 0px --primitive('color.black.8')",
@@ -1020,18 +1024,18 @@
 				"0px 24px 24px -12px --primitive('color.black.12')"
 			]
 		},
-		"input-base": {
+		"control-input-base": {
 			"$type": "shadow",
 			"$value": [
 				"inset 0px 1px 2px 0px --primitive('color.black.16')",
 				"inset 0px 2px 4px 0px --primitive('color.black.16')"
 			]
 		},
-		"table-strong": {
+		"control-table-strong": {
 			"$type": "shadow",
 			"$value": ["0px -1px 0px 0px --primitive('color.aurora.0')"]
 		},
-		"toolbar-base": {
+		"control-toolbar-base": {
 			"$type": "shadow",
 			"$value": [
 				"0px 1px 0px 0px --primitive('color.black.8')",
@@ -1044,7 +1048,7 @@
 				"0px 24px 24px -12px --primitive('color.black.16')"
 			]
 		},
-		"tooltip-base": {
+		"control-tooltip-base": {
 			"$type": "shadow",
 			"$value": [
 				"inset 0px 0px 0px 1px --primitive('color.black.80')",
@@ -1052,6 +1056,13 @@
 				"0px 3px 3px -1.5px --primitive('color.black.16')",
 				"0px 6px 6px -3px --primitive('color.black.16')",
 				"0px 12px 12px -6px --primitive('color.black.16')"
+			]
+		},
+		"brand-logo-base": {
+			"$type": "shadow",
+			"$value": [
+				"0px 0.5px 0px 0px --primitive('color.black.56')",
+				"0px 1px 2px 0px --primitive('color.black.40')"
 			]
 		}
 	}

--- a/internal/theme-light.json
+++ b/internal/theme-light.json
@@ -171,10 +171,6 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.gray.5}"
-				},
-				"zebra": {
-					"$type": "color",
-					"$value": "{p-color.black.4}"
 				}
 			},
 			"elevation": {
@@ -297,6 +293,10 @@
 				"textbox": {
 					"$type": "color",
 					"$value": "{p-color.white.100}"
+				},
+				"table-zebra": {
+					"$type": "color",
+					"$value": "{p-color.black.2}"
 				},
 				"scrollbar-surface": {
 					"$type": "color",
@@ -921,9 +921,13 @@
 			"$value": "{p-color.black.100}"
 		},
 		"brand": {
-			"logo": {
+			"logo-fill": {
 				"$type": "color",
 				"$value": "{p-color.gray.700}"
+			},
+			"logo-stroke": {
+				"$type": "color",
+				"$value": "{p-color.gray.925}"
 			}
 		}
 	},
@@ -983,18 +987,18 @@
 				"0px 24px 24px -12px --primitive('color.black.4')"
 			]
 		},
-		"button-base-drop": {
+		"control-button-base-drop": {
 			"$type": "shadow",
 			"$value": [
 				"0px 1px 1px -0.5px --primitive('color.black.4')",
 				"0px 3px 3px -1.5px --primitive('color.black.4')"
 			]
 		},
-		"button-base-inset": {
+		"control-button-base-inset": {
 			"$type": "shadow",
 			"$value": ["inset 0px -1px 0px 0px --primitive('color.black.8')"]
 		},
-		"dialog-base": {
+		"control-dialog-base": {
 			"$type": "shadow",
 			"$value": [
 				"0px 1px 0px 0px --primitive('color.black.8')",
@@ -1007,7 +1011,7 @@
 				"0px 24px 24px -12px --primitive('color.black.8')"
 			]
 		},
-		"dropdown-base": {
+		"control-dropdown-base": {
 			"$type": "shadow",
 			"$value": [
 				"0px 1px 0px 0px --primitive('color.black.4')",
@@ -1020,18 +1024,18 @@
 				"0px 24px 24px -12px --primitive('color.black.4')"
 			]
 		},
-		"input-base": {
+		"control-input-base": {
 			"$type": "shadow",
 			"$value": [
 				"inset 0px 1px 2px 0px --primitive('color.black.4')",
 				"inset 0px 2px 4px 0px --primitive('color.black.4')"
 			]
 		},
-		"table-strong": {
+		"control-table-strong": {
 			"$type": "shadow",
 			"$value": ["0px -1px 0px 0px --primitive('color.aurora.500')"]
 		},
-		"toolbar-base": {
+		"control-toolbar-base": {
 			"$type": "shadow",
 			"$value": [
 				"0px 1px 0px 0px --primitive('color.black.8')",
@@ -1044,7 +1048,7 @@
 				"0px 24px 24px -12px --primitive('color.black.8')"
 			]
 		},
-		"tooltip-base": {
+		"control-tooltip-base": {
 			"$type": "shadow",
 			"$value": [
 				"inset 0px 0px 0px 1px --primitive('color.black.96')",
@@ -1052,6 +1056,13 @@
 				"0px 3px 3px -1.5px --primitive('color.black.4')",
 				"0px 6px 6px -3px --primitive('color.black.4')",
 				"0px 12px 12px -6px --primitive('color.black.4')"
+			]
+		},
+		"brand-logo-base": {
+			"$type": "shadow",
+			"$value": [
+				"0px 2px 4px 0px --primitive('color.black.4')",
+				"0px 1px 2px 0px --primitive('color.black.24')"
 			]
 		}
 	}

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -33,8 +33,8 @@
 	--✨bg--solid-disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
 
 	--✨shadow--solid:
-		var(--stratakit-shadow-button-base-inset), var(--✨shadow-border),
-		var(--stratakit-shadow-button-base-drop);
+		var(--stratakit-shadow-control-button-base-inset), var(--✨shadow-border),
+		var(--stratakit-shadow-control-button-base-drop);
 
 	--✨border--solid-neutral-default: var(--stratakit-color-border-shadow-base);
 	--✨border--solid-neutral-hover: color-mix(

--- a/packages/bricks/src/Checkbox.css
+++ b/packages/bricks/src/Checkbox.css
@@ -56,8 +56,8 @@
 		transition-property: background-color, border-color, box-shadow, --🥝Checkbox-border-color;
 		position: relative;
 		box-shadow:
-			var(--stratakit-shadow-button-base-inset), var(--✨shadow-border),
-			var(--stratakit-shadow-button-base-drop);
+			var(--stratakit-shadow-control-button-base-inset), var(--✨shadow-border),
+			var(--stratakit-shadow-control-button-base-drop);
 		-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 
 		--🥝Checkbox-border-color: var(--🌀Checkbox-visual-state--default, var(--✨border--default))

--- a/packages/bricks/src/Kbd.css
+++ b/packages/bricks/src/Kbd.css
@@ -29,8 +29,8 @@
 
 		&:where([data-_sk-variant="solid"]) {
 			box-shadow:
-				var(--stratakit-shadow-button-base-inset), var(--✨shadow-border),
-				var(--stratakit-shadow-button-base-drop);
+				var(--stratakit-shadow-control-button-base-inset), var(--✨shadow-border),
+				var(--stratakit-shadow-control-button-base-drop);
 		}
 
 		&:where([data-_sk-variant="ghost"]) {

--- a/packages/bricks/src/Switch.css
+++ b/packages/bricks/src/Switch.css
@@ -100,8 +100,8 @@
 			margin: calc(0.125rem - 1px) /* sizing-2 - 1px to account for border */;
 			background-color: var(--🥝Switch-thumb-color);
 			box-shadow:
-				var(--stratakit-shadow-button-base-inset), var(--✨shadow-border),
-				var(--stratakit-shadow-button-base-drop);
+				var(--stratakit-shadow-control-button-base-inset), var(--✨shadow-border),
+				var(--stratakit-shadow-control-button-base-drop);
 			border-radius: var(--🥝Switch-thumb-radius, var(--✨radius));
 			transform-origin: left;
 			transform: var(--🥝Switch-thumb-transform);

--- a/packages/bricks/src/TextBox.css
+++ b/packages/bricks/src/TextBox.css
@@ -50,8 +50,11 @@
 		--🥝TextBox-border-color: var(--🌀TextBox-state--default, var(--✨border--default))
 			var(--🌀TextBox-state--hover, var(--✨border--hover))
 			var(--🌀TextBox-state--disabled, var(--✨border--disabled));
-		--🥝TextBox-box-shadow: var(--🌀TextBox-state--default, var(--stratakit-shadow-input-base))
-			var(--🌀TextBox-state--hover, var(--stratakit-shadow-input-base))
+		--🥝TextBox-box-shadow: var(
+				--🌀TextBox-state--default,
+				var(--stratakit-shadow-control-input-base)
+			)
+			var(--🌀TextBox-state--hover, var(--stratakit-shadow-control-input-base))
 			var(--🌀TextBox-state--disabled, none);
 
 		/* Styles specific to wrapper ("root") */

--- a/packages/bricks/src/Tooltip.css
+++ b/packages/bricks/src/Tooltip.css
@@ -15,7 +15,7 @@
 		hyphens: auto;
 
 		background-color: var(--✨bg);
-		box-shadow: var(--stratakit-shadow-tooltip-base);
+		box-shadow: var(--stratakit-shadow-control-tooltip-base);
 		color: var(--✨color);
 
 		display: flex;

--- a/packages/structures/src/Dialog.css
+++ b/packages/structures/src/Dialog.css
@@ -29,7 +29,7 @@
 
 		border-radius: 12px; /* radius/large */
 		background-color: var(--stratakit-color-bg-elevation-base);
-		box-shadow: var(--stratakit-shadow-dialog-base);
+		box-shadow: var(--stratakit-shadow-control-dialog-base);
 
 		/* Prevents footer from overlapping the box-shadow */
 		padding: 1px;

--- a/packages/structures/src/DropdownMenu.css
+++ b/packages/structures/src/DropdownMenu.css
@@ -15,7 +15,7 @@
 		min-inline-size: min(95vi, 164px);
 		border-radius: 8px /* radius(in progress)/medium */;
 		padding: var(--✨padding);
-		box-shadow: var(--stratakit-shadow-dropdown-base);
+		box-shadow: var(--stratakit-shadow-control-dropdown-base);
 	}
 }
 

--- a/packages/structures/src/Toolbar.css
+++ b/packages/structures/src/Toolbar.css
@@ -9,7 +9,7 @@
 		align-items: center;
 
 		background-color: var(--stratakit-color-bg-page-base);
-		box-shadow: var(--stratakit-shadow-toolbar-base);
+		box-shadow: var(--stratakit-shadow-control-toolbar-base);
 		border-radius: 8px;
 		padding: var(--stratakit-space-x1);
 


### PR DESCRIPTION
Based on latest export from Figma. **The renames are breaking** (see below).

Non-breaking additions: `--stratakit-color-bg-brand-logo-stroke` and `--stratakit-shadow-brand-logo-base`

### Breaking changes (for consumers)

| Old | New |
| --- | --- |
| `--stratakit-color-bg-page-zebra` | `--stratakit-color-bg-control-table-zebra` |
| `--stratakit-color-brand-logo` | `--stratakit-color-brand-logo-fill` |
| `--stratakit-shadow-button-base-drop` | `--stratakit-shadow-control-button-base-drop` |
| `--stratakit-shadow-button-base-inset` | `--stratakit-shadow-control-button-base-inset` |
| `--stratakit-shadow-dialog-base` | `--stratakit-shadow-control-dialog-base` |
| `--stratakit-shadow-dropdown-base` | `--stratakit-shadow-control-dropdown-base` |
| `--stratakit-shadow-input-base` | `--stratakit-shadow-control-input-base` |
| `--stratakit-shadow-table-strong` | `--stratakit-shadow-control-table-strong` |
| `--stratakit-shadow-toolbar-base` | `--stratakit-shadow-control-toolbar-base` |
| `--stratakit-shadow-tooltip-base` | `--stratakit-shadow-control-tooltip-base` |