### PR TITLE
[investigation] publish to `gh-pages`

### DIFF
--- a/apps/test-app/app/tests/dropdown-menu/index.tsx
+++ b/apps/test-app/app/tests/dropdown-menu/index.tsx
@@ -15,34 +15,45 @@ export const handle = { title: "DropdownMenu" };
 export default definePage(
 	function Page({ disabled }) {
 		return (
-			<DropdownMenu.Provider>
-				<DropdownMenu.Button disabled={!!disabled}>Actions</DropdownMenu.Button>
+			<>
+				<DropdownMenu.Provider>
+					<DropdownMenu.Button disabled={!!disabled}>
+						Actions
+					</DropdownMenu.Button>
 
-				<DropdownMenu.Content>
-					<DropdownMenu.Item shortcuts="Command+A" label="Add" />
-					<DropdownMenu.Item shortcuts="Shift+E" label="Edit" />
-					<DropdownMenu.Item disabled label="Delete" />
-					<DropdownMenu.Item label="Disable" />
-					<DropdownMenu.Item
-						label="Filter"
-						unstable_dot="Some filters applied"
-					/>
-					<DropdownMenu.Item
-						label="More"
-						submenu={
-							<DropdownMenu.Submenu>
-								<DropdownMenu.Item shortcuts="Command+C" label="Clone" />
-								<DropdownMenu.Item disabled label="Archive" />
-								<DropdownMenu.Item label="Export" />
-								<DropdownMenu.Item
-									label="Import"
-									unstable_dot="Some filters applied"
-								/>
-							</DropdownMenu.Submenu>
-						}
-					/>
-				</DropdownMenu.Content>
-			</DropdownMenu.Provider>
+					<DropdownMenu.Content>
+						<DropdownMenu.Item shortcuts="Command+A" label="Add" />
+						<DropdownMenu.Item shortcuts="Shift+E" label="Edit" />
+						<DropdownMenu.Item disabled label="Delete" />
+						<DropdownMenu.Item label="Disable" />
+						<DropdownMenu.Item
+							label="Filter"
+							unstable_dot="Some filters applied"
+						/>
+						<DropdownMenu.Item
+							label="More"
+							submenu={
+								<DropdownMenu.Submenu>
+									<DropdownMenu.Item shortcuts="Command+C" label="Clone" />
+									<DropdownMenu.Item disabled label="Archive" />
+									<DropdownMenu.Item label="Export" />
+									<DropdownMenu.Item
+										label="Import"
+										unstable_dot="Some filters applied"
+									/>
+								</DropdownMenu.Submenu>
+							}
+						/>
+					</DropdownMenu.Content>
+				</DropdownMenu.Provider>
+				<div
+					style={{
+						boxShadow: `var(--stratakit-shadow-dropdown-base)`,
+					}}
+				>
+					XYZ
+				</div>
+			</>
 		);
 	},
 	{


### PR DESCRIPTION
Observe that "XYZ" doesn't have a shadow, while `DropdownMenu` does: https://supreme-barnacle-pl8jn8m.pages.github.io/1065/tests/dropdown-menu

Both `DropdownMenu` and `XYZ` use the same CSS variable `--stratakit-shadow-dropdown-base` in code:
https://github.com/iTwin/design-system/blob/096bf305b3c515303d3227af779f6231f2659756/packages/structures/src/DropdownMenu.css#L18C19-L18C51
https://github.com/iTwin/design-system/blob/096bf305b3c515303d3227af779f6231f2659756/apps/test-app/app/tests/dropdown-menu/index.tsx#L51

In published version of `test-app` `DropdownMenu` uses `--stratakit-shadow-control-dropdown-base`.