### PR TITLE
Remove valid styling to `TextBox`

### DIFF
--- a/.changeset/silly-mirrors-boil.md
+++ b/.changeset/silly-mirrors-boil.md
@@ -1,5 +1,0 @@
----
-"@stratakit/bricks": patch
----
-
-Removed valid state styling to `TextBox` due to improper application.

--- a/.changeset/silly-mirrors-boil.md
+++ b/.changeset/silly-mirrors-boil.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Removed valid state styling to `TextBox` due to improper application.

--- a/.changeset/two-readers-rest.md
+++ b/.changeset/two-readers-rest.md
@@ -1,5 +1,0 @@
----
-"@stratakit/bricks": patch
----
-
-Added valid state styling to `TextBox`.

--- a/packages/bricks/src/TextBox.css
+++ b/packages/bricks/src/TextBox.css
@@ -17,7 +17,6 @@
 		var(--stratakit-color-glow-hue) var(--stratakit-color-border-glow-base-hover-\%)
 	);
 	--✨border--focus: var(--stratakit-color-border-accent-strong);
-	--✨border--valid: var(--stratakit-color-border-accent-strong);
 	--✨border--invalid: var(--stratakit-color-border-critical-base);
 	--✨border--disabled: var(--stratakit-color-border-glow-on-surface-disabled);
 	--✨color--default: var(--stratakit-color-text-neutral-primary);
@@ -159,11 +158,6 @@
 				--🥝TextBox-border-color: var(--✨border--focus);
 				--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
 			}
-		}
-
-		&:where(:is(input, textarea):user-valid, :has(:is(input, textarea):user-valid)) {
-			--🥝Icon-color: var(--stratakit-color-icon-positive-base);
-			--🥝TextBox-border-color: var(--✨border--valid);
 		}
 
 		&:where(


### PR DESCRIPTION
Revert #1067 due to `:user-valid` being applied in scenarios where we don't want it applied.  Example: if you add text to a search `TextBox` and tab out of it, it will apply the valid styling, which is not desired.
Will revisit this feature in a future PR addressing `Field.SuccessMessage`.