### PR TITLE
add optional chaining to `CSS.supports`

### DIFF
--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -20,7 +20,7 @@ import type {
 // ----------------------------------------------------------------------------
 
 const supportsAnchorPositioning =
-	isBrowser && CSS?.supports("anchor-name: --foo");
+	isBrowser && CSS?.supports?.("anchor-name: --foo");
 
 const prefersReducedMotion = () =>
 	isBrowser && window.matchMedia("(prefers-reduced-motion)").matches;


### PR DESCRIPTION
Apparently some testing environments have `CSS` but don't have `CSS.supports`, so both should use optional chaining for extra safety.