### PR TITLE
`Tree`: expand non-selectable items on click

### DIFF
--- a/.changeset/easy-points-unite.md
+++ b/.changeset/easy-points-unite.md
@@ -1,0 +1,8 @@
+---
+"@stratakit/structures": patch
+---
+
+Increased the click target area of non-selectable `Tree.Item`s.
+
+- If `selected` is undefined, the `Tree.Item` will expand/collapse when clicked.
+- If `selected` is defined, the `Tree.Item` will continue to toggle selection when clicked.

--- a/apps/test-app/app/tests/tree/index.spec.ts
+++ b/apps/test-app/app/tests/tree/index.spec.ts
@@ -34,6 +34,53 @@ test("default", async ({ page }) => {
 	await expect(item1_1).toHaveAttribute("aria-setsize", "3");
 });
 
+test("expansion", async ({ page }) => {
+	const parent = page.getByRole("treeitem", { name: "Parent" });
+	const child = page.getByRole("treeitem", { name: "Child Item 1" });
+
+	await test.step("expansion is the default action when not selectable", async () => {
+		await page.goto("/tests/tree?_expansion");
+
+		// Initially collapsed
+		await expect(parent).toHaveAttribute("aria-expanded", "false");
+		await expect(child).not.toBeVisible();
+
+		// Expand when clicking the entire item
+		await parent.click();
+		await expect(parent).toHaveAttribute("aria-expanded", "true");
+		await expect(child).toBeVisible();
+
+		// Collapse when clicking the entire item again
+		await parent.click();
+		await expect(parent).toHaveAttribute("aria-expanded", "false");
+		await expect(child).not.toBeVisible();
+
+		// Similarly, expand/collapse when pressing Enter
+		await expect(parent).toBeFocused();
+		await page.keyboard.press("Enter");
+		await expect(parent).toHaveAttribute("aria-expanded", "true");
+		await expect(child).toBeVisible();
+		await page.keyboard.press("Enter");
+		await expect(parent).toHaveAttribute("aria-expanded", "false");
+		await expect(child).not.toBeVisible();
+	});
+
+	await test.step("expansion is not the default action when selectable", async () => {
+		await page.goto("/tests/tree?_expansion&selectable");
+
+		// Do not expand when clicking a selectable item
+		await parent.click();
+		await expect(parent).toHaveAttribute("aria-expanded", "false");
+		await expect(child).not.toBeVisible();
+
+		// Expand when clicking just the chevron
+		const chevron = parent.locator("svg");
+		await chevron.click();
+		await expect(parent).toHaveAttribute("aria-expanded", "true");
+		await expect(child).toBeVisible();
+	});
+});
+
 test("actions", async ({ page, browserName }) => {
 	test.fixme(
 		browserName === "firefox",

--- a/apps/test-app/app/tests/tree/index.tsx
+++ b/apps/test-app/app/tests/tree/index.tsx
@@ -212,6 +212,7 @@ export default definePage(
 	},
 	{
 		actions: ActionsTest,
+		_expansion: ExpansionTest,
 	},
 );
 interface ItemActionProps extends React.ComponentProps<typeof Tree.ItemAction> {
@@ -262,6 +263,42 @@ function ActionsTest({
 				actions={actions}
 				error={error}
 			/>
+		</Tree.Root>
+	);
+}
+
+// ----------------------------------------------------------------------------
+
+function ExpansionTest({ selectable }: VariantProps) {
+	const [expanded, setExpanded] = React.useState(false);
+
+	return (
+		<Tree.Root>
+			<Tree.Item
+				label="Parent Item"
+				aria-level={1}
+				aria-posinset={1}
+				aria-setsize={1}
+				expanded={expanded}
+				onExpandedChange={setExpanded}
+				selected={selectable ? false : undefined}
+			/>
+			{expanded && (
+				<>
+					<Tree.Item
+						label="Child Item 1"
+						aria-level={2}
+						aria-posinset={1}
+						aria-setsize={2}
+					/>
+					<Tree.Item
+						label="Child Item 2"
+						aria-level={2}
+						aria-posinset={2}
+						aria-setsize={2}
+					/>
+				</>
+			)}
 		</Tree.Root>
 	);
 }

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -215,10 +215,16 @@ const TreeItem = React.memo(
 		});
 
 		const handleClick = (event: React.MouseEvent) => {
-			if (selected === undefined) return;
+			if (selected !== undefined) {
+				event.stopPropagation(); // Avoid selecting parent treeitem
+				onSelectedChange?.(!selected);
+				return;
+			}
 
-			event.stopPropagation(); // Avoid selecting parent treeitem
-			onSelectedChange?.(!selected);
+			// Expand on click if not selectable
+			if (expanded === undefined) return;
+			event.stopPropagation(); // Avoid expanding parent treeitem
+			onExpandedChange?.(!expanded);
 		};
 
 		const handleKeyDown = (event: React.KeyboardEvent) => {


### PR DESCRIPTION
This PR updates the `Tree.Item` component to call `onExpandedChange` when clicked _if_ the item is not selectable (i.e. `selected` prop is `undefined`).

This is partially based on the [APG recommendation](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/#keyboardinteraction) (emphasis mine):
> <kbd>Enter</kbd>: activates a node, i.e., performs its default action. **For parent nodes, one possible default action is to open or close the node.** In single-select trees where selection does not follow focus (see note below), the default action is typically to select the focused node.

While APG is too focused on describing keyboard interactions, I believe the "default action" intent is consistent between left click and <kbd>Enter</kbd> key, as seen in [this APG example](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/examples/treeview-1a/).

---

**Preview:** [/tests/tree?_expansion](https://itwin.github.io/design-system/tests/tree?_expansion) vs [/tests/tree?_expansion&selectable](https://itwin.github.io/design-system/tests/tree?_expansion&selectable)