### PR TITLE
`NavigationRail`: set `aria-current` to `"true"` instead of `"page"`

### DIFF
--- a/apps/test-app/app/tests/navigation-rail/index.spec.ts
+++ b/apps/test-app/app/tests/navigation-rail/index.spec.ts
@@ -11,6 +11,11 @@ test("default", async ({ page }) => {
 
 	const navigationRail = page.getByRole("navigation");
 	await expect(navigationRail).toBeVisible();
+
+	const activeItem = navigationRail.getByRole("link", {
+		name: "Administration",
+	});
+	await expect(activeItem).toHaveAttribute("aria-current");
 });
 
 test.describe("expansion", () => {

--- a/packages/structures/src/NavigationRail.css
+++ b/packages/structures/src/NavigationRail.css
@@ -242,7 +242,7 @@
 
 @media (forced-colors: active) {
 	.🥝NavigationRailItemAction {
-		&:where([aria-current="page"]) {
+		&:where([aria-current]:not([aria-current="false"])) {
 			forced-color-adjust: none;
 			background-color: SelectedItem;
 			border-color: LinkText;

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -470,7 +470,7 @@ const NavigationRailAnchor = forwardRef<"a", NavigationRailAnchorProps>(
 			<NavigationRailItemAction
 				label={label}
 				icon={icon}
-				aria-current={active ? "page" : undefined}
+				aria-current={active ? "true" : undefined}
 				render={<Role.a {...rest} ref={forwardedRef} />}
 			/>
 		);


### PR DESCRIPTION
Follow-up to #884. This changes `NavigationRail.Anchor` to use the more versatile `aria-current="true"` instead of `aria-current="page"`.

### Rationale

This is how it was originally implemented [before being changed](https://github.com/iTwin/design-system/pull/884#discussion_r2302074124). We are now changing it back based on feedback from @Heydon and to make consistent with `NavigationList` (which will even be used inside the `NavigationRail`).

There is very little difference for the end user, as both of these have similar support and are announced similarly by screen readers ("current" or "current page").