### PR TITLE
Unify `displayName` of components

### DIFF
--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -71,7 +71,7 @@ const FieldRoot = forwardRef<"div", FieldRootProps>((props, forwardedRef) => {
 		/>
 	);
 });
-DEV: FieldRoot.displayName = "Field";
+DEV: FieldRoot.displayName = "Field.Root";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -196,7 +196,7 @@ const NavigationRailRootInner = forwardRef<"nav", NavigationRailRootInnerProps>(
 		);
 	},
 );
-DEV: NavigationRailRootInner.displayName = "NavigationRail.RootInner";
+DEV: NavigationRailRootInner.displayName = "NavigationRailRootInner";
 
 // ----------------------------------------------------------------------------
 
@@ -388,7 +388,7 @@ const NavigationRailListItem = forwardRef<"div", NavigationRailListItemProps>(
 		);
 	},
 );
-DEV: NavigationRailListItem.displayName = "NavigationRail.Item";
+DEV: NavigationRailListItem.displayName = "NavigationRail.ListItem";
 
 // ----------------------------------------------------------------------------
 
@@ -436,7 +436,7 @@ const NavigationRailItemAction = forwardRef<
 
 	return action;
 });
-DEV: NavigationRailItemAction.displayName = "NavigationRail.ItemAction";
+DEV: NavigationRailItemAction.displayName = "NavigationRailItemAction";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Popover.tsx
+++ b/packages/structures/src/Popover.tsx
@@ -40,7 +40,7 @@ function PopoverProvider(props: PopoverProviderProps) {
 		</AkPopover.PopoverProvider>
 	);
 }
-DEV: PopoverProvider.displayName = "Popover.Provider";
+DEV: PopoverProvider.displayName = "PopoverProvider";
 
 // ----------------------------------------------------------------------------
 
@@ -62,7 +62,7 @@ const PopoverDisclosure = forwardRef<"button", PopoverDisclosureProps>(
 		);
 	},
 );
-DEV: PopoverDisclosure.displayName = "Popover.Disclosure";
+DEV: PopoverDisclosure.displayName = "PopoverDisclosure";
 
 // ----------------------------------------------------------------------------
 
@@ -106,7 +106,7 @@ const PopoverRoot = forwardRef<"div", PopoverRootProps>(
 		);
 	},
 );
-DEV: PopoverRoot.displayName = "Popover.Root";
+DEV: PopoverRoot.displayName = "PopoverRoot";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/~utils.ListItem.tsx
+++ b/packages/structures/src/~utils.ListItem.tsx
@@ -14,7 +14,7 @@ import type { RoleProps } from "@ariakit/react/role";
 
 interface ListItemProps extends RoleProps<"div"> {}
 
-/** @internal */
+/** @private */
 const ListItem = forwardRef<"div", ListItemProps>((props, forwardedRef) => {
 	return (
 		<Role.div
@@ -31,7 +31,7 @@ DEV: ListItem.displayName = "ListItemRoot";
 
 interface ListItemContentProps extends RoleProps<"div"> {}
 
-/** @internal */
+/** @private */
 const ListItemContent = forwardRef<"div", ListItemContentProps>(
 	(props, forwardedRef) => {
 		return (
@@ -50,7 +50,7 @@ DEV: ListItemContent.displayName = "ListItemContent";
 
 interface ListItemDecorationProps extends RoleProps<"div"> {}
 
-/** @internal */
+/** @private */
 const ListItemDecoration = forwardRef<"div", ListItemDecorationProps>(
 	(props, forwardedRef) => {
 		return (

--- a/packages/structures/src/~utils.ListItem.tsx
+++ b/packages/structures/src/~utils.ListItem.tsx
@@ -25,7 +25,7 @@ const ListItem = forwardRef<"div", ListItemProps>((props, forwardedRef) => {
 		/>
 	);
 });
-DEV: ListItem.displayName = "ListItem.Root";
+DEV: ListItem.displayName = "ListItemRoot";
 
 // ----------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ const ListItemContent = forwardRef<"div", ListItemContentProps>(
 		);
 	},
 );
-DEV: ListItemContent.displayName = "ListItem.Content";
+DEV: ListItemContent.displayName = "ListItemContent";
 
 // ----------------------------------------------------------------------------
 
@@ -62,7 +62,7 @@ const ListItemDecoration = forwardRef<"div", ListItemDecorationProps>(
 		);
 	},
 );
-DEV: ListItemDecoration.displayName = "ListItem.Decoration";
+DEV: ListItemDecoration.displayName = "ListItemDecoration";
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Unify component `displayName` based on https://github.com/iTwin/design-system/pull/1075#discussion_r2518503218

Changes `@internal` JSDoc tag to `@private`.