### PR TITLE
internal: add `useInit()` hook to every component

### DIFF
--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -7,6 +7,7 @@ import { Focusable } from "@ariakit/react/focusable";
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
 import type {
@@ -39,6 +40,8 @@ interface AnchorRootProps extends FocusableProps<"a"> {
  * ```
  */
 const AnchorRoot = forwardRef<"a", AnchorRootProps>((props, forwardedRef) => {
+	useInit();
+
 	const { tone = "neutral", ...rest } = props;
 
 	return (

--- a/packages/bricks/src/Avatar.tsx
+++ b/packages/bricks/src/Avatar.tsx
@@ -6,6 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -58,6 +59,8 @@ interface AvatarProps extends Omit<BaseProps<"span">, "children"> {
  * ```
  */
 const Avatar = forwardRef<"span", AvatarProps>((props, forwardedRef) => {
+	useInit();
+
 	const { size = "medium", initials, alt, image, ...rest } = props;
 
 	const isDecorative = !alt;

--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -8,6 +8,7 @@ import { Text } from "@stratakit/bricks";
 import { Icon } from "@stratakit/foundations";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -48,6 +49,7 @@ interface BadgeProps extends Omit<BaseProps<"span">, "children"> {
  * ```
  */
 const Badge = forwardRef<"span", BadgeProps>((props, forwardedRef) => {
+	useInit();
 	const { tone = "neutral", variant = "solid", label, icon, ...rest } = props;
 	return (
 		<Role.span

--- a/packages/bricks/src/Button.tsx
+++ b/packages/bricks/src/Button.tsx
@@ -7,6 +7,7 @@ import { Button as AkButton } from "@ariakit/react/button";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
+import { useInit } from "./~utils.useInit.js";
 
 import type { FocusableProps } from "@stratakit/foundations/secret-internals";
 
@@ -47,6 +48,8 @@ interface ButtonProps extends FocusableProps<"button"> {
  * The button's appearance can be customized using the `variant` and `tone` props.
  */
 const Button = forwardRef<"button", ButtonProps>((props, forwardedRef) => {
+	useInit();
+
 	const { variant = "solid", tone = "neutral", ...rest } = props;
 
 	const ghostAlignment = useGhostAlignment();

--- a/packages/bricks/src/Checkbox.tsx
+++ b/packages/bricks/src/Checkbox.tsx
@@ -6,6 +6,7 @@
 import { Checkbox as AkCheckbox } from "@ariakit/react/checkbox";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
@@ -47,6 +48,7 @@ interface CheckboxProps extends InputBaseProps, CheckboxOwnProps {}
  * including `value`, `defaultChecked`, `checked`, and `onChange`.
  */
 const Checkbox = forwardRef<"input", CheckboxProps>((props, forwardedRef) => {
+	useInit();
 	useFieldControlType("checkable");
 	return (
 		<AkCheckbox

--- a/packages/bricks/src/Description.tsx
+++ b/packages/bricks/src/Description.tsx
@@ -5,6 +5,7 @@
 
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
@@ -24,6 +25,8 @@ interface DescriptionProps extends BaseProps {
  */
 const Description = forwardRef<"div", DescriptionProps>(
 	(props, forwardedRef) => {
+		useInit();
+
 		const { tone, ...rest } = props;
 
 		return (

--- a/packages/bricks/src/Divider.tsx
+++ b/packages/bricks/src/Divider.tsx
@@ -7,6 +7,7 @@ import { Role } from "@ariakit/react/role";
 import { Separator } from "@ariakit/react/separator";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { SeparatorProps } from "@ariakit/react/separator";
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
@@ -35,6 +36,8 @@ interface DividerProps
  * and can be a semantic divider or a purely presentational one (using the `presentational` prop).
  */
 const Divider = forwardRef<"hr", DividerProps>((props, forwardedRef) => {
+	useInit();
+
 	const { presentational, bleed, ...rest } = props;
 
 	const Comp = presentational ? Role : Separator;

--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -12,6 +12,7 @@ import { Role } from "@ariakit/react/role";
 import { useStoreState } from "@ariakit/react/store";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import Description from "./Description.js";
 import { FieldCollection, FieldControlTypeContext } from "./Field.internal.js";
 import Label from "./Label.js";
@@ -57,6 +58,7 @@ interface FieldRootProps extends BaseProps {
  * - `Switch`
  */
 const FieldRoot = forwardRef<"div", FieldRootProps>((props, forwardedRef) => {
+	useInit();
 	const { layout, ...rest } = props;
 	return (
 		<FieldCollection

--- a/packages/bricks/src/IconButton.tsx
+++ b/packages/bricks/src/IconButton.tsx
@@ -10,6 +10,7 @@ import {
 	useMergedRefs,
 } from "@stratakit/foundations/secret-internals";
 import { Dot } from "./~utils.Dot.js";
+import { useInit } from "./~utils.useInit.js";
 import Button from "./Button.js";
 import {
 	IconButtonContext,
@@ -109,6 +110,8 @@ interface IconButtonProps
  */
 const IconButton = forwardRef<"button", IconButtonProps>(
 	(props, forwardedRef) => {
+		useInit();
+
 		const { label, icon, active, labelVariant, dot, ...rest } = props;
 
 		const baseId = React.useId();

--- a/packages/bricks/src/Kbd.tsx
+++ b/packages/bricks/src/Kbd.tsx
@@ -6,6 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import { predefinedSymbols } from "./Kbd.internal.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
@@ -42,6 +43,8 @@ interface KbdProps extends BaseProps<"kbd"> {
  * ```
  */
 const Kbd = forwardRef<"kbd", KbdProps>((props, forwardedRef) => {
+	useInit();
+
 	const { variant = "solid", symbol, children, ...rest } = props;
 
 	DEV: {

--- a/packages/bricks/src/Label.tsx
+++ b/packages/bricks/src/Label.tsx
@@ -6,6 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -25,6 +26,7 @@ interface LabelProps extends BaseProps<"label"> {}
  * association with adjacent form control).
  */
 const Label = forwardRef<"label", LabelProps>((props, forwardedRef) => {
+	useInit();
 	return (
 		<Role.label
 			{...props}

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -59,6 +60,8 @@ interface ProgressBarProps extends Omit<BaseProps, "aria-labelledby"> {
  */
 const ProgressBar = forwardRef<"div", ProgressBarProps>(
 	(props, forwardedRef) => {
+		useInit();
+
 		const {
 			size = "medium",
 			tone = "neutral",

--- a/packages/bricks/src/Radio.tsx
+++ b/packages/bricks/src/Radio.tsx
@@ -6,6 +6,7 @@
 import { Radio as AkRadio } from "@ariakit/react/radio";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { RadioProps as AkRadioProps } from "@ariakit/react/radio";
@@ -42,6 +43,7 @@ interface RadioProps extends InputBaseProps, RadioOwnProps {}
  * including `value`, `defaultChecked`, `checked`, and `onChange`.
  */
 const Radio = forwardRef<"input", RadioProps>((props, forwardedRef) => {
+	useInit();
 	useFieldControlType("checkable");
 	return (
 		<AkRadio

--- a/packages/bricks/src/Select.tsx
+++ b/packages/bricks/src/Select.tsx
@@ -8,6 +8,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef, isBrowser } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
 import { CaretsUpDown } from "./~utils.icons.js";
+import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type {
@@ -60,6 +61,7 @@ const HtmlSelectContext = React.createContext<
  * ```
  */
 const SelectRoot = forwardRef<"div", BaseProps>((props, forwardedRef) => {
+	useInit();
 	useFieldControlType("textlike");
 	const [isHtmlSelect, setIsHtmlSelect] = React.useState(false);
 

--- a/packages/bricks/src/Skeleton.tsx
+++ b/packages/bricks/src/Skeleton.tsx
@@ -6,6 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -36,6 +37,8 @@ type SkeletonProps = SkeletonPropsBase & {
  * ```
  */
 const Skeleton = forwardRef<"div", SkeletonProps>((props, forwardedRef) => {
+	useInit();
+
 	const { variant = "text", size = "medium", ...rest } = props;
 
 	return (

--- a/packages/bricks/src/Spinner.tsx
+++ b/packages/bricks/src/Spinner.tsx
@@ -6,6 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
@@ -42,6 +43,8 @@ interface SpinnerProps extends BaseProps {
  * Supports a `size` prop to change the size of the spinner.
  */
 const Spinner = forwardRef<"div", SpinnerProps>((props, forwardedRef) => {
+	useInit();
+
 	const {
 		alt = "Loading…",
 		size = "medium",

--- a/packages/bricks/src/Switch.tsx
+++ b/packages/bricks/src/Switch.tsx
@@ -6,6 +6,7 @@
 import { Checkbox as AkCheckbox } from "@ariakit/react/checkbox";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
@@ -51,6 +52,7 @@ interface SwitchProps extends InputBaseProps, CheckboxOwnProps {
  * including `value`, `defaultChecked`, `checked`, and `onChange`.
  */
 const Switch = forwardRef<"input", SwitchProps>((props, forwardedRef) => {
+	useInit();
 	useFieldControlType("checkable");
 	return (
 		<AkCheckbox

--- a/packages/bricks/src/Text.tsx
+++ b/packages/bricks/src/Text.tsx
@@ -6,6 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -43,6 +44,8 @@ interface TextProps extends BaseProps {
  * ```
  */
 const Text = forwardRef<"div", TextProps>((props, forwardedRef) => {
+	useInit();
+
 	const { variant, ...rest } = props;
 
 	return (

--- a/packages/bricks/src/TextBox.tsx
+++ b/packages/bricks/src/TextBox.tsx
@@ -13,6 +13,7 @@ import {
 	useMergedRefs,
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type {
@@ -73,6 +74,7 @@ interface TextBoxInputProps extends Omit<BaseInputProps, "children" | "type"> {
  */
 const TextBoxInput = forwardRef<"input", TextBoxInputProps>(
 	(props, forwardedRef) => {
+		useInit();
 		useFieldControlType("textlike");
 		const rootContext = React.useContext(TextBoxRootContext);
 		const setDisabled = rootContext?.setDisabled;

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -11,6 +11,7 @@ import {
 	usePopoverApi,
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import { TooltipContext } from "./Tooltip.internal.js";
 
 import type { FocusableProps } from "@stratakit/foundations/secret-internals";
@@ -74,6 +75,8 @@ interface TooltipProps
  * **Note**: If `type` is set to `"none"`, the tooltip will not use ARIA attributes.
  */
 const Tooltip = forwardRef<"div", TooltipProps>((props, forwardedRef) => {
+	useInit();
+
 	const generatedId = React.useId();
 	const context = React.useContext(TooltipContext);
 

--- a/packages/bricks/src/VisuallyHidden.tsx
+++ b/packages/bricks/src/VisuallyHidden.tsx
@@ -6,6 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -26,6 +27,7 @@ interface VisuallyHiddenProps extends BaseProps<"span"> {}
  */
 const VisuallyHidden = forwardRef<"span", VisuallyHiddenProps>(
 	(props, forwardedRef) => {
+		useInit();
 		return (
 			<Role.span
 				{...props}

--- a/packages/bricks/src/~utils.useInit.tsx
+++ b/packages/bricks/src/~utils.useInit.tsx
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { RootContext } from "@stratakit/foundations/secret-internals";
+
+/**
+ * Internal hook that should be called by all bricks.
+ * Currently, it just validates that bricks are used inside `Root` (from foundations).
+ *
+ * @private
+ */
+export function useInit() {
+	if (!React.useContext(RootContext)) {
+		DEV: console.error(
+			`All @stratakit/bricks components must be used within a <Root> component from @stratakit/foundations.`,
+		);
+	}
+}

--- a/packages/foundations/src/Root.internal.tsx
+++ b/packages/foundations/src/Root.internal.tsx
@@ -8,6 +8,12 @@ import { useIsClient } from "./~hooks.js";
 
 // ----------------------------------------------------------------------------
 
+/** @private */
+export const RootContext = React.createContext({});
+DEV: RootContext.displayName = "RootContext";
+
+// ----------------------------------------------------------------------------
+
 export const RootNodeContext = React.createContext<
 	Document | ShadowRoot | undefined
 >(undefined);

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -20,6 +20,7 @@ import {
 } from "./~utils.js";
 import {
 	HtmlSanitizerContext,
+	RootContext,
 	RootNodeContext,
 	spriteSheetId,
 	useRootNode,
@@ -110,25 +111,27 @@ export const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 	} = props;
 
 	return (
-		<RootInternal {...rest} ref={forwardedRef}>
-			<Styles />
-			<Fonts />
-			<InlineSpriteSheet />
+		<RootContext.Provider value={true}>
+			<RootInternal {...rest} ref={forwardedRef}>
+				<Styles />
+				<Fonts />
+				<InlineSpriteSheet />
 
-			{synchronizeColorScheme ? (
-				<SynchronizeColorScheme colorScheme={props.colorScheme} />
-			) : null}
+				{synchronizeColorScheme ? (
+					<SynchronizeColorScheme colorScheme={props.colorScheme} />
+				) : null}
 
-			<HtmlSanitizerContext.Provider value={unstable_htmlSanitizer}>
-				<PortalProvider
-					colorScheme={props.colorScheme}
-					density={props.density}
-					portalContainerProp={portalContainerProp}
-				>
-					{children}
-				</PortalProvider>
-			</HtmlSanitizerContext.Provider>
-		</RootInternal>
+				<HtmlSanitizerContext.Provider value={unstable_htmlSanitizer}>
+					<PortalProvider
+						colorScheme={props.colorScheme}
+						density={props.density}
+						portalContainerProp={portalContainerProp}
+					>
+						{children}
+					</PortalProvider>
+				</HtmlSanitizerContext.Provider>
+			</RootInternal>
+		</RootContext.Provider>
 	);
 });
 DEV: Root.displayName = "Root";

--- a/packages/foundations/src/secret-internals.ts
+++ b/packages/foundations/src/secret-internals.ts
@@ -6,3 +6,4 @@
 export * from "./~hooks.js";
 export * from "./~utils.icons.js";
 export * from "./~utils.js";
+export { RootContext } from "./Root.internal.js";

--- a/packages/structures/src/AccordionItem.tsx
+++ b/packages/structures/src/AccordionItem.tsx
@@ -20,6 +20,7 @@ import {
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -97,6 +98,8 @@ interface AccordionItemProps extends BaseProps {
  */
 const AccordionItemRoot = forwardRef<"div", AccordionItemProps>(
 	(props, forwardedRef) => {
+		useInit();
+
 		const {
 			defaultOpen,
 			open: openProp,

--- a/packages/structures/src/Banner.tsx
+++ b/packages/structures/src/Banner.tsx
@@ -16,6 +16,7 @@ import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
 import { Dismiss, StatusIcon } from "./~utils.icons.js";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 import type { ExtractState } from "zustand";
@@ -101,6 +102,8 @@ interface BannerRootProps extends BaseProps<"div"> {
  * ```
  */
 const BannerRoot = forwardRef<"div", BannerRootProps>((props, forwardedRef) => {
+	useInit();
+
 	const { tone = "neutral", variant = "outline", ...rest } = props;
 
 	return (
@@ -413,6 +416,8 @@ type BannerProps = Omit<BaseProps, "children"> &
  * ```
  */
 const Banner = forwardRef<"div", BannerProps>((props, forwardedRef) => {
+	useInit();
+
 	const {
 		message,
 		label,

--- a/packages/structures/src/Chip.tsx
+++ b/packages/structures/src/Chip.tsx
@@ -14,6 +14,7 @@ import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
 import { Dismiss } from "./~utils.icons.js";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 import type { ExtractState } from "zustand";
@@ -76,6 +77,8 @@ interface ChipRootProps extends BaseProps<"div"> {
  * ```
  */
 const ChipRoot = forwardRef<"div", ChipRootProps>((props, forwardedRef) => {
+	useInit();
+
 	const { variant = "solid", ...rest } = props;
 
 	return (
@@ -188,6 +191,8 @@ interface ChipProps
  * ```
  */
 const Chip = forwardRef<"div", ChipProps>((props, forwardedRef) => {
+	useInit();
+
 	const { onDismiss, label, ...rest } = props;
 
 	return (

--- a/packages/structures/src/Dialog.tsx
+++ b/packages/structures/src/Dialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
 import { Dismiss } from "./~utils.icons.js";
+import { useInit } from "./~utils.useInit.js";
 
 import type {
 	BaseProps,
@@ -71,6 +72,8 @@ interface DialogRootProps
  * ```
  */
 const DialogRoot = forwardRef<"div", DialogRootProps>((props, forwardedRef) => {
+	useInit();
+
 	const { backdrop = true, unmountOnHide = true, ...rest } = props;
 
 	const store = AkDialog.useDialogStore();

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -30,6 +30,7 @@ import {
 import cx from "classnames";
 import { Checkmark, ChevronRight } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
+import { useInit } from "./~utils.useInit.js";
 
 import type {
 	MenuItemCheckboxProps,
@@ -72,6 +73,8 @@ interface DropdownMenuProps
  * **Note**: `DropdownMenu` should not be used for navigation; it is only intended for actions.
  */
 function DropdownMenuProvider(props: DropdownMenuProps) {
+	useInit();
+
 	const { children, placement, open, setOpen, defaultOpen } = props;
 
 	return (

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -24,6 +24,7 @@ import {
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
 import { ChevronDown, StatusIcon } from "./~utils.icons.js";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -99,6 +100,8 @@ type ErrorRegionRootProps = ErrorRegionRootBaseProps &
  */
 const ErrorRegionRoot = forwardRef<"div", ErrorRegionRootProps>(
 	(props, forwardedRef) => {
+		useInit();
+
 		const {
 			label,
 			items = [],

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -17,6 +17,7 @@ import {
 import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
+import { useInit } from "./~utils.useInit.js";
 
 import type {
 	BaseProps,
@@ -168,6 +169,8 @@ interface NavigationRailRootProps extends NavigationRailRootInnerProps {
  */
 const NavigationRailRoot = forwardRef<"nav", NavigationRailRootProps>(
 	(props, forwardedRef) => {
+		useInit();
+
 		const { defaultExpanded = false, expanded, setExpanded, ...rest } = props;
 
 		return (

--- a/packages/structures/src/Popover.tsx
+++ b/packages/structures/src/Popover.tsx
@@ -13,6 +13,7 @@ import {
 	usePopoverApi,
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type {
 	BaseProps,
@@ -142,6 +143,8 @@ interface PopoverProps
  * ```
  */
 const Popover = forwardRef<"div", PopoverProps>((props, forwardedRef) => {
+	useInit();
+
 	const { children, content, open, setOpen, placement, ...rest } = props;
 
 	return (

--- a/packages/structures/src/Table.tsx
+++ b/packages/structures/src/Table.tsx
@@ -11,6 +11,7 @@ import {
 	useSafeContext,
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -66,6 +67,8 @@ interface HtmlTableProps extends BaseProps {}
  * ```
  */
 const HtmlTable = forwardRef<"table", HtmlTableProps>((props, forwardedRef) => {
+	useInit();
+
 	const tableContextValue = React.useMemo(
 		() => ({ mode: "html" as const }),
 		[],
@@ -125,6 +128,8 @@ interface CustomTableProps extends BaseProps {}
  */
 const CustomTable = forwardRef<"div", CustomTableProps>(
 	(props, forwardedRef) => {
+		useInit();
+
 		// const { captionId } = useSafeContext(TableContext);
 		const [captionId, setCaptionId] = React.useState<string | undefined>();
 

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -11,6 +11,7 @@ import {
 	useUnreactiveCallback,
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type {
 	BaseProps,
@@ -69,6 +70,8 @@ interface TabsProviderProps
  * **Note**: `Tabs` should _not_ be used for navigation; it is only intended for switching smaller views within an existing page.
  */
 function TabsProvider(props: TabsProviderProps) {
+	useInit();
+
 	const {
 		defaultSelectedId,
 		selectedId,

--- a/packages/structures/src/Toolbar.tsx
+++ b/packages/structures/src/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
 } from "@stratakit/bricks/secret-internals";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -53,6 +54,8 @@ interface ToolbarGroupProps extends BaseProps {
  */
 const ToolbarGroup = forwardRef<"div", ToolbarGroupProps>(
 	(props, forwardedRef) => {
+		useInit();
+
 		return (
 			<IconButtonContext.Provider
 				value={React.useMemo(() => ({ iconSize: "large" }), [])}

--- a/packages/structures/src/Tree.tsx
+++ b/packages/structures/src/Tree.tsx
@@ -7,6 +7,7 @@ import { Composite, useCompositeStore } from "@ariakit/react/composite";
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
+import { useInit } from "./~utils.useInit.js";
 import { Action as TreeItemAction, Root as TreeItemRoot } from "./TreeItem.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
@@ -32,6 +33,8 @@ interface TreeProps extends BaseProps {}
  * ```
  */
 const Tree = forwardRef<"div", TreeProps>((props, forwardedRef) => {
+	useInit();
+
 	const composite = useCompositeStore({ orientation: "vertical" });
 
 	return (

--- a/packages/structures/src/~utils.useInit.tsx
+++ b/packages/structures/src/~utils.useInit.tsx
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { RootContext } from "@stratakit/foundations/secret-internals";
+
+/**
+ * Internal hook that should be called by all structures.
+ * Currently, it just validates that structures are used inside `Root` (from foundations).
+ *
+ * @private
+ */
+export function useInit() {
+	if (!React.useContext(RootContext)) {
+		DEV: console.error(
+			`All @stratakit/structures components must be used within a <Root> component from @stratakit/foundations.`,
+		);
+	}
+}


### PR DESCRIPTION
Every component in `@stratakit/bricks` and `@stratakit/structures` now calls `useInit()` which looks for `RootContext` exported from `@stratakit/foundations/secret-internals`. If not found, it prints a console error during development.

In the future, we can evolve the `useInit()` hook to:
- `throw` if the context is not found.
- load CSS (instead of relying on `Root`). #826