### PR TITLE
show `Tooltip` when long pressing buttons

### DIFF
--- a/.changeset/three-beers-serve.md
+++ b/.changeset/three-beers-serve.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+`Tooltip` will now be triggered when long pressing buttons on touch devices (except in Safari).

--- a/apps/test-app/app/tests/tooltip/index.spec.ts
+++ b/apps/test-app/app/tests/tooltip/index.spec.ts
@@ -45,6 +45,17 @@ test.describe("default", () => {
 		await expect(tooltip).toBeVisible();
 		await expect(button).toHaveAttribute("data-has-popover-open");
 	});
+
+	test("contextmenu should display the tooltip", async ({ page }) => {
+		const button = page.getByRole("button");
+		const tooltip = page.getByRole("tooltip", { includeHidden: true });
+
+		// Contextmenu event simulates a long press on Android browsers
+		await page.dispatchEvent("button", "contextmenu");
+
+		await expect(tooltip).toBeVisible();
+		await expect(button).toHaveAttribute("data-has-popover-open");
+	});
 });
 
 test.describe("hover", () => {

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -8,6 +8,7 @@ import { useStoreState } from "@ariakit/react/store";
 import * as AkTooltip from "@ariakit/react/tooltip";
 import {
 	forwardRef,
+	useEventHandlers,
 	usePopoverApi,
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
@@ -108,6 +109,19 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, forwardedRef) => {
 		>
 			<AkTooltip.TooltipAnchor
 				render={children}
+				onContextMenu={useEventHandlers(
+					(children.props as React.ComponentProps<"div">)?.onContextMenu,
+					(event) => {
+						// Show tooltip on long press for buttons
+						const isButton =
+							event.currentTarget.localName === "button" ||
+							event.currentTarget.role === "button";
+						if (!isButton) return;
+
+						event.preventDefault();
+						store.setOpen(true);
+					},
+				)}
 				data-has-popover-open={open || undefined}
 				{...(type === "description" && { "aria-describedby": id })}
 				{...(type === "label" && { "aria-labelledby": id })}


### PR DESCRIPTION
This improves the accessibility of `Tooltip` on touch devices by making it triggered by the [`contextmenu`](https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event) event. This event is unfortunately not supported in iOS, but on supported platforms, it's fired when long pressing the target.

This is only done for `<button>` or `role="button"` elements, because the default context menu is useful for other elements (e.g. for opening a link in a new tab or selecting/pasting text inside an input).

This also works for `IconButton` which uses `Tooltip` internally.

(See also: previous exploration https://github.com/iTwin/design-system/pull/703)

### Testing

[Deploy preview](https://itwin.github.io/design-system/1090/tests/tooltip)

✅ Manually tested on Chrome Android that long pressing triggers the tooltip.

<details>
<summary>Screen recording (from desktop browser emulation)</summary>

https://github.com/user-attachments/assets/054a916b-fbe9-4041-b05f-852b324217aa

</details>

See [comment](https://github.com/iTwin/design-system/pull/1090#discussion_r2543253289) about automated testing.