### PR TITLE
`Label`: set explicit `line-height`

### DIFF
--- a/.changeset/sour-laws-build.md
+++ b/.changeset/sour-laws-build.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+`Label` component will now set an explicit `line-height`.

--- a/packages/bricks/src/Label.css
+++ b/packages/bricks/src/Label.css
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 .🥝Label {
 	@layer base {
+		@apply --typography("body-sm");
+
 		color: var(--stratakit-color-text-neutral-secondary);
 		cursor: default;
-		font-size: var(--stratakit-font-size-12);
 
 		&:is(label) {
 			cursor: pointer;


### PR DESCRIPTION
Replaced `font-size` declaration with `--typography("body-sm")`. This addresses https://github.com/iTwin/iTwinUI/issues/2649#issuecomment-3541735027.

(The `--typography` mixin has built-in `line-height` to go with the `font-size`)