### PR TITLE
keep `DropdownMenu.Submenu` mounted when parent menu is open

### DIFF
--- a/.changeset/every-feet-arrive.md
+++ b/.changeset/every-feet-arrive.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+`DropdownMenu.Submenu` will now remain mounted in the DOM as long as the parent DropdownMenu is open.

--- a/apps/test-app/app/tests/dropdown-menu/index.spec.ts
+++ b/apps/test-app/app/tests/dropdown-menu/index.spec.ts
@@ -11,7 +11,7 @@ test("default", async ({ page }) => {
 
 	const button = page.getByRole("button", { name: "Actions" });
 	const add = page.getByRole("menuitem", { name: "Add" });
-	const menu = page.getByRole("menu", { includeHidden: true });
+	const menu = page.getByRole("menu", { includeHidden: true }).first();
 
 	await expect(button).not.toHaveAttribute("data-has-popover-open");
 	await expect(menu).toHaveCount(0);
@@ -134,20 +134,21 @@ test.describe("submenu", () => {
 		await page.goto("/tests/dropdown-menu?submenu");
 
 		const button = page.getByRole("button", { name: "Actions" });
-		const menu = page.getByRole("menu", { includeHidden: true });
+		const allMenus = page.getByRole("menu", { includeHidden: true });
+		const visibleMenus = page.getByRole("menu", { includeHidden: false });
 		const item1 = page.getByRole("menuitem", { name: "Item 1" });
 		const item3 = page.getByRole("menuitem", { name: "Item 3", exact: true });
 		const item3_1 = page.getByRole("menuitem", { name: "Item 3_1" });
 
-		await expect(menu).toHaveCount(0);
+		await expect(allMenus).toHaveCount(0);
 
 		await button.click();
-		await expect(menu).toHaveCount(1);
+		await expect(visibleMenus).toHaveCount(1);
 		await expect(button).toHaveAttribute("data-has-popover-open");
 		await expect(item1).toBeVisible();
 
 		await item3.hover();
-		await expect(menu).toHaveCount(2);
+		await expect(visibleMenus).toHaveCount(2);
 		await expect(item3).toHaveAttribute("data-has-popover-open");
 		await expect(item3_1).toBeVisible();
 
@@ -164,7 +165,7 @@ test.describe("submenu", () => {
 		await page.goto("/tests/dropdown-menu?submenu");
 
 		const button = page.getByRole("button", { name: "Actions" });
-		const menu = page.getByRole("menu", { includeHidden: true });
+		const menu = page.getByRole("menu");
 		const item3 = page.getByRole("menuitem", { name: "Item 3", exact: true });
 
 		await button.click();
@@ -181,7 +182,7 @@ test.describe("submenu", () => {
 		await page.goto("/tests/dropdown-menu?submenu");
 
 		const button = page.getByRole("button", { name: "Actions" });
-		const menu = page.getByRole("menu", { includeHidden: true });
+		const menu = page.getByRole("menu");
 		const item1 = page.getByRole("menuitem", { name: "Item 1" });
 		const item3 = page.getByRole("menuitem", { name: "Item 3", exact: true });
 		const item3_1 = page.getByRole("menuitem", { name: "Item 3_1" });
@@ -207,7 +208,7 @@ test.describe("submenu", () => {
 		await page.goto("/tests/dropdown-menu?submenu");
 
 		const button = page.getByRole("button", { name: "Actions" });
-		const menu = page.getByRole("menu", { includeHidden: true });
+		const menu = page.getByRole("menu");
 		const item1 = page.getByRole("menuitem", { name: "Item 1" });
 		const item2 = page.getByRole("menuitem", { name: "Item 2" });
 		const item3 = page.getByRole("menuitem", { name: "Item 3", exact: true });

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -488,7 +488,6 @@ const DropdownMenuSubmenu = forwardRef<"div", DropdownMenuSubmenuProps>(
 					portal
 					portalElement={popoverElement}
 					preserveTabOrder={false}
-					unmountOnHide
 					{...props}
 					gutter={2}
 					shift={-4}


### PR DESCRIPTION
This removes [`unmountOnHide`](https://ariakit.org/reference/menu#unmountonhide) from `DropdownMenu.Submenu`. Instead, it will automatically unmount when the parent `DropdownMenu.Content` is unmounted. This makes the behavior more predictable, preserving ephemeral state until the entire menu is closed.

### Rationale

This is based on my observation playing with the `?visual` story.

- [`main` branch](https://itwin.github.io/design-system/tests/dropdown-menu?visual): When trying to uncheck a `defaultChecked` item inside a submenu, it returns back to being checked after the submenu is closed. This makes the `defaultChecked` prop useless, basically requiring consumers to maintain `checked` state.
- [This PR](https://itwin.github.io/design-system/1103/tests/dropdown-menu?visual): `defaultChecked` does not override user-set state as long as the parent menu is open. This allows consumers to re-set `defaultChecked` whenever the menu opens next time.
   - Side note: To remove even more state (`open`/`setOpen`) from consumer code, we could also consider exposing an `onClose` prop (similar to `Dialog`).