### PR TITLE
add foundations to MUI Root

### DIFF
--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -14,6 +14,7 @@ import {
 	DialogContent,
 	DialogContentText,
 	DialogTitle,
+	IconButton,
 	Link,
 	Menu,
 	MenuItem,
@@ -22,12 +23,16 @@ import {
 	Tab,
 	Tabs,
 	TextField,
+	Tooltip,
 	Typography,
 } from "@mui/material";
+import { Icon } from "@stratakit/foundations";
 import { Root } from "@stratakit/mui";
 import { useColorScheme } from "./~utils.tsx";
 
 import type { MetaFunction } from "react-router";
+
+import svgPlaceholder from "@stratakit/icons/placeholder.svg";
 
 export const meta: MetaFunction = () => {
 	return [{ title: "StrataKit theme" }];
@@ -50,10 +55,23 @@ export default function Page() {
 						<Link href="#">Accent</Link>
 					</Stack>
 
-					<Stack spacing={1} direction="row">
-						<Button variant="contained">Solid</Button>
-						<Button variant="outlined">Outline</Button>
+					<Stack spacing={1} direction="row" alignItems="center">
+						<Button
+							variant="contained"
+							startIcon={<Icon href={svgPlaceholder} />}
+						>
+							Solid
+						</Button>
+						<Button variant="outlined" endIcon={<Icon href={svgPlaceholder} />}>
+							Outline
+						</Button>
 						<Button>Ghost</Button>
+
+						<Tooltip title="Default">
+							<IconButton>
+								<Icon href={svgPlaceholder} />
+							</IconButton>
+						</Tooltip>
 					</Stack>
 
 					<Stack spacing={1} direction="row">

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -45,6 +45,7 @@
 		"dev": "wireit"
 	},
 	"dependencies": {
+		"@stratakit/foundations": "^0.4.2",
 		"react-compiler-runtime": "^1.0.0"
 	},
 	"devDependencies": {

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -10,6 +10,7 @@ import {
 	ThemeProvider,
 	useColorScheme,
 } from "@mui/material/styles";
+import { Root as StrataKitRoot } from "@stratakit/foundations";
 import { createTheme } from "./createTheme.js";
 
 const theme = createTheme();
@@ -41,15 +42,41 @@ const Root = React.forwardRef<HTMLDivElement, RootProps>(
 				<ThemeProvider theme={theme} defaultMode={colorScheme}>
 					<CssBaseline />
 					<ColorScheme colorScheme={colorScheme} />
-					<div {...rest} ref={forwardedRef}>
+					<RootInner {...rest} colorScheme={colorScheme} ref={forwardedRef}>
 						{children}
-					</div>
+					</RootInner>
 				</ThemeProvider>
 			</StyledEngineProvider>
 		);
 	},
 );
 DEV: Root.displayName = "Root";
+
+// ----------------------------------------------------------------------------
+
+interface RootInnerProps
+	extends React.ComponentPropsWithoutRef<"div">,
+		Pick<RootProps, "colorScheme"> {}
+
+/** @private */
+const RootInner = React.forwardRef<HTMLDivElement, RootInnerProps>(
+	(props, forwardedRef) => {
+		const { children, colorScheme, ...rest } = props;
+
+		return (
+			<StrataKitRoot
+				{...rest}
+				colorScheme={colorScheme}
+				synchronizeColorScheme
+				density="dense"
+				ref={forwardedRef}
+			>
+				{children}
+			</StrataKitRoot>
+		);
+	},
+);
+DEV: RootInner.displayName = "RootInner";
 
 // ----------------------------------------------------------------------------
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       "@mui/material":
         specifier: ^7.3.5
         version: 7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@stratakit/foundations":
+        specifier: ^0.4.2
+        version: link:../foundations
       react-compiler-runtime:
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.1)


### PR DESCRIPTION
_Follow-up to #1109._

This PR updates the `Root` from `@stratakit/mui` to internally render the `Root` from `@stratakit/foundations`, while synchronizing the themes between the two Roots (~~using MUI's `useColorScheme` hook~~ using newly added `colorScheme` prop from #1109).

- The primary reason for this change right now is to unlock the use of StrataKit `Icon` component and the `@stratakit/icons` package. (Without foundations, consumers would get a "Context not found" error)
- A secondary reason for this change is to unlock the future use of custom CSS in the `@stratakit/mui` package.