### PR TITLE
add basic `typography` configuration for MUI

### DIFF
--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -15,6 +15,8 @@ npm add @stratakit/mui
 
 `@stratakit/mui` has a direct dependency on [`@stratakit/foundations`](https://www.npmjs.com/package/@stratakit/foundations) and [`@stratakit/icons`](https://www.npmjs.com/package/@stratakit/icons), the latter of which requires [bundler configuration](https://github.com/iTwin/design-system/tree/main/packages/icons#bundler-configuration) to ensure that `.svg` files are not inlined.
 
+Additionally, you should ensure that [StrataKit fonts](#fonts) are loaded in your application.
+
 ## Usage
 
 To use the StrataKit MUI theme, you’ll need to wrap your application's entrypoint with the `<Root>` component and set its `colorScheme` (to `"light"` or `"dark"`). This component will automatically configure MUI's `ThemeProvider` with the StrataKit theme.
@@ -37,6 +39,37 @@ import svgPlaceholder from "@stratakit/icons/placeholder.svg";
 ```
 
 For more details on using specific features, refer to the inline documentation available on every component and prop.
+
+## Fonts
+
+StrataKit uses [InterVariable](https://rsms.me/inter/) as its interface font. In the future, other fonts may also be added for different purposes. We recommend self-hosting all fonts for robustness, security and performance reasons.
+
+To self-host `InterVariable`, download the [`InterVariable.woff2`](https://rsms.me/inter/font-files/InterVariable.woff2) and [`InterVariable-Italic.woff2`](https://rsms.me/inter/font-files/InterVariable-Italic.woff2) font files from the official website, and serve them alongside your other assets. Then include the following CSS in the `<head>` of your document, replacing the placeholder paths with the correct path to where the fonts are located:
+
+```html
+<style>
+	@font-face {
+		font-family: InterVariable;
+		font-style: normal;
+		font-weight: 100 900;
+		font-display: swap;
+		src: url("/path/to/InterVariable.woff2") format("woff2");
+	}
+
+	@font-face {
+		font-family: InterVariable;
+		font-style: italic;
+		font-weight: 100 900;
+		font-display: swap;
+		src: url("/path/to/InterVariable-Italic.woff2") format("woff2");
+	}
+</style>
+```
+
+Build tools such as [Vite](https://vite.dev/guide/assets.html#importing-asset-as-url) can handle `url()` references and automatically copy these files into your output directory with hashed file names. These files can then be safely served with [HTTP caching](https://developer.chrome.com/docs/lighthouse/performance/uses-long-cache-ttl/#how_to_cache_static_resources_using_http_caching) without blocking upgrades to newer versions of the fonts.
+
+> [!NOTE]
+> If the `<Root>` component cannot find `InterVariable` as a font in the document, it will automatically add a fallback which uses [Inter’s CDN](https://rsms.me/inter/#faq-cdn). In all cases, we recommend self-hosting to avoid any potential security and reliability issues that may arise from the use of a third-party CDN.
 
 ## Contributing
 

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -43,6 +43,13 @@ function createTheme() {
 			light: true,
 			dark: true,
 		},
+		typography: {
+			fontFamily: `"InterVariable", "Noto Sans", "Open Sans", sans-serif`,
+			fontSize: 14,
+			button: {
+				textTransform: "none", // Disable all-caps on buttons and tabs
+			},
+		},
 		components: {
 			MuiAccordionSummary: {
 				defaultProps: {


### PR DESCRIPTION
This PR adds some basic `typography` configuration to `@stratakit/mui`.

- Changed the primary font-family to `InterVariable`. The precise value of the font stack is the same as that of `--stratakit-font-family-sans` variable (which I would have liked to use directly but decided not to because there are [unresolved concerns](https://github.com/iTwin/design-system/pull/1112#discussion_r2592826664) around tokens).
  - Updated README with instructions on how to load InterVariable (same as https://github.com/iTwin/design-system/pull/564).

- Explicitly set the `font-size` to `14`, which gets translated to `0.875rem` and is already the default for MUI. In a future PR, I would like to set this to `12` depending on the `density`. (Note: `@stratakit/foundations` still sets `0.75rem`. I will address that in a future PR as well)

- Disabled uppercase text from all buttons (and tabs). This makes a hugely noticeabe difference, because uppercase text, combined with `Roboto`, is one of the biggest tells of Google's Material Design 2.

---

Originally I was also going to update all the [typography variants](https://mui.com/material-ui/customization/typography/#variants), but decided to defer that for future.

---

[Deploy preview](https://itwin.github.io/design-system/1114/mui) (compare with [`main`](https://itwin.github.io/design-system/mui))