### PR TITLE
add `density` option to MUI

### DIFF
--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -23,6 +23,7 @@ import {
 	DialogTitle,
 	Divider,
 	FormControl,
+	FormControlLabel,
 	IconButton,
 	InputLabel,
 	Link,
@@ -59,16 +60,33 @@ export const meta: MetaFunction = () => {
 	return [{ title: "StrataKit MUI theme" }];
 };
 
+export const handle = { title: "StrataKit MUI Theme", mui: true };
+
 // ----------------------------------------------------------------------------
 
 export default function Page() {
 	const colorScheme = useColorScheme();
+
+	const [density, setDensity] = React.useState<"dense" | undefined>(undefined);
+
 	return (
-		<Root colorScheme={colorScheme}>
+		<Root colorScheme={colorScheme} density={density}>
 			<Container maxWidth="lg" sx={{ p: 4, minBlockSize: "100dvb" }}>
 				<Typography variant="h4" component="h1">
 					StrataKit MUI theme
 				</Typography>
+
+				<FormControlLabel
+					control={
+						<Switch
+							onChange={(event) => {
+								const isDense = event.currentTarget.checked;
+								setDensity(isDense ? "dense" : undefined);
+							}}
+						/>
+					}
+					label="Dense"
+				/>
 
 				<Divider sx={{ mt: 2, mb: 2 }} />
 

--- a/apps/test-app/app/root.tsx
+++ b/apps/test-app/app/root.tsx
@@ -72,16 +72,21 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
 
 export default function App() {
 	const colorScheme = useColorScheme();
+	const isMuiRoute = useIsMuiRoute();
 
 	React.useEffect(function signalPageLoad() {
 		document.body.dataset.loaded = "true";
 	}, []);
 
+	const MaybeRoot = !isMuiRoute ? Root : React.Fragment;
+
+	console.log({ isMuiRoute, MaybeRoot });
+
 	return (
 		<QueryClientProvider client={queryClient}>
-			<Root colorScheme={colorScheme} density="dense">
+			<MaybeRoot colorScheme={colorScheme} density="dense">
 				<Outlet />
-			</Root>
+			</MaybeRoot>
 		</QueryClientProvider>
 	);
 }
@@ -100,6 +105,11 @@ export function HydrateFallback() {
 			<noscript>Please enable JavaScript.</noscript>
 		</>
 	);
+}
+
+function useIsMuiRoute() {
+	type MuiRouteHandle = typeof import("~/mui.tsx").handle;
+	return !!(useMatches()?.at(-1)?.handle as MuiRouteHandle)?.mui;
 }
 
 function useIsRootTest() {

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -59,7 +59,7 @@ interface RootProps extends BaseProps {
 	/**
 	 * The density to use for all components under the Root.
 	 */
-	density: "dense";
+	density?: "dense" | undefined;
 
 	/**
 	 * An HTML sanitizer function that will be used across all components wherever DOM elements

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -20,8 +20,6 @@ import css from "./styles.css.js";
 
 // ----------------------------------------------------------------------------
 
-const theme = createTheme();
-
 const packageName = "@stratakit/mui";
 const key = `${packageName}@${__VERSION__}`;
 
@@ -33,6 +31,13 @@ interface RootProps extends React.ComponentPropsWithoutRef<"div"> {
 	 * The color scheme to use for all components on the page.
 	 */
 	colorScheme: "light" | "dark";
+
+	/**
+	 * The density to use for all descendants of the `Root`.
+	 *
+	 * Set to `"dense"` for a more compact UI.
+	 */
+	density?: "dense" | undefined;
 }
 
 /**
@@ -47,13 +52,20 @@ interface RootProps extends React.ComponentPropsWithoutRef<"div"> {
  */
 const Root = React.forwardRef<HTMLDivElement, RootProps>(
 	(props, forwardedRef) => {
-		const { children, colorScheme, ...rest } = props;
+		const { children, colorScheme, density, ...rest } = props;
+
+		const theme = React.useMemo(() => createTheme({ density }), [density]);
 
 		return (
 			<StyledEngineProvider enableCssLayer>
 				<ThemeProvider theme={theme} defaultMode={colorScheme}>
 					<ColorScheme colorScheme={colorScheme} />
-					<RootInner {...rest} colorScheme={colorScheme} ref={forwardedRef}>
+					<RootInner
+						{...rest}
+						colorScheme={colorScheme}
+						density={density}
+						ref={forwardedRef}
+					>
 						<Styles />
 						{children}
 					</RootInner>
@@ -68,12 +80,12 @@ DEV: Root.displayName = "Root";
 
 interface RootInnerProps
 	extends React.ComponentPropsWithoutRef<"div">,
-		Pick<RootProps, "colorScheme"> {}
+		Pick<RootProps, "colorScheme" | "density"> {}
 
 /** @private */
 const RootInner = React.forwardRef<HTMLDivElement, RootInnerProps>(
 	(props, forwardedRef) => {
-		const { children, colorScheme, ...rest } = props;
+		const { children, colorScheme, density, ...rest } = props;
 
 		return (
 			<StrataKitRoot
@@ -81,7 +93,7 @@ const RootInner = React.forwardRef<HTMLDivElement, RootInnerProps>(
 				className={cx("🥝MuiRoot", props.className)}
 				colorScheme={colorScheme}
 				synchronizeColorScheme
-				density="dense"
+				density={density}
 				ref={forwardedRef}
 			>
 				{children}

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -33,7 +33,7 @@ import {
  * </ThemeProvider>
  * ```
  */
-function createTheme() {
+function createTheme({ density }: { density?: "dense" | undefined } = {}) {
 	return createMuiTheme({
 		cssVariables: {
 			nativeColor: true,
@@ -44,9 +44,10 @@ function createTheme() {
 			light: true,
 			dark: true,
 		},
+		spacing: density === "dense" ? 4 : 8,
 		typography: {
 			fontFamily: "var(--stratakit-font-family-sans)",
-			fontSize: 14,
+			fontSize: density === "dense" ? 12 : 14,
 			button: {
 				textTransform: "none", // Disable all-caps on buttons and tabs
 			},
@@ -100,11 +101,22 @@ function createTheme() {
 			MuiButton: {
 				defaultProps: {
 					color: "secondary",
+					size: density === "dense" ? "small" : undefined,
+				},
+				styleOverrides: {
+					root: {
+						fontSize: "inherit", // Button text becomes too small otherwise in dense mode
+					},
 				},
 			},
 			MuiChip: {
 				defaultProps: {
 					deleteIcon: <DismissIcon />,
+				},
+				styleOverrides: {
+					root: {
+						fontSize: "inherit", // Chip text becomes too small otherwise in dense mode
+					},
 				},
 			},
 			MuiCheckbox: {
@@ -112,9 +124,56 @@ function createTheme() {
 					disableRipple: true, // Checkbox doesn't inherit from ButtonBase
 				},
 			},
+			MuiFab: {
+				defaultProps: {
+					size: density === "dense" ? "small" : undefined,
+				},
+			},
+			MuiFilledInput: {
+				defaultProps: {
+					margin: density === "dense" ? "dense" : undefined,
+				},
+			},
+			MuiFormControl: {
+				defaultProps: {
+					margin: density === "dense" ? "dense" : undefined,
+				},
+			},
+			MuiFormHelperText: {
+				defaultProps: {
+					margin: density === "dense" ? "dense" : undefined,
+				},
+			},
+			MuiIconButton: {
+				defaultProps: {
+					size: density === "dense" ? "small" : undefined,
+				},
+			},
+			MuiInputBase: {
+				defaultProps: {
+					margin: density === "dense" ? "dense" : undefined,
+					size: density === "dense" ? "small" : undefined,
+				},
+			},
+			MuiInputLabel: {
+				defaultProps: {
+					margin: density === "dense" ? "dense" : undefined,
+				},
+			},
 			MuiLink: {
 				defaultProps: {
 					color: "textPrimary",
+				},
+			},
+			MuiListItem: {
+				defaultProps: {
+					dense: density === "dense" ? true : undefined,
+				},
+			},
+			MuiOutlinedInput: {
+				defaultProps: {
+					margin: density === "dense" ? "dense" : undefined,
+					size: density === "dense" ? "small" : undefined,
 				},
 			},
 			MuiPaginationItem: {
@@ -132,6 +191,12 @@ function createTheme() {
 					IconComponent: CaretsUpDownIcon,
 				},
 			},
+			MuiTable: {
+				defaultProps: {
+					// TODO: Unsure about this one
+					// size: density === "dense" ? "small" : undefined,
+				},
+			},
 			MuiTablePaginationActions: {
 				defaultProps: {
 					slots: {
@@ -146,6 +211,17 @@ function createTheme() {
 				defaultProps: {
 					// TODO: This should use sort-ascending and sort-descending icons, but that requires disabling MUI's built-in icon rotation.
 					IconComponent: ArrowDownIcon,
+				},
+			},
+			MuiTextField: {
+				defaultProps: {
+					margin: density === "dense" ? "dense" : undefined,
+					size: density === "dense" ? "small" : undefined,
+				},
+			},
+			MuiToolbar: {
+				defaultProps: {
+					variant: density === "dense" ? "dense" : undefined,
 				},
 			},
 		},


### PR DESCRIPTION
_PR stack: This PR → #1114 → #1113 → `main`_

---

**🚧 WIP but I would like some initial feedback.**

This PR:
1. Adds an optional `density` prop to the `Root` from `@stratakit/mui`. When set to `"dense"`, it:
   - uses the [small density/size](https://mui.com/material-ui/customization/density/) for all MUI components (except `Table`). It also sets `fontSize` to `12` (which becomes `0.75rem`).
   - updates the spacing scale to use increments of `4` (rather than `8`).
2. Makes the `density` prop optional for the `Root` from `@stratakit/foundations`. When not set, it will not apply the data attribute which sets `font-size: 0.75rem` via CSS.
3. Updates `test-app` to add a density toggle and remove `@stratakit/foundations` `Root` from the `/mui` route.

---

[Deploy preview](https://itwin.github.io/design-system/1115/mui) (compare with [`main`](https://itwin.github.io/design-system/mui))