### PR TITLE
start theming MUI using StrataKit tokens

### DIFF
--- a/apps/test-app/app/index.tsx
+++ b/apps/test-app/app/index.tsx
@@ -66,12 +66,12 @@ export default function Index() {
 			</ul>
 
 			<Text variant="headline-md" render={<h2 />} className={styles.h2}>
-				Material UI
+				MUI
 			</Text>
 
 			<ul className={styles.list}>
 				<li>
-					<Anchor href={useHref("/mui")}>StrataKit theme</Anchor>
+					<Anchor href={useHref("/mui")}>StrataKit MUI theme</Anchor>
 				</li>
 			</ul>
 

--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -21,6 +21,7 @@ import {
 	DialogContent,
 	DialogContentText,
 	DialogTitle,
+	Divider,
 	FormControl,
 	IconButton,
 	InputLabel,
@@ -52,36 +53,47 @@ import type { MetaFunction } from "react-router";
 
 import svgPlaceholder from "@stratakit/icons/placeholder.svg";
 
+// ----------------------------------------------------------------------------
+
 export const meta: MetaFunction = () => {
-	return [{ title: "StrataKit theme" }];
+	return [{ title: "StrataKit MUI theme" }];
 };
+
+// ----------------------------------------------------------------------------
 
 export default function Page() {
 	const colorScheme = useColorScheme();
 	return (
 		<Root colorScheme={colorScheme}>
 			<Container maxWidth="lg" sx={{ p: 4, minBlockSize: "100dvb" }}>
-				<Typography variant="h4" component="h1" gutterBottom sx={{ mb: 4 }}>
-					StrataKit theme for Material UI
+				<Typography variant="h4" component="h1">
+					StrataKit MUI theme
 				</Typography>
+
+				<Divider sx={{ mt: 2, mb: 2 }} />
 
 				<Stack spacing={2}>
 					<Stack spacing={1} direction="row">
-						<Link color="inherit" href="#">
-							Default
+						<Link href="#">Default</Link>
+						<Link href="#" sx={{ color: "primary.dark" }}>
+							Accent
 						</Link>
-						<Link href="#">Accent</Link>
 					</Stack>
 
 					<Stack spacing={1} direction="row" alignItems="center">
+						<Button variant="contained">Contained</Button>
 						<Button
 							variant="contained"
+							color="primary"
 							startIcon={<Icon href={svgPlaceholder} />}
 						>
-							Solid
+							Contained
 						</Button>
 						<Button variant="outlined" endIcon={<Icon href={svgPlaceholder} />}>
-							Outline
+							Outlined
+						</Button>
+						<Button variant="outlined" color="primary">
+							Outlined
 						</Button>
 						<Button>Ghost</Button>
 
@@ -171,7 +183,7 @@ function MenuExample() {
 	return (
 		<div>
 			<Button
-				variant="outlined"
+				variant="contained"
 				id={buttonId}
 				aria-controls={open ? menuId : undefined}
 				aria-haspopup="true"
@@ -208,7 +220,7 @@ function DialogExample() {
 
 	return (
 		<React.Fragment>
-			<Button variant="outlined" onClick={() => setOpen(true)}>
+			<Button variant="contained" onClick={() => setOpen(true)}>
 				Open dialog
 			</Button>
 			<Dialog open={open} onClose={handleClose}>
@@ -324,12 +336,8 @@ function AutocompleteExample() {
 function BreadcrumbsExample() {
 	return (
 		<Breadcrumbs aria-label="breadcrumb">
-			<Link color="inherit" href="/">
-				Home
-			</Link>
-			<Link color="inherit" href="/material-ui/getting-started/installation/">
-				Packages
-			</Link>
+			<Link href="/">Home</Link>
+			<Link href="#">Packages</Link>
 			<Typography sx={{ color: "text.primary" }}>@stratakit/mui</Typography>
 		</Breadcrumbs>
 	);

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -47,6 +47,7 @@
 	"dependencies": {
 		"@stratakit/foundations": "^0.4.2",
 		"@stratakit/icons": "^0.2.2",
+		"classnames": "^2.5.1",
 		"react-compiler-runtime": "^1.0.0"
 	},
 	"devDependencies": {

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -15,6 +15,7 @@ import {
 	RootContext,
 	useSafeContext,
 } from "@stratakit/foundations/secret-internals";
+import cx from "classnames";
 import { createTheme } from "./createTheme.js";
 import css from "./styles.css.js";
 
@@ -79,6 +80,7 @@ const RootInner = React.forwardRef<HTMLDivElement, RootInnerProps>(
 		return (
 			<StrataKitRoot
 				{...rest}
+				className={cx("🥝MuiRoot", props.className)}
 				colorScheme={colorScheme}
 				synchronizeColorScheme
 				density="dense"
@@ -117,6 +119,7 @@ function Styles() {
 		const { cleanup } = loadStyles(rootNode, { css, key });
 		return cleanup;
 	}, [rootNode, loadStyles]);
+
 	return null;
 }
 

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -37,19 +37,29 @@ function createTheme() {
 	return createMuiTheme({
 		cssVariables: {
 			nativeColor: true,
-			colorSchemeSelector: "data",
+			colorSchemeSelector: "[data-color-scheme='%s']",
+			cssVarPrefix: "stratakit-mui",
 		},
 		colorSchemes: {
 			light: true,
 			dark: true,
 		},
 		typography: {
-			fontFamily: `"InterVariable", "Noto Sans", "Open Sans", sans-serif`,
+			fontFamily: "var(--stratakit-font-family-sans)",
 			fontSize: 14,
 			button: {
 				textTransform: "none", // Disable all-caps on buttons and tabs
 			},
 		},
+		shadows: [
+			"none", // 0
+			"none", // 1
+			"var(--stratakit-shadow-surface-xs)", // 2
+			"var(--stratakit-shadow-surface-sm)", // 3
+			...new Array(4).fill("var(--stratakit-shadow-surface-md)"), // 4-7
+			...new Array(17).fill("var(--stratakit-shadow-surface-lg)"), // 8-24
+			// biome-ignore lint/suspicious/noExplicitAny: MUI expects 25 items in the shadows array
+		] as any,
 		components: {
 			MuiAccordionSummary: {
 				defaultProps: {
@@ -70,6 +80,11 @@ function createTheme() {
 				defaultProps: {
 					popupIcon: <ChevronDownIcon />,
 					clearIcon: <DismissIcon />,
+					slotProps: {
+						paper: {
+							elevation: 8, // match Menu elevation
+						},
+					},
 				},
 			},
 			MuiBreadcrumbs: {
@@ -82,6 +97,11 @@ function createTheme() {
 					disableRipple: true, // https://mui.com/material-ui/getting-started/faq/#how-can-i-disable-the-ripple-effect-globally
 				},
 			},
+			MuiButton: {
+				defaultProps: {
+					color: "secondary",
+				},
+			},
 			MuiChip: {
 				defaultProps: {
 					deleteIcon: <DismissIcon />,
@@ -90,6 +110,11 @@ function createTheme() {
 			MuiCheckbox: {
 				defaultProps: {
 					disableRipple: true, // Checkbox doesn't inherit from ButtonBase
+				},
+			},
+			MuiLink: {
+				defaultProps: {
+					color: "textPrimary",
 				},
 			},
 			MuiPaginationItem: {

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -4,7 +4,197 @@
  *--------------------------------------------------------------------------------------------*/
 
 @layer stratakit {
+	[data-color-scheme],
+	.🥝MuiRoot {
+		--stratakit-mui-palette-background-default: var(--stratakit-color-bg-page-depth);
+		--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-page-depth);
+
+		--stratakit-mui-palette-divider: var(--stratakit-color-border-page-base);
+
+		--stratakit-mui-palette-text-primary: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-text-secondary: var(--stratakit-color-text-neutral-secondary);
+		--stratakit-mui-palette-text-disabled: var(--stratakit-color-text-neutral-disabled);
+
+		--stratakit-mui-palette-primary-main: var(--stratakit-color-bg-accent-base);
+		--stratakit-mui-palette-primary-dark: var(--stratakit-color-bg-accent-faded);
+		--stratakit-mui-palette-primary-light: var(--stratakit-color-bg-accent-muted);
+		--stratakit-mui-palette-primary-contrastText: var(--stratakit-color-text-neutral-emphasis);
+
+		--stratakit-mui-palette-secondary-main: var(--stratakit-color-bg-mono-base);
+		--stratakit-mui-palette-secondary-dark: var(--stratakit-color-bg-mono-faded);
+		--stratakit-mui-palette-secondary-light: var(--stratakit-color-bg-mono-muted);
+		--stratakit-mui-palette-secondary-contrastText: var(--stratakit-color-text-neutral-emphasis);
+
+		--stratakit-mui-palette-action-active: var(--stratakit-color-icon-neutral-primary);
+		--stratakit-mui-palette-action-disabled: var(--stratakit-color-icon-neutral-disabled);
+		--stratakit-mui-palette-action-disabledBackground: var(
+			--stratakit-color-bg-glow-on-surface-disabled
+		);
+
+		--stratakit-mui-palette-error-main: var(--stratakit-color-bg-critical-base);
+		--stratakit-mui-palette-error-dark: var(--stratakit-color-bg-critical-faded);
+		--stratakit-mui-palette-error-light: var(--stratakit-color-bg-critical-muted);
+		--stratakit-mui-palette-error-contrastText: var(--stratakit-color-text-neutral-emphasis);
+
+		--stratakit-mui-palette-warning-main: var(--stratakit-color-bg-severe-base);
+		--stratakit-mui-palette-warning-dark: var(--stratakit-color-bg-severe-faded);
+		--stratakit-mui-palette-warning-light: var(--stratakit-color-bg-severe-muted);
+		--stratakit-mui-palette-warning-contrastText: var(--stratakit-color-text-neutral-emphasis);
+
+		--stratakit-mui-palette-success-main: var(--stratakit-color-bg-positive-base);
+		--stratakit-mui-palette-success-dark: var(--stratakit-color-bg-positive-faded);
+		--stratakit-mui-palette-success-light: var(--stratakit-color-bg-positive-muted);
+		--stratakit-mui-palette-success-contrastText: var(--stratakit-color-text-neutral-emphasis);
+
+		--stratakit-mui-palette-info-main: var(--stratakit-color-bg-info-base);
+		--stratakit-mui-palette-info-dark: var(--stratakit-color-bg-info-faded);
+		--stratakit-mui-palette-info-light: var(--stratakit-color-bg-info-muted);
+		--stratakit-mui-palette-info-contrastText: var(--stratakit-color-text-neutral-emphasis);
+
+		--stratakit-mui-palette-grey-50: oklch(85.95% 0.006 255.48);
+		--stratakit-mui-palette-grey-100: oklch(79.56% 0.008 241.69);
+		--stratakit-mui-palette-grey-200: oklch(75.82% 0.01 252.83);
+		--stratakit-mui-palette-grey-300: oklch(69.04% 0.014 255.53);
+		--stratakit-mui-palette-grey-400: oklch(62.09% 0.017 257.22);
+		--stratakit-mui-palette-grey-500: oklch(55.22% 0.018 253.99);
+		--stratakit-mui-palette-grey-600: oklch(48.26% 0.017 254.7);
+		--stratakit-mui-palette-grey-700: oklch(41.45% 0.013 256.75);
+		--stratakit-mui-palette-grey-800: oklch(34.4% 0.011 264.42);
+		--stratakit-mui-palette-grey-900: oklch(26.92% 0.008 268.32);
+		--stratakit-mui-palette-grey-A100: oklch(79.56% 0.008 241.69);
+		--stratakit-mui-palette-grey-A200: oklch(75.82% 0.01 252.83);
+		--stratakit-mui-palette-grey-A400: oklch(62.09% 0.017 257.22);
+		--stratakit-mui-palette-grey-A700: oklch(48.26% 0.017 254.7);
+	}
+
 	.MuiAlert-icon {
 		align-items: center; /* Fix vertical alignment of differently sized icons */
+	}
+
+	.MuiButton-root {
+		&:where(.MuiButton-colorSecondary) {
+			--variant-containedBg: var(--stratakit-color-bg-neutral-base);
+			--variant-containedColor: var(--stratakit-color-text-neutral-primary);
+			--variant-outlinedColor: var(--stratakit-color-text-neutral-primary);
+			--variant-textColor: var(--stratakit-color-text-neutral-primary);
+
+			&:where(:hover) {
+				--variant-containedBg: color-mix(
+					in oklch,
+					var(--stratakit-color-bg-neutral-base) 100%,
+					var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%)
+				);
+			}
+		}
+
+		&:where(.MuiButton-colorPrimary) {
+			--variant-outlinedColor: var(--stratakit-color-text-accent-strong);
+			--variant-textColor: var(--stratakit-color-text-accent-strong);
+		}
+	}
+
+	.MuiCheckbox-root {
+		&:where(.MuiCheckbox-colorPrimary) {
+			&:where(.Mui-checked, .MuiCheckbox-indeterminate):where(:not(.Mui-disabled)) {
+				color: var(--stratakit-mui-palette-primary-dark);
+			}
+		}
+
+		&:where(.Mui-focusVisible) {
+			outline: 2px solid var(--stratakit-color-border-accent-strong);
+		}
+	}
+
+	.MuiFormLabel-colorPrimary {
+		&.Mui-focused {
+			color: var(--stratakit-mui-palette-primary-dark);
+		}
+	}
+
+	.MuiLink-root {
+		font-weight: 500;
+		text-decoration-color: currentColor;
+		text-underline-offset: var(--stratakit-space-x05);
+		transition: text-underline-offset 150ms ease-out;
+
+		&:where(:hover, :focus-visible) {
+			text-underline-offset: var(--stratakit-space-x1);
+		}
+	}
+
+	.MuiMenuItem-root {
+		&:where(.Mui-focusVisible) {
+			outline-offset: -2px;
+		}
+	}
+
+	.MuiPaper-root {
+		--Paper-overlay: unset !important; /* Remove background-image overlay that MUI adds in dark mode */
+
+		&:where(.MuiPaper-elevation1) {
+			--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-page-base);
+		}
+
+		&:where(
+				.MuiPaper-elevation2,
+				.MuiPaper-elevation3,
+				.MuiPaper-elevation4,
+				.MuiPaper-elevation5,
+				.MuiPaper-elevation6,
+				.MuiPaper-elevation7
+			) {
+			--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-elevation-base);
+		}
+
+		&:where(
+				.MuiPaper-elevation8,
+				.MuiPaper-elevation9,
+				.MuiPaper-elevation10,
+				.MuiPaper-elevation11,
+				.MuiPaper-elevation12,
+				.MuiPaper-elevation13,
+				.MuiPaper-elevation14,
+				.MuiPaper-elevation15,
+				.MuiPaper-elevation16,
+				.MuiPaper-elevation17,
+				.MuiPaper-elevation18,
+				.MuiPaper-elevation19,
+				.MuiPaper-elevation20,
+				.MuiPaper-elevation21,
+				.MuiPaper-elevation22,
+				.MuiPaper-elevation23,
+				.MuiPaper-elevation24
+			) {
+			--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-elevation-level-1);
+		}
+	}
+
+	.MuiTab-root {
+		&:where(.Mui-selected) {
+			color: var(--stratakit-color-text-accent-strong);
+		}
+		&:where(:focus-visible) {
+			outline-offset: -4px;
+		}
+	}
+	.MuiTabs-indicator {
+		background-color: var(--stratakit-color-border-accent-strong);
+	}
+
+	.MuiTooltip-tooltip {
+		--stratakit-mui-palette-Tooltip-bg: var(--stratakit-color-bg-elevation-emphasis);
+		box-shadow: var(--stratakit-shadow-control-tooltip-base);
+	}
+
+	.MuiSwitch-root {
+		.MuiSwitch-switchBase:where(.MuiSwitch-colorPrimary) {
+			&:where(.Mui-checked):where(:not(.Mui-disabled)) {
+				color: var(--stratakit-mui-palette-primary-dark);
+			}
+		}
+
+		&:where(:has(.MuiSwitch-switchBase.Mui-focusVisible)) {
+			outline: 2px solid var(--stratakit-color-border-accent-strong);
+		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       "@stratakit/icons":
         specifier: ^0.2.2
         version: link:../icons
+      classnames:
+        specifier: ^2.5.1
+        version: 2.5.1
       react-compiler-runtime:
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.1)


### PR DESCRIPTION
First stab at theming using `--stratakit` tokens.

[Deploy preview](https://itwin.github.io/design-system/1118/mui)

### Implementation notes

- Based on token mapping provided by @msllrs.
- Lots of stuff missing (see below for full list of tokens that MUI generates).
- The additional CSS we write will override MUI.
- Required referencing StrataKit original tokens directly in many places.

`createTheme` changes:
- Prefix for all `--mui` variables changed to `--stratakit-mui`.
- Selector changed to `data-color-scheme` (matching existing StrataKit selector).
- The 24 elevations are required to be present, so mapped them to `--stratakit-shadow` tokens.
- Default color variant for `Button` and `Link` overridden at theme level.
- `Autocomplete` elevation is too low by default, so made consistent with `Menu`.

Incomplete list of TODOs:
- [x] Focus states
- [x] Map grey palette
- [x] Alert colors (handled in #1276)
- [x] SelectOption selected state (handled in #1253)
- [x] Checkbox/Switch colors (handled in #1186 and #1244)

---

### Original MUI-generated CSS

(This is after `createTheme` configuration)

<details>
<summary>Light</summary>

```css
:root, [data-color-scheme="dark"] {
    -webkit-print-color-scheme: light;
    color-scheme: light;
    --stratakit-mui-palette-common-black: #000;
    --stratakit-mui-palette-common-white: #fff;
    --stratakit-mui-palette-common-background: #fff;
    --stratakit-mui-palette-common-onBackground: #000;
    --stratakit-mui-palette-common-backgroundChannel: 255 255 255;
    --stratakit-mui-palette-common-onBackgroundChannel: 0 0 0;
    --stratakit-mui-palette-primary-main: #1976d2;
    --stratakit-mui-palette-primary-light: #42a5f5;
    --stratakit-mui-palette-primary-dark: #1565c0;
    --stratakit-mui-palette-primary-contrastText: oklch(from #1976d2 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-primary-mainChannel: 25 118 210;
    --stratakit-mui-palette-primary-lightChannel: 66 165 245;
    --stratakit-mui-palette-primary-darkChannel: 21 101 192;
    --stratakit-mui-palette-primary-contrastTextChannel: oklch(from #1976d2 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-secondary-main: #9c27b0;
    --stratakit-mui-palette-secondary-light: #ba68c8;
    --stratakit-mui-palette-secondary-dark: #7b1fa2;
    --stratakit-mui-palette-secondary-contrastText: oklch(from #9c27b0 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-secondary-mainChannel: 156 39 176;
    --stratakit-mui-palette-secondary-lightChannel: 186 104 200;
    --stratakit-mui-palette-secondary-darkChannel: 123 31 162;
    --stratakit-mui-palette-secondary-contrastTextChannel: oklch(from #9c27b0 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-error-main: #d32f2f;
    --stratakit-mui-palette-error-light: #ef5350;
    --stratakit-mui-palette-error-dark: #c62828;
    --stratakit-mui-palette-error-contrastText: oklch(from #d32f2f var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-error-mainChannel: 211 47 47;
    --stratakit-mui-palette-error-lightChannel: 239 83 80;
    --stratakit-mui-palette-error-darkChannel: 198 40 40;
    --stratakit-mui-palette-error-contrastTextChannel: oklch(from #d32f2f var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-warning-main: #ed6c02;
    --stratakit-mui-palette-warning-light: #ff9800;
    --stratakit-mui-palette-warning-dark: #e65100;
    --stratakit-mui-palette-warning-contrastText: oklch(from #ed6c02 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-warning-mainChannel: 237 108 2;
    --stratakit-mui-palette-warning-lightChannel: 255 152 0;
    --stratakit-mui-palette-warning-darkChannel: 230 81 0;
    --stratakit-mui-palette-warning-contrastTextChannel: oklch(from #ed6c02 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-info-main: #0288d1;
    --stratakit-mui-palette-info-light: #03a9f4;
    --stratakit-mui-palette-info-dark: #01579b;
    --stratakit-mui-palette-info-contrastText: oklch(from #0288d1 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-info-mainChannel: 2 136 209;
    --stratakit-mui-palette-info-lightChannel: 3 169 244;
    --stratakit-mui-palette-info-darkChannel: 1 87 155;
    --stratakit-mui-palette-info-contrastTextChannel: oklch(from #0288d1 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-success-main: #2e7d32;
    --stratakit-mui-palette-success-light: #4caf50;
    --stratakit-mui-palette-success-dark: #1b5e20;
    --stratakit-mui-palette-success-contrastText: oklch(from #2e7d32 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-success-mainChannel: 46 125 50;
    --stratakit-mui-palette-success-lightChannel: 76 175 80;
    --stratakit-mui-palette-success-darkChannel: 27 94 32;
    --stratakit-mui-palette-success-contrastTextChannel: oklch(from #2e7d32 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-grey-50: #fafafa;
    --stratakit-mui-palette-grey-100: #f5f5f5;
    --stratakit-mui-palette-grey-200: #eeeeee;
    --stratakit-mui-palette-grey-300: #e0e0e0;
    --stratakit-mui-palette-grey-400: #bdbdbd;
    --stratakit-mui-palette-grey-500: #9e9e9e;
    --stratakit-mui-palette-grey-600: #757575;
    --stratakit-mui-palette-grey-700: #616161;
    --stratakit-mui-palette-grey-800: #424242;
    --stratakit-mui-palette-grey-900: #212121;
    --stratakit-mui-palette-grey-A100: #f5f5f5;
    --stratakit-mui-palette-grey-A200: #eeeeee;
    --stratakit-mui-palette-grey-A400: #bdbdbd;
    --stratakit-mui-palette-grey-A700: #616161;
    --stratakit-mui-palette-text-primary: rgba(0, 0, 0, 0.87);
    --stratakit-mui-palette-text-secondary: rgba(0, 0, 0, 0.6);
    --stratakit-mui-palette-text-disabled: rgba(0, 0, 0, 0.38);
    --stratakit-mui-palette-text-primaryChannel: 0 0 0;
    --stratakit-mui-palette-text-secondaryChannel: 0 0 0;
    --stratakit-mui-palette-divider: rgba(0, 0, 0, 0.12);
    --stratakit-mui-palette-background-paper: #fff;
    --stratakit-mui-palette-background-default: #fff;
    --stratakit-mui-palette-background-defaultChannel: 255 255 255;
    --stratakit-mui-palette-background-paperChannel: 255 255 255;
    --stratakit-mui-palette-action-active: rgba(0, 0, 0, 0.54);
    --stratakit-mui-palette-action-hover: rgba(0, 0, 0, 0.04);
    --stratakit-mui-palette-action-hoverOpacity: 0.04;
    --stratakit-mui-palette-action-selected: rgba(0, 0, 0, 0.08);
    --stratakit-mui-palette-action-selectedOpacity: 0.08;
    --stratakit-mui-palette-action-disabled: rgba(0, 0, 0, 0.26);
    --stratakit-mui-palette-action-disabledBackground: rgba(0, 0, 0, 0.12);
    --stratakit-mui-palette-action-disabledOpacity: 0.38;
    --stratakit-mui-palette-action-focus: rgba(0, 0, 0, 0.12);
    --stratakit-mui-palette-action-focusOpacity: 0.12;
    --stratakit-mui-palette-action-activatedOpacity: 0.12;
    --stratakit-mui-palette-action-activeChannel: 0 0 0;
    --stratakit-mui-palette-action-selectedChannel: 0 0 0;
    --stratakit-mui-palette-Alert-errorColor: color-mix(in oklch, #ef5350, #000 60%);
    --stratakit-mui-palette-Alert-infoColor: color-mix(in oklch, #03a9f4, #000 60%);
    --stratakit-mui-palette-Alert-successColor: color-mix(in oklch, #4caf50, #000 60%);
    --stratakit-mui-palette-Alert-warningColor: color-mix(in oklch, #ff9800, #000 60%);
    --stratakit-mui-palette-Alert-errorFilledBg: var(--stratakit-mui-palette-error-main, #d32f2f);
    --stratakit-mui-palette-Alert-infoFilledBg: var(--stratakit-mui-palette-info-main, #0288d1);
    --stratakit-mui-palette-Alert-successFilledBg: var(--stratakit-mui-palette-success-main, #2e7d32);
    --stratakit-mui-palette-Alert-warningFilledBg: var(--stratakit-mui-palette-warning-main, #ed6c02);
    --stratakit-mui-palette-Alert-errorFilledColor: oklch(from #d32f2f var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-Alert-infoFilledColor: oklch(from #0288d1 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-Alert-successFilledColor: oklch(from #2e7d32 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-Alert-warningFilledColor: oklch(from #ed6c02 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-Alert-errorStandardBg: color-mix(in oklch, #ef5350, #fff 90%);
    --stratakit-mui-palette-Alert-infoStandardBg: color-mix(in oklch, #03a9f4, #fff 90%);
    --stratakit-mui-palette-Alert-successStandardBg: color-mix(in oklch, #4caf50, #fff 90%);
    --stratakit-mui-palette-Alert-warningStandardBg: color-mix(in oklch, #ff9800, #fff 90%);
    --stratakit-mui-palette-Alert-errorIconColor: var(--stratakit-mui-palette-error-main, #d32f2f);
    --stratakit-mui-palette-Alert-infoIconColor: var(--stratakit-mui-palette-info-main, #0288d1);
    --stratakit-mui-palette-Alert-successIconColor: var(--stratakit-mui-palette-success-main, #2e7d32);
    --stratakit-mui-palette-Alert-warningIconColor: var(--stratakit-mui-palette-warning-main, #ed6c02);
    --stratakit-mui-palette-AppBar-defaultBg: var(--stratakit-mui-palette-grey-100, #f5f5f5);
    --stratakit-mui-palette-Avatar-defaultBg: var(--stratakit-mui-palette-grey-400, #bdbdbd);
    --stratakit-mui-palette-Button-inheritContainedBg: var(--stratakit-mui-palette-grey-300, #e0e0e0);
    --stratakit-mui-palette-Button-inheritContainedHoverBg: var(--stratakit-mui-palette-grey-A100, #f5f5f5);
    --stratakit-mui-palette-Chip-defaultBorder: var(--stratakit-mui-palette-grey-400, #bdbdbd);
    --stratakit-mui-palette-Chip-defaultAvatarColor: var(--stratakit-mui-palette-grey-700, #616161);
    --stratakit-mui-palette-Chip-defaultIconColor: var(--stratakit-mui-palette-grey-700, #616161);
    --stratakit-mui-palette-FilledInput-bg: rgba(0, 0, 0, 0.06);
    --stratakit-mui-palette-FilledInput-hoverBg: rgba(0, 0, 0, 0.09);
    --stratakit-mui-palette-FilledInput-disabledBg: rgba(0, 0, 0, 0.12);
    --stratakit-mui-palette-LinearProgress-primaryBg: color-mix(in oklch, #1976d2, #fff 62%);
    --stratakit-mui-palette-LinearProgress-secondaryBg: color-mix(in oklch, #9c27b0, #fff 62%);
    --stratakit-mui-palette-LinearProgress-errorBg: color-mix(in oklch, #d32f2f, #fff 62%);
    --stratakit-mui-palette-LinearProgress-infoBg: color-mix(in oklch, #0288d1, #fff 62%);
    --stratakit-mui-palette-LinearProgress-successBg: color-mix(in oklch, #2e7d32, #fff 62%);
    --stratakit-mui-palette-LinearProgress-warningBg: color-mix(in oklch, #ed6c02, #fff 62%);
    --stratakit-mui-palette-Skeleton-bg: color-mix(in oklch, rgba(0, 0, 0, 0.87), transparent 89%);
    --stratakit-mui-palette-Slider-primaryTrack: color-mix(in oklch, #1976d2, #fff 62%);
    --stratakit-mui-palette-Slider-secondaryTrack: color-mix(in oklch, #9c27b0, #fff 62%);
    --stratakit-mui-palette-Slider-errorTrack: color-mix(in oklch, #d32f2f, #fff 62%);
    --stratakit-mui-palette-Slider-infoTrack: color-mix(in oklch, #0288d1, #fff 62%);
    --stratakit-mui-palette-Slider-successTrack: color-mix(in oklch, #2e7d32, #fff 62%);
    --stratakit-mui-palette-Slider-warningTrack: color-mix(in oklch, #ed6c02, #fff 62%);
    --stratakit-mui-palette-SnackbarContent-bg: color-mix(in oklch, #fff, #000 68%);
    --stratakit-mui-palette-SnackbarContent-color: #fff;
    --stratakit-mui-palette-SpeedDialAction-fabHoverBg: rgb(216, 216, 216);
    --stratakit-mui-palette-StepConnector-border: var(--stratakit-mui-palette-grey-400, #bdbdbd);
    --stratakit-mui-palette-StepContent-border: var(--stratakit-mui-palette-grey-400, #bdbdbd);
    --stratakit-mui-palette-Switch-defaultColor: var(--stratakit-mui-palette-common-white, #fff);
    --stratakit-mui-palette-Switch-defaultDisabledColor: var(--stratakit-mui-palette-grey-100, #f5f5f5);
    --stratakit-mui-palette-Switch-primaryDisabledColor: color-mix(in oklch, #1976d2, #fff 62%);
    --stratakit-mui-palette-Switch-secondaryDisabledColor: color-mix(in oklch, #9c27b0, #fff 62%);
    --stratakit-mui-palette-Switch-errorDisabledColor: color-mix(in oklch, #d32f2f, #fff 62%);
    --stratakit-mui-palette-Switch-infoDisabledColor: color-mix(in oklch, #0288d1, #fff 62%);
    --stratakit-mui-palette-Switch-successDisabledColor: color-mix(in oklch, #2e7d32, #fff 62%);
    --stratakit-mui-palette-Switch-warningDisabledColor: color-mix(in oklch, #ed6c02, #fff 62%);
    --stratakit-mui-palette-TableCell-border: color-mix(in oklch, color-mix(in oklch, rgba(0, 0, 0, 0.12), transparent 0%), #fff 88%);
    --stratakit-mui-palette-Tooltip-bg: color-mix(in oklch, #616161, transparent 8%);
    --stratakit-mui-palette-dividerChannel: 0 0 0;
    --stratakit-mui-opacity-inputPlaceholder: 0.42;
    --stratakit-mui-opacity-inputUnderline: 0.42;
    --stratakit-mui-opacity-switchTrackDisabled: 0.12;
    --stratakit-mui-opacity-switchTrack: 0.38;
}
```

</details>

<details>
<summary>Dark</summary>

```css
[data-color-scheme="dark"] {
    -webkit-print-color-scheme: dark;
    color-scheme: dark;
    --stratakit-mui-palette-common-black: #000;
    --stratakit-mui-palette-common-white: #fff;
    --stratakit-mui-palette-common-background: #000;
    --stratakit-mui-palette-common-onBackground: #fff;
    --stratakit-mui-palette-common-backgroundChannel: 0 0 0;
    --stratakit-mui-palette-common-onBackgroundChannel: 255 255 255;
    --stratakit-mui-palette-primary-main: #90caf9;
    --stratakit-mui-palette-primary-light: #e3f2fd;
    --stratakit-mui-palette-primary-dark: #42a5f5;
    --stratakit-mui-palette-primary-contrastText: oklch(from #90caf9 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-primary-mainChannel: 144 202 249;
    --stratakit-mui-palette-primary-lightChannel: 227 242 253;
    --stratakit-mui-palette-primary-darkChannel: 66 165 245;
    --stratakit-mui-palette-primary-contrastTextChannel: oklch(from #90caf9 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-secondary-main: #ce93d8;
    --stratakit-mui-palette-secondary-light: #f3e5f5;
    --stratakit-mui-palette-secondary-dark: #ab47bc;
    --stratakit-mui-palette-secondary-contrastText: oklch(from #ce93d8 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-secondary-mainChannel: 206 147 216;
    --stratakit-mui-palette-secondary-lightChannel: 243 229 245;
    --stratakit-mui-palette-secondary-darkChannel: 171 71 188;
    --stratakit-mui-palette-secondary-contrastTextChannel: oklch(from #ce93d8 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-error-main: #f44336;
    --stratakit-mui-palette-error-light: #e57373;
    --stratakit-mui-palette-error-dark: #d32f2f;
    --stratakit-mui-palette-error-contrastText: oklch(from #f44336 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-error-mainChannel: 244 67 54;
    --stratakit-mui-palette-error-lightChannel: 229 115 115;
    --stratakit-mui-palette-error-darkChannel: 211 47 47;
    --stratakit-mui-palette-error-contrastTextChannel: oklch(from #f44336 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-warning-main: #ffa726;
    --stratakit-mui-palette-warning-light: #ffb74d;
    --stratakit-mui-palette-warning-dark: #f57c00;
    --stratakit-mui-palette-warning-contrastText: oklch(from #ffa726 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-warning-mainChannel: 255 167 38;
    --stratakit-mui-palette-warning-lightChannel: 255 183 77;
    --stratakit-mui-palette-warning-darkChannel: 245 124 0;
    --stratakit-mui-palette-warning-contrastTextChannel: oklch(from #ffa726 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-info-main: #29b6f6;
    --stratakit-mui-palette-info-light: #4fc3f7;
    --stratakit-mui-palette-info-dark: #0288d1;
    --stratakit-mui-palette-info-contrastText: oklch(from #29b6f6 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-info-mainChannel: 41 182 246;
    --stratakit-mui-palette-info-lightChannel: 79 195 247;
    --stratakit-mui-palette-info-darkChannel: 2 136 209;
    --stratakit-mui-palette-info-contrastTextChannel: oklch(from #29b6f6 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-success-main: #66bb6a;
    --stratakit-mui-palette-success-light: #81c784;
    --stratakit-mui-palette-success-dark: #388e3c;
    --stratakit-mui-palette-success-contrastText: oklch(from #66bb6a var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-success-mainChannel: 102 187 106;
    --stratakit-mui-palette-success-lightChannel: 129 199 132;
    --stratakit-mui-palette-success-darkChannel: 56 142 60;
    --stratakit-mui-palette-success-contrastTextChannel: oklch(from #66bb6a var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-grey-50: #fafafa;
    --stratakit-mui-palette-grey-100: #f5f5f5;
    --stratakit-mui-palette-grey-200: #eeeeee;
    --stratakit-mui-palette-grey-300: #e0e0e0;
    --stratakit-mui-palette-grey-400: #bdbdbd;
    --stratakit-mui-palette-grey-500: #9e9e9e;
    --stratakit-mui-palette-grey-600: #757575;
    --stratakit-mui-palette-grey-700: #616161;
    --stratakit-mui-palette-grey-800: #424242;
    --stratakit-mui-palette-grey-900: #212121;
    --stratakit-mui-palette-grey-A100: #f5f5f5;
    --stratakit-mui-palette-grey-A200: #eeeeee;
    --stratakit-mui-palette-grey-A400: #bdbdbd;
    --stratakit-mui-palette-grey-A700: #616161;
    --stratakit-mui-palette-text-primary: #fff;
    --stratakit-mui-palette-text-secondary: rgba(255, 255, 255, 0.7);
    --stratakit-mui-palette-text-disabled: rgba(255, 255, 255, 0.5);
    --stratakit-mui-palette-text-icon: rgba(255, 255, 255, 0.5);
    --stratakit-mui-palette-text-primaryChannel: 255 255 255;
    --stratakit-mui-palette-text-secondaryChannel: 255 255 255;
    --stratakit-mui-palette-divider: rgba(255, 255, 255, 0.12);
    --stratakit-mui-palette-background-paper: #121212;
    --stratakit-mui-palette-background-default: #121212;
    --stratakit-mui-palette-background-defaultChannel: 18 18 18;
    --stratakit-mui-palette-background-paperChannel: 18 18 18;
    --stratakit-mui-palette-action-active: #fff;
    --stratakit-mui-palette-action-hover: rgba(255, 255, 255, 0.08);
    --stratakit-mui-palette-action-hoverOpacity: 0.08;
    --stratakit-mui-palette-action-selected: rgba(255, 255, 255, 0.16);
    --stratakit-mui-palette-action-selectedOpacity: 0.16;
    --stratakit-mui-palette-action-disabled: rgba(255, 255, 255, 0.3);
    --stratakit-mui-palette-action-disabledBackground: rgba(255, 255, 255, 0.12);
    --stratakit-mui-palette-action-disabledOpacity: 0.38;
    --stratakit-mui-palette-action-focus: rgba(255, 255, 255, 0.12);
    --stratakit-mui-palette-action-focusOpacity: 0.12;
    --stratakit-mui-palette-action-activatedOpacity: 0.24;
    --stratakit-mui-palette-action-activeChannel: 255 255 255;
    --stratakit-mui-palette-action-selectedChannel: 255 255 255;
    --stratakit-mui-palette-Alert-errorColor: color-mix(in oklch, #e57373, #fff 60%);
    --stratakit-mui-palette-Alert-infoColor: color-mix(in oklch, #4fc3f7, #fff 60%);
    --stratakit-mui-palette-Alert-successColor: color-mix(in oklch, #81c784, #fff 60%);
    --stratakit-mui-palette-Alert-warningColor: color-mix(in oklch, #ffb74d, #fff 60%);
    --stratakit-mui-palette-Alert-errorFilledBg: var(--stratakit-mui-palette-error-dark, #d32f2f);
    --stratakit-mui-palette-Alert-infoFilledBg: var(--stratakit-mui-palette-info-dark, #0288d1);
    --stratakit-mui-palette-Alert-successFilledBg: var(--stratakit-mui-palette-success-dark, #388e3c);
    --stratakit-mui-palette-Alert-warningFilledBg: var(--stratakit-mui-palette-warning-dark, #f57c00);
    --stratakit-mui-palette-Alert-errorFilledColor: oklch(from #d32f2f var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-Alert-infoFilledColor: oklch(from #0288d1 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-Alert-successFilledColor: oklch(from #388e3c var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-Alert-warningFilledColor: oklch(from #f57c00 var(--__l) 0 h / var(--__a));
    --stratakit-mui-palette-Alert-errorStandardBg: color-mix(in oklch, #e57373, #000 90%);
    --stratakit-mui-palette-Alert-infoStandardBg: color-mix(in oklch, #4fc3f7, #000 90%);
    --stratakit-mui-palette-Alert-successStandardBg: color-mix(in oklch, #81c784, #000 90%);
    --stratakit-mui-palette-Alert-warningStandardBg: color-mix(in oklch, #ffb74d, #000 90%);
    --stratakit-mui-palette-Alert-errorIconColor: var(--stratakit-mui-palette-error-main, #f44336);
    --stratakit-mui-palette-Alert-infoIconColor: var(--stratakit-mui-palette-info-main, #29b6f6);
    --stratakit-mui-palette-Alert-successIconColor: var(--stratakit-mui-palette-success-main, #66bb6a);
    --stratakit-mui-palette-Alert-warningIconColor: var(--stratakit-mui-palette-warning-main, #ffa726);
    --stratakit-mui-palette-AppBar-defaultBg: var(--stratakit-mui-palette-grey-900, #212121);
    --stratakit-mui-palette-AppBar-darkBg: var(--stratakit-mui-palette-background-paper, #121212);
    --stratakit-mui-palette-AppBar-darkColor: var(--stratakit-mui-palette-text-primary, #fff);
    --stratakit-mui-palette-Avatar-defaultBg: var(--stratakit-mui-palette-grey-600, #757575);
    --stratakit-mui-palette-Button-inheritContainedBg: var(--stratakit-mui-palette-grey-800, #424242);
    --stratakit-mui-palette-Button-inheritContainedHoverBg: var(--stratakit-mui-palette-grey-700, #616161);
    --stratakit-mui-palette-Chip-defaultBorder: var(--stratakit-mui-palette-grey-700, #616161);
    --stratakit-mui-palette-Chip-defaultAvatarColor: var(--stratakit-mui-palette-grey-300, #e0e0e0);
    --stratakit-mui-palette-Chip-defaultIconColor: var(--stratakit-mui-palette-grey-300, #e0e0e0);
    --stratakit-mui-palette-FilledInput-bg: rgba(255, 255, 255, 0.09);
    --stratakit-mui-palette-FilledInput-hoverBg: rgba(255, 255, 255, 0.13);
    --stratakit-mui-palette-FilledInput-disabledBg: rgba(255, 255, 255, 0.12);
    --stratakit-mui-palette-LinearProgress-primaryBg: color-mix(in oklch, #90caf9, #000 50%);
    --stratakit-mui-palette-LinearProgress-secondaryBg: color-mix(in oklch, #ce93d8, #000 50%);
    --stratakit-mui-palette-LinearProgress-errorBg: color-mix(in oklch, #f44336, #000 50%);
    --stratakit-mui-palette-LinearProgress-infoBg: color-mix(in oklch, #29b6f6, #000 50%);
    --stratakit-mui-palette-LinearProgress-successBg: color-mix(in oklch, #66bb6a, #000 50%);
    --stratakit-mui-palette-LinearProgress-warningBg: color-mix(in oklch, #ffa726, #000 50%);
    --stratakit-mui-palette-Skeleton-bg: color-mix(in oklch, #fff, transparent 87%);
    --stratakit-mui-palette-Slider-primaryTrack: color-mix(in oklch, #90caf9, #000 50%);
    --stratakit-mui-palette-Slider-secondaryTrack: color-mix(in oklch, #ce93d8, #000 50%);
    --stratakit-mui-palette-Slider-errorTrack: color-mix(in oklch, #f44336, #000 50%);
    --stratakit-mui-palette-Slider-infoTrack: color-mix(in oklch, #29b6f6, #000 50%);
    --stratakit-mui-palette-Slider-successTrack: color-mix(in oklch, #66bb6a, #000 50%);
    --stratakit-mui-palette-Slider-warningTrack: color-mix(in oklch, #ffa726, #000 50%);
    --stratakit-mui-palette-SnackbarContent-bg: color-mix(in oklch, #121212, #fff 99%);
    --stratakit-mui-palette-SnackbarContent-color: rgba(0, 0, 0, 0.87);
    --stratakit-mui-palette-SpeedDialAction-fabHoverBg: rgb(53, 53, 53);
    --stratakit-mui-palette-StepConnector-border: var(--stratakit-mui-palette-grey-600, #757575);
    --stratakit-mui-palette-StepContent-border: var(--stratakit-mui-palette-grey-600, #757575);
    --stratakit-mui-palette-Switch-defaultColor: var(--stratakit-mui-palette-grey-300, #e0e0e0);
    --stratakit-mui-palette-Switch-defaultDisabledColor: var(--stratakit-mui-palette-grey-600, #757575);
    --stratakit-mui-palette-Switch-primaryDisabledColor: color-mix(in oklch, #90caf9, #000 55%);
    --stratakit-mui-palette-Switch-secondaryDisabledColor: color-mix(in oklch, #ce93d8, #000 55%);
    --stratakit-mui-palette-Switch-errorDisabledColor: color-mix(in oklch, #f44336, #000 55%);
    --stratakit-mui-palette-Switch-infoDisabledColor: color-mix(in oklch, #29b6f6, #000 55%);
    --stratakit-mui-palette-Switch-successDisabledColor: color-mix(in oklch, #66bb6a, #000 55%);
    --stratakit-mui-palette-Switch-warningDisabledColor: color-mix(in oklch, #ffa726, #000 55%);
    --stratakit-mui-palette-TableCell-border: color-mix(in oklch, color-mix(in oklch, rgba(255, 255, 255, 0.12), transparent 0%), #000 68%);
    --stratakit-mui-palette-Tooltip-bg: color-mix(in oklch, #616161, transparent 8%);
    --stratakit-mui-palette-dividerChannel: 255 255 255;
    --stratakit-mui-opacity-inputPlaceholder: 0.5;
    --stratakit-mui-opacity-inputUnderline: 0.7;
    --stratakit-mui-opacity-switchTrackDisabled: 0.2;
    --stratakit-mui-opacity-switchTrack: 0.3;
    --stratakit-mui-overlays-0: none;
    --stratakit-mui-overlays-1: linear-gradient(rgba(255 255 255 / 0.051), rgba(255 255 255 / 0.051));
    --stratakit-mui-overlays-2: linear-gradient(rgba(255 255 255 / 0.069), rgba(255 255 255 / 0.069));
    --stratakit-mui-overlays-3: linear-gradient(rgba(255 255 255 / 0.082), rgba(255 255 255 / 0.082));
    --stratakit-mui-overlays-4: linear-gradient(rgba(255 255 255 / 0.092), rgba(255 255 255 / 0.092));
    --stratakit-mui-overlays-5: linear-gradient(rgba(255 255 255 / 0.101), rgba(255 255 255 / 0.101));
    --stratakit-mui-overlays-6: linear-gradient(rgba(255 255 255 / 0.108), rgba(255 255 255 / 0.108));
    --stratakit-mui-overlays-7: linear-gradient(rgba(255 255 255 / 0.114), rgba(255 255 255 / 0.114));
    --stratakit-mui-overlays-8: linear-gradient(rgba(255 255 255 / 0.119), rgba(255 255 255 / 0.119));
    --stratakit-mui-overlays-9: linear-gradient(rgba(255 255 255 / 0.124), rgba(255 255 255 / 0.124));
    --stratakit-mui-overlays-10: linear-gradient(rgba(255 255 255 / 0.128), rgba(255 255 255 / 0.128));
    --stratakit-mui-overlays-11: linear-gradient(rgba(255 255 255 / 0.132), rgba(255 255 255 / 0.132));
    --stratakit-mui-overlays-12: linear-gradient(rgba(255 255 255 / 0.135), rgba(255 255 255 / 0.135));
    --stratakit-mui-overlays-13: linear-gradient(rgba(255 255 255 / 0.139), rgba(255 255 255 / 0.139));
    --stratakit-mui-overlays-14: linear-gradient(rgba(255 255 255 / 0.142), rgba(255 255 255 / 0.142));
    --stratakit-mui-overlays-15: linear-gradient(rgba(255 255 255 / 0.145), rgba(255 255 255 / 0.145));
    --stratakit-mui-overlays-16: linear-gradient(rgba(255 255 255 / 0.147), rgba(255 255 255 / 0.147));
    --stratakit-mui-overlays-17: linear-gradient(rgba(255 255 255 / 0.15), rgba(255 255 255 / 0.15));
    --stratakit-mui-overlays-18: linear-gradient(rgba(255 255 255 / 0.152), rgba(255 255 255 / 0.152));
    --stratakit-mui-overlays-19: linear-gradient(rgba(255 255 255 / 0.155), rgba(255 255 255 / 0.155));
    --stratakit-mui-overlays-20: linear-gradient(rgba(255 255 255 / 0.157), rgba(255 255 255 / 0.157));
    --stratakit-mui-overlays-21: linear-gradient(rgba(255 255 255 / 0.159), rgba(255 255 255 / 0.159));
    --stratakit-mui-overlays-22: linear-gradient(rgba(255 255 255 / 0.161), rgba(255 255 255 / 0.161));
    --stratakit-mui-overlays-23: linear-gradient(rgba(255 255 255 / 0.163), rgba(255 255 255 / 0.163));
    --stratakit-mui-overlays-24: linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165));
}
```

</details>

<details>
<summary>Common</summary>

```css
:root {
    --stratakit-mui-spacing: 8px;
    --stratakit-mui-shape-borderRadius: 4px;
    --stratakit-mui-shadows-0: none;
    --stratakit-mui-shadows-1: none;
    --stratakit-mui-shadows-2: var(--stratakit-shadow-surface-xs);
    --stratakit-mui-shadows-3: var(--stratakit-shadow-surface-sm);
    --stratakit-mui-shadows-4: var(--stratakit-shadow-surface-md);
    --stratakit-mui-shadows-5: var(--stratakit-shadow-surface-md);
    --stratakit-mui-shadows-6: var(--stratakit-shadow-surface-md);
    --stratakit-mui-shadows-7: var(--stratakit-shadow-surface-md);
    --stratakit-mui-shadows-8: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-9: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-10: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-11: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-12: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-13: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-14: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-15: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-16: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-17: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-18: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-19: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-20: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-21: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-22: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-23: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-shadows-24: var(--stratakit-shadow-surface-lg);
    --stratakit-mui-colorSpace: oklch;
    --stratakit-mui-zIndex-mobileStepper: 1000;
    --stratakit-mui-zIndex-fab: 1050;
    --stratakit-mui-zIndex-speedDial: 1050;
    --stratakit-mui-zIndex-appBar: 1100;
    --stratakit-mui-zIndex-drawer: 1200;
    --stratakit-mui-zIndex-modal: 1300;
    --stratakit-mui-zIndex-snackbar: 1400;
    --stratakit-mui-zIndex-tooltip: 1500;
    --stratakit-mui-font-button: 500 0.875rem/1.75 var(--stratakit-font-family-sans);
    --stratakit-mui-font-h1: 300 6rem/1.167 var(--stratakit-font-family-sans);
    --stratakit-mui-font-h2: 300 3.75rem/1.2 var(--stratakit-font-family-sans);
    --stratakit-mui-font-h3: 400 3rem/1.167 var(--stratakit-font-family-sans);
    --stratakit-mui-font-h4: 400 2.125rem/1.235 var(--stratakit-font-family-sans);
    --stratakit-mui-font-h5: 400 1.5rem/1.334 var(--stratakit-font-family-sans);
    --stratakit-mui-font-h6: 500 1.25rem/1.6 var(--stratakit-font-family-sans);
    --stratakit-mui-font-subtitle1: 400 1rem/1.75 var(--stratakit-font-family-sans);
    --stratakit-mui-font-subtitle2: 500 0.875rem/1.57 var(--stratakit-font-family-sans);
    --stratakit-mui-font-body1: 400 1rem/1.5 var(--stratakit-font-family-sans);
    --stratakit-mui-font-body2: 400 0.875rem/1.43 var(--stratakit-font-family-sans);
    --stratakit-mui-font-caption: 400 0.75rem/1.66 var(--stratakit-font-family-sans);
    --stratakit-mui-font-overline: 400 0.75rem/2.66 var(--stratakit-font-family-sans);
    --stratakit-mui-font-inherit: inherit inherit/inherit inherit;
}
```

</details>