### PR TITLE
remove `@stratakit/foundations` from peer deps

### DIFF
--- a/.changeset/old-cups-slide.md
+++ b/.changeset/old-cups-slide.md
@@ -1,0 +1,6 @@
+---
+"@stratakit/structures": patch
+"@stratakit/bricks": patch
+---
+
+Moved `@stratakit/foundations` from `peerDependencies` to direct `dependencies`.

--- a/packages/bricks/package.json
+++ b/packages/bricks/package.json
@@ -178,6 +178,7 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.20",
+		"@stratakit/foundations": "^0.4.3",
 		"classnames": "^2.5.1",
 		"react-compiler-runtime": "^1.0.0"
 	},
@@ -192,7 +193,6 @@
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {
-		"@stratakit/foundations": "^0.4.3",
 		"react": ">=18.0.0",
 		"react-dom": ">=18.0.0"
 	},

--- a/packages/structures/package.json
+++ b/packages/structures/package.json
@@ -125,6 +125,7 @@
 	"dependencies": {
 		"@ariakit/react": "^0.4.20",
 		"@stratakit/bricks": "^0.5.3",
+		"@stratakit/foundations": "^0.4.3",
 		"classnames": "^2.5.1",
 		"react-compiler-runtime": "^1.0.0",
 		"zustand": "^5.0.9"
@@ -140,7 +141,6 @@
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {
-		"@stratakit/foundations": "^0.4.3",
 		"react": ">=18.0.0",
 		"react-dom": ">=18.0.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       "@ariakit/react":
         specifier: ^0.4.20
         version: 0.4.20(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@stratakit/foundations":
+        specifier: ^0.4.3
+        version: link:../foundations
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -210,9 +213,6 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.1)
     devDependencies:
-      "@stratakit/foundations":
-        specifier: workspace:*
-        version: link:../foundations
       "@types/node":
         specifier: "catalog:"
         version: 22.19.1
@@ -319,6 +319,9 @@ importers:
       "@stratakit/bricks":
         specifier: ^0.5.3
         version: link:../bricks
+      "@stratakit/foundations":
+        specifier: ^0.4.3
+        version: link:../foundations
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -329,9 +332,6 @@ importers:
         specifier: ^5.0.9
         version: 5.0.9(@types/react@19.2.7)(immer@11.0.1)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
     devDependencies:
-      "@stratakit/foundations":
-        specifier: workspace:*
-        version: link:../foundations
       "@types/node":
         specifier: "catalog:"
         version: 22.19.1


### PR DESCRIPTION
`@stratakit/foundations` will no longer required to be installed manually be consumers. (Instead, `@stratakit/mui` will be the new "peer" dep)