### PR TITLE
remove `density="dense"` from MUI `Root`

### DIFF
--- a/.changeset/witty-tigers-bet.md
+++ b/.changeset/witty-tigers-bet.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/foundations": patch
+---
+
+`Root` component no longer requires `density` prop. When `density` is not specified, `font-size: 0.75rem` will _not_ be used globally.

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -59,7 +59,7 @@ interface RootProps extends BaseProps {
 	/**
 	 * The density to use for all components under the Root.
 	 */
-	density: "dense";
+	density?: "dense";
 
 	/**
 	 * An HTML sanitizer function that will be used across all components wherever DOM elements

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -81,7 +81,6 @@ const RootInner = React.forwardRef<HTMLDivElement, RootInnerProps>(
 				className={cx("🥝MuiRoot", props.className)}
 				colorScheme={colorScheme}
 				synchronizeColorScheme
-				density="dense"
 				ref={forwardedRef}
 			>
 				{children}


### PR DESCRIPTION
_Extracted out of #1115_

In `@stratakit/foundations` Root, the `density` prop is now optional. This prop controls whether the `data-_sk-density` attribute is set.

In `@stratakit/mui` Root, we no longer set `density="dense"`. As a result, **global font-size is now `0.875rem`** (previously `0.75rem`).

<figure>

<figcaption>Any text that relies on inherited font-size now looks closer to the text that specifies a larger font-size (which many MUI components do by default).</figcaption>

| Before | After |
| --- | --- |
| <img width="249" height="97" alt="Screenshot" src="https://github.com/user-attachments/assets/2dd6ef65-2f59-459f-9cf3-78c4a458e168" /> | <img width="252" height="102" alt="Screenshot" src="https://github.com/user-attachments/assets/9d2cf9d4-33ca-4c2f-830b-fafd7b724eed" />
| <img width="201" height="103" alt="Screenshot" src="https://github.com/user-attachments/assets/1c39edde-8dce-45ce-a3ed-d3079283a6bf" /> | <img width="214" height="104" alt="Screenshot" src="https://github.com/user-attachments/assets/60506bf4-1276-47dc-ab85-15ff31fcb099" /> |

</figure>

(This change cannot be readily seen in the test-app because it still uses `density="dense"` via the global `root.tsx` wrapper. #1147 fixes that.)
