### PR TITLE
prepare `@stratakit/mui` for publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,9 @@ This repo uses [Pnpm workspaces](https://pnpm.io/workspaces) to allow multiple p
 
 Packages:
 
-- [`@stratakit/foundations`](./packages/foundations/): Foundational pieces of StrataKit.
+- [`@stratakit/mui`](./packages/mui/): A StrataKit theme for [MUI](https://mui.com/material-ui/).
 - [`@stratakit/icons`](./packages/icons/): A standalone SVG icon library.
+- [`@stratakit/foundations`](./packages/foundations/): Foundational pieces of StrataKit.
 - [`@stratakit/bricks`](./packages/bricks/): Small, modular components that can be assembled to create larger, more functional experiences.
 - [`@stratakit/structures`](./packages/structures): Medium-sized component structures built on top of `@stratakit/bricks`.
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This monorepo is a [pnpm workspace](https://pnpm.io/workspaces) which can be con
 
 ### Packages
 
-These are the packages of StrataKit:
+These are the main packages of StrataKit:
 
-- [`@stratakit/foundations`](./packages/foundations/): Foundational pieces of StrataKit.
+- [`@stratakit/mui`](./packages/mui/): A StrataKit theme for [MUI](https://mui.com/material-ui/).
 - [`@stratakit/icons`](./packages/icons/): A standalone SVG icon library.
-- [`@stratakit/bricks`](./packages/bricks/): Small, modular components that can be assembled to create larger, more functional experiences.
-- [`@stratakit/structures`](./packages/structures): Medium-sized component structures built on top of `@stratakit/bricks`.
+
+Additional packages: [`@stratakit/foundations`](./packages/foundations/), [`@stratakit/bricks`](./packages/bricks/), [`@stratakit/structures`](./packages/structures).
 
 > [!NOTE]
 > StrataKit packages are currently published as `0.X` versions. StrataKit follows [semantic versioning](https://semver.org/), and breaking changes will only be published in _minor_ version bumps. It is therefore safe to use the `^` syntax to specify version ranges in your `package.json`.

--- a/packages/mui/CHANGELOG.md
+++ b/packages/mui/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Changelog
+
+## 0.1.0
+
+Initial release 🥳

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -1,9 +1,6 @@
 # @stratakit/mui
 
-StrataKit theme for [MUI](https://mui.com/).
-
-> [!CAUTION]
-> 🚧 This package is not published yet.
+StrataKit theme for [MUI](https://mui.com/material-ui/).
 
 ## Installation and setup
 
@@ -13,9 +10,11 @@ Using your package manager of choice, install the latest version of [`@stratakit
 npm add @stratakit/mui
 ```
 
-`@stratakit/mui` has a direct dependency on [`@stratakit/foundations`](https://www.npmjs.com/package/@stratakit/foundations) and [`@stratakit/icons`](https://www.npmjs.com/package/@stratakit/icons), the latter of which requires [bundler configuration](https://github.com/iTwin/design-system/tree/main/packages/icons#bundler-configuration) to ensure that `.svg` files are not inlined.
+Additional setup/considerations:
 
-Additionally, you should ensure that [StrataKit fonts](#fonts) are loaded in your application.
+- `@stratakit/mui` has a direct dependency on [`@stratakit/foundations`](https://www.npmjs.com/package/@stratakit/foundations) and [`@stratakit/icons`](https://www.npmjs.com/package/@stratakit/icons), the latter of which requires [bundler configuration](https://github.com/iTwin/design-system/tree/main/packages/icons#bundler-configuration) to ensure that `.svg` files are not inlined.
+- You should ensure that [StrataKit fonts](#fonts) are loaded in your application.
+- If you are trying to use this package alongside iTwinUI, you will also need to set up the [theme bridge](https://github.com/iTwin/iTwinUI/wiki/StrataKit-theme-bridge).
 
 ## Usage
 
@@ -29,6 +28,13 @@ export function App() {
 }
 ```
 
+Now you can use any components directly from `@mui/material`, and they will be automatically themed to use StrataKit's visual language.
+
+> [!CAUTION]
+> Do not use MUI's `ThemeProvider`, `StyledEngineProvider`, or `CssBaseline` components directly. The `Root` component will handle all global configuration for you.
+
+### Icon component
+
 `@stratakit/mui` also exports an `Icon` component that makes it easy to use `.svg` icons from [`@stratakit/icons`](https://www.npmjs.com/package/@stratakit/icons).
 
 ```jsx
@@ -38,7 +44,8 @@ import svgPlaceholder from "@stratakit/icons/placeholder.svg";
 <Icon href={svgPlaceholder} />;
 ```
 
-For more details on using specific features, refer to the inline documentation available on every component and prop.
+> [!NOTE]
+> `@stratakit/icons` requires [bundler configuration](https://github.com/iTwin/design-system/tree/main/packages/icons#bundler-configuration) to ensure that `.svg` files are not inlined.
 
 ## Fonts
 

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@stratakit/mui",
-	"private": true,
 	"type": "module",
 	"version": "0.1.0",
 	"license": "MIT",
@@ -59,7 +58,7 @@
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {
-		"@mui/material": "^7.3.5",
+		"@mui/material": "^7.3.6",
 		"react": ">=18.0.0",
 		"react-dom": ">=18.0.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,7 +280,7 @@ importers:
   packages/mui:
     dependencies:
       "@mui/material":
-        specifier: ^7.3.5
+        specifier: ^7.3.6
         version: 7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@stratakit/foundations":
         specifier: ^0.4.4


### PR DESCRIPTION
Removed `"private": true`, which will result in this package being published as soon as this PR merges.

Updated docs in several places.

### Notes for consumers

This is just the very first release primarily meant to unblock `@mui/material` usage.

MUI components should be used with little to no style overrides. If you see anything that looks off, please report it back to us so we can fix it. Do not try to patch over any potential bugs or visual issues.