### PR TITLE
WIP: MUI Tree

### DIFF
--- a/apps/test-app/app/tests/tree/index.tsx
+++ b/apps/test-app/app/tests/tree/index.tsx
@@ -5,9 +5,10 @@
 
 import * as React from "react";
 import { Icon } from "@stratakit/foundations";
+import { Root } from "@stratakit/mui";
 import { Tree } from "@stratakit/structures";
 import { produce } from "immer";
-import { definePage } from "~/~utils.tsx";
+import { definePage, useColorScheme } from "~/~utils.tsx";
 
 import type { VariantProps } from "~/~utils.tsx";
 
@@ -103,111 +104,115 @@ export default definePage(
 		const handleRetry = React.useCallback(() => {
 			setRenderError(false);
 		}, []);
+		const colorScheme = useColorScheme();
 		return (
-			<Tree.Root style={{ maxInlineSize: overflow ? 300 : undefined }}>
-				{flatData.map((item) => {
-					const { index, childIndex } = item;
+			<Root colorScheme={colorScheme}>
+				<Tree.Root style={{ maxInlineSize: overflow ? 300 : undefined }}>
+					{flatData.map((item) => {
+						const { index, childIndex } = item;
 
-					const error = renderError && index === 0 && childIndex === undefined;
-					const hasDescription =
-						(index === 0 && childIndex === undefined) || childIndex === 0;
-					return (
-						<Tree.Item
-							key={item.label}
-							aria-level={item.level}
-							aria-posinset={
-								childIndex !== undefined ? childIndex + 1 : index + 1
-							}
-							aria-setsize={item.setSize}
-							label={item.label}
-							description={hasDescription ? description : undefined}
-							expanded={item.expanded}
-							selected={item.selected}
-							error={error}
-							onSelectedChange={() => {
-								setData(
-									produce((prev) => {
-										const itemToUpdate =
-											childIndex === undefined
-												? prev[index]
-												: prev[index].children?.[childIndex];
-										if (!itemToUpdate) return;
-										itemToUpdate.selected = !itemToUpdate.selected;
-									}),
-								);
-							}}
-							onExpandedChange={() => {
-								startTransition(() => {
+						const error =
+							renderError && index === 0 && childIndex === undefined;
+						const hasDescription =
+							(index === 0 && childIndex === undefined) || childIndex === 0;
+						return (
+							<Tree.Item
+								key={item.label}
+								aria-level={item.level}
+								aria-posinset={
+									childIndex !== undefined ? childIndex + 1 : index + 1
+								}
+								aria-setsize={item.setSize}
+								label={item.label}
+								description={hasDescription ? description : undefined}
+								expanded={item.expanded}
+								selected={item.selected}
+								error={error}
+								onSelectedChange={() => {
 									setData(
 										produce((prev) => {
-											const itemToUpdate = prev[index];
-											if (itemToUpdate.expanded === undefined) return;
-
-											itemToUpdate.expanded = !itemToUpdate.expanded;
+											const itemToUpdate =
+												childIndex === undefined
+													? prev[index]
+													: prev[index].children?.[childIndex];
+											if (!itemToUpdate) return;
+											itemToUpdate.selected = !itemToUpdate.selected;
 										}),
 									);
-								});
-							}}
-							icon={
-								childIndex === undefined ? (
-									<Icon href={placeholderIcon} alt="decoration" />
-								) : undefined
-							}
-							unstable_decorations={
-								childIndex === 0 ? (
-									<>
+								}}
+								onExpandedChange={() => {
+									startTransition(() => {
+										setData(
+											produce((prev) => {
+												const itemToUpdate = prev[index];
+												if (itemToUpdate.expanded === undefined) return;
+
+												itemToUpdate.expanded = !itemToUpdate.expanded;
+											}),
+										);
+									});
+								}}
+								icon={
+									childIndex === undefined ? (
+										<Icon href={placeholderIcon} alt="decoration" />
+									) : undefined
+								}
+								unstable_decorations={
+									childIndex === 0 ? (
+										<>
+											<Icon href={placeholderIcon} />
+											<Icon href={placeholderIcon} />
+										</>
+									) : (
 										<Icon href={placeholderIcon} />
-										<Icon href={placeholderIcon} />
-									</>
-								) : (
-									<Icon href={placeholderIcon} />
-								)
-							}
-							inlineActions={
-								error
-									? [
-											<Tree.ItemAction
-												key="retry"
-												icon={refreshIcon}
-												label="Retry"
-												onClick={handleRetry}
-											/>,
-										]
-									: [
-											<Tree.ItemAction
-												key="unlock"
-												icon={unlockIcon}
-												label="Unlock"
-												visible={visible}
-											/>,
-											<Tree.ItemAction
-												key="show"
-												icon={showIcon}
-												label="Show"
-												visible={visible}
-											/>,
-										]
-							}
-							actions={
-								error
-									? [
-											<Tree.ItemAction
-												key="unlock"
-												icon={unlockIcon}
-												label="Unlock"
-											/>,
-											<Tree.ItemAction
-												key="show"
-												icon={showIcon}
-												label="Show"
-											/>,
-										]
-									: undefined
-							}
-						/>
-					);
-				})}
-			</Tree.Root>
+									)
+								}
+								inlineActions={
+									error
+										? [
+												<Tree.ItemAction
+													key="retry"
+													icon={refreshIcon}
+													label="Retry"
+													onClick={handleRetry}
+												/>,
+											]
+										: [
+												<Tree.ItemAction
+													key="unlock"
+													icon={unlockIcon}
+													label="Unlock"
+													visible={visible}
+												/>,
+												<Tree.ItemAction
+													key="show"
+													icon={showIcon}
+													label="Show"
+													visible={visible}
+												/>,
+											]
+								}
+								actions={
+									error
+										? [
+												<Tree.ItemAction
+													key="unlock"
+													icon={unlockIcon}
+													label="Unlock"
+												/>,
+												<Tree.ItemAction
+													key="show"
+													icon={showIcon}
+													label="Show"
+												/>,
+											]
+										: undefined
+								}
+							/>
+						);
+					})}
+				</Tree.Root>
+			</Root>
 		);
 	},
 	{
@@ -252,18 +257,22 @@ function ActionsTest({
 	});
 	const inlineActions = allActions.slice(0, inline);
 	const actions = allActions.slice(inline);
+
+	const colorScheme = useColorScheme();
 	return (
-		<Tree.Root>
-			<Tree.Item
-				label="Item 1"
-				aria-level={1}
-				aria-posinset={1}
-				aria-setsize={1}
-				inlineActions={inlineActions}
-				actions={actions}
-				error={error}
-			/>
-		</Tree.Root>
+		<Root colorScheme={colorScheme}>
+			<Tree.Root>
+				<Tree.Item
+					label="Item 1"
+					aria-level={1}
+					aria-posinset={1}
+					aria-setsize={1}
+					inlineActions={inlineActions}
+					actions={actions}
+					error={error}
+				/>
+			</Tree.Root>
+		</Root>
 	);
 }
 
@@ -271,34 +280,36 @@ function ActionsTest({
 
 function ExpansionTest({ selectable }: VariantProps) {
 	const [expanded, setExpanded] = React.useState(false);
-
+	const colorScheme = useColorScheme();
 	return (
-		<Tree.Root>
-			<Tree.Item
-				label="Parent Item"
-				aria-level={1}
-				aria-posinset={1}
-				aria-setsize={1}
-				expanded={expanded}
-				onExpandedChange={setExpanded}
-				selected={selectable ? false : undefined}
-			/>
-			{expanded && (
-				<>
-					<Tree.Item
-						label="Child Item 1"
-						aria-level={2}
-						aria-posinset={1}
-						aria-setsize={2}
-					/>
-					<Tree.Item
-						label="Child Item 2"
-						aria-level={2}
-						aria-posinset={2}
-						aria-setsize={2}
-					/>
-				</>
-			)}
-		</Tree.Root>
+		<Root colorScheme={colorScheme}>
+			<Tree.Root>
+				<Tree.Item
+					label="Parent Item"
+					aria-level={1}
+					aria-posinset={1}
+					aria-setsize={1}
+					expanded={expanded}
+					onExpandedChange={setExpanded}
+					selected={selectable ? false : undefined}
+				/>
+				{expanded && (
+					<>
+						<Tree.Item
+							label="Child Item 1"
+							aria-level={2}
+							aria-posinset={1}
+							aria-setsize={2}
+						/>
+						<Tree.Item
+							label="Child Item 2"
+							aria-level={2}
+							aria-posinset={2}
+							aria-setsize={2}
+						/>
+					</>
+				)}
+			</Tree.Root>
+		</Root>
 	);
 }

--- a/packages/structures/package.json
+++ b/packages/structures/package.json
@@ -124,6 +124,7 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.20",
+		"@mui/material": "catalog:",
 		"@stratakit/bricks": "^0.5.3",
 		"@stratakit/foundations": "^0.4.3",
 		"classnames": "^2.5.1",

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -127,7 +127,7 @@
 	}
 }
 
-.🥝TreeItemAction:is(.🥝IconButton) {
+.🥝TreeItemAction:is(.MuiIconButton-root) {
 	@layer base {
 		visibility: var(--🥝TreeItem-action-visibility);
 		transition: visibility 16ms; /* This allows some time focus to "settle" before determining final visibility. */

--- a/packages/structures/src/TreeItem.css
+++ b/packages/structures/src/TreeItem.css
@@ -38,7 +38,7 @@
 	}
 }
 
-.🥝TreeItemNode:is(.🥝ListItem) {
+.🥝TreeItemNode {
 	--✨first-level-indent: var(--stratakit-space-x2);
 	--✨subsequent-level-indent: calc(var(--stratakit-space-x1) + var(--stratakit-space-x05));
 
@@ -84,13 +84,13 @@
 	}
 }
 
-.🥝TreeItemContent:is(.🥝ListItemContent) {
+.🥝TreeItemContent {
 	@layer base {
 		white-space: nowrap;
 	}
 }
 
-.🥝TreeItemDescription:is(.🥝ListItemContent) {
+.🥝TreeItemDescription {
 	@layer base {
 		color: var(
 			--🥝TreeItem-color,
@@ -99,7 +99,7 @@
 	}
 }
 
-.🥝TreeItemActionsContainer:is(.🥝ListItemDecoration) {
+.🥝TreeItemActionsContainer {
 	@layer base {
 		align-self: stretch;
 		position: sticky;
@@ -127,7 +127,7 @@
 	}
 }
 
-.🥝TreeItemAction:is(.MuiIconButton-root) {
+.🥝TreeItemAction {
 	@layer base {
 		visibility: var(--🥝TreeItem-action-visibility);
 		transition: visibility 16ms; /* This allows some time focus to "settle" before determining final visibility. */
@@ -144,7 +144,7 @@
 	}
 }
 
-.🥝TreeItemExpander:is(.🥝IconButton) {
+.🥝TreeItemExpander {
 	@layer base {
 		visibility: var(--🥝TreeItem-expander-visibility);
 		z-index: 1; /* Ensure the expander is above the invisible content button */
@@ -160,7 +160,7 @@
 }
 
 @media (forced-colors: active) {
-	.🥝TreeItemNode:is(.🥝ListItem) {
+	.🥝TreeItemNode {
 		--🥝ListItem-background-color: Canvas;
 		--🥝TreeItem-color: CanvasText;
 

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { CompositeItem } from "@ariakit/react/composite";
 import { Role } from "@ariakit/react/role";
 import { Toolbar, ToolbarItem } from "@ariakit/react/toolbar";
-import { IconButton } from "@stratakit/bricks";
+import { Badge, IconButton, Tooltip } from "@mui/material";
 import {
 	GhostAligner,
 	IconButtonPresentation,
@@ -752,20 +752,32 @@ const TreeItemInlineAction = React.memo(
 		}
 
 		return (
-			<IconButton
-				id={id}
-				label={label}
-				icon={icon}
-				// @ts-expect-error: Using string value as a workaround for React 18
-				inert={visible === false ? "true" : undefined}
-				{...rest}
-				render={<ToolbarItem render={props.render} />}
-				dot={dot}
-				variant="ghost"
-				className={cx("🥝TreeItemAction", props.className)}
-				data-_sk-visible={visible}
-				ref={forwardedRef}
-			/>
+			<Tooltip title={label}>
+				<ToolbarItem
+					render={
+						<IconButton
+							id={id}
+							size="small"
+							// @ts-expect-error: Using string value as a workaround for React 18
+							inert={visible === false ? "true" : undefined}
+							{...rest}
+							// render={props.render} // TODO:
+							className={cx("🥝TreeItemAction", props.className)}
+							data-_sk-visible={visible}
+							ref={forwardedRef}
+						>
+							{/* TODO: dot message */}
+							<Badge variant="dot" invisible={!dot} color="primary">
+								{typeof icon === "string" ? (
+									<Icon href={icon} size="regular" />
+								) : (
+									icon
+								)}
+							</Badge>
+						</IconButton>
+					}
+				/>
+			</Tooltip>
 		);
 	}),
 );

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -11,6 +11,7 @@ import { VisuallyHidden } from "@ariakit/react/visually-hidden";
 import {
 	Badge,
 	IconButton,
+	ListItem,
 	ListItemIcon,
 	ListItemText,
 	Menu,
@@ -29,7 +30,6 @@ import {
 } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
 import { ChevronDown, MoreHorizontal, StatusIcon } from "./~utils.icons.js";
-import * as ListItem from "./~utils.ListItem.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
@@ -441,21 +441,23 @@ const TreeItemNode = React.memo((props: TreeItemNodeProps) => {
 
 	const [ref, renderActions] = useRenderActions();
 	return (
-		<ListItem.Root
+		<ListItem
+			component="div"
 			data-_sk-expanded={expanded}
 			data-_sk-selected={selected}
 			data-_sk-error={error ? true : undefined}
 			className="🥝TreeItemNode"
 			role={undefined}
-			ref={ref}
+			// biome-ignore lint/suspicious/noExplicitAny: TODO:
+			ref={ref as any}
+			dense
+			alignItems="flex-start"
+			secondaryAction={renderActions ? <TreeItemActions /> : undefined}
 		>
 			<TreeItemDecorations onExpanderClick={onExpanderClick} />
 
 			<TreeItemContent />
-			<TreeItemDescription />
-
-			{renderActions && <TreeItemActions />}
-		</ListItem.Root>
+		</ListItem>
 	);
 });
 DEV: TreeItemNode.displayName = "TreeItemNode";
@@ -472,10 +474,10 @@ interface TreeItemDecorationsProps {
  */
 const TreeItemDecorations = React.memo((props: TreeItemDecorationsProps) => {
 	return (
-		<ListItem.Decoration>
+		<ListItemIcon>
 			<TreeItemExpander onClick={props.onExpanderClick} />
 			<TreeItemDecoration />
-		</ListItem.Decoration>
+		</ListItemIcon>
 	);
 });
 DEV: TreeItemDecorations.displayName = "TreeItemDecorations";
@@ -517,30 +519,23 @@ DEV: TreeItemDecoration.displayName = "TreeItemDecoration";
 const TreeItemContent = React.memo(() => {
 	const labelId = React.useContext(TreeItemLabelIdContext);
 	const label = React.useContext(TreeItemLabelContext);
+	const description = React.useContext(TreeItemDescriptionContext);
+	const descriptionId = React.useContext(TreeItemDescriptionIdContext);
 	return (
-		<ListItem.Content id={labelId} className="🥝TreeItemContent">
-			{label}
-		</ListItem.Content>
+		<ListItemText
+			id={labelId}
+			className="🥝TreeItemContent"
+			primary={label}
+			secondary={description}
+			slotProps={{
+				secondary: {
+					id: descriptionId,
+				},
+			}}
+		/>
 	);
 });
 DEV: TreeItemContent.displayName = "TreeItemContent";
-
-// ----------------------------------------------------------------------------
-
-/**
- * Displays the description of a `<Tree.Item>`.
- * @private
- */
-const TreeItemDescription = React.memo(() => {
-	const description = React.useContext(TreeItemDescriptionContext);
-	const descriptionId = React.useContext(TreeItemDescriptionIdContext);
-	return description ? (
-		<ListItem.Content id={descriptionId} className="🥝TreeItemDescription">
-			{description}
-		</ListItem.Content>
-	) : undefined;
-});
-DEV: TreeItemDescription.displayName = "TreeItemDescription";
 
 // ----------------------------------------------------------------------------
 
@@ -554,7 +549,8 @@ DEV: TreeItemDescription.displayName = "TreeItemDescription";
 const TreeItemActions = React.memo(
 	forwardRef<"div", Omit<BaseProps, "children">>((props, forwardedRef) => {
 		return (
-			<ListItem.Decoration
+			<Toolbar
+				focusLoop={false}
 				{...props}
 				onClick={useEventHandlers(props.onClick, (e) => e.stopPropagation())}
 				onKeyDown={useEventHandlers(props.onKeyDown, (e) =>
@@ -562,11 +558,10 @@ const TreeItemActions = React.memo(
 				)}
 				className={cx("🥝TreeItemActionsContainer", props.className)}
 				ref={forwardedRef}
-				render={<Toolbar focusLoop={false} />}
 			>
 				<TreeItemInlineActionsRenderer />
 				<TreeItemActionMenu />
-			</ListItem.Decoration>
+			</Toolbar>
 		);
 	}),
 );

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { CompositeItem } from "@ariakit/react/composite";
 import { Role } from "@ariakit/react/role";
 import { Toolbar, ToolbarItem } from "@ariakit/react/toolbar";
+import { VisuallyHidden } from "@ariakit/react/visually-hidden";
 import { Badge, IconButton, Tooltip } from "@mui/material";
 import {
 	GhostAligner,
@@ -760,13 +761,13 @@ const TreeItemInlineAction = React.memo(
 							size="small"
 							// @ts-expect-error: Using string value as a workaround for React 18
 							inert={visible === false ? "true" : undefined}
+							aria-describedby={dot ? `${id}-dot` : undefined}
 							{...rest}
 							// render={props.render} // TODO:
 							className={cx("🥝TreeItemAction", props.className)}
 							data-_sk-visible={visible}
 							ref={forwardedRef}
 						>
-							{/* TODO: dot message */}
 							<Badge variant="dot" invisible={!dot} color="primary">
 								{typeof icon === "string" ? (
 									<Icon href={icon} size="regular" />
@@ -774,6 +775,7 @@ const TreeItemInlineAction = React.memo(
 									icon
 								)}
 							</Badge>
+							<VisuallyHidden id={`${id}-dot`}>{dot}</VisuallyHidden>
 						</IconButton>
 					}
 				/>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
       "@ariakit/react":
         specifier: ^0.4.20
         version: 0.4.20(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@mui/material":
+        specifier: "catalog:"
+        version: 7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@stratakit/bricks":
         specifier: ^0.5.3
         version: link:../bricks


### PR DESCRIPTION
This PR replaces components used in `Tree` and related `TreeItem` components. 
- `IconButton` of `@stratakit/bricks` is replaced with MUI [`IconButton`](https://mui.com/material-ui/react-button/#icon-button).
  - [`Badge`](https://mui.com/material-ui/react-badge/) visually hidden label is manually associated with `MenuItem`
- `DropdownMenu` of `@stratakit/structures` is replaced with MUI [`Menu`](https://mui.com/material-ui/react-menu/)
  - NOTE: wrappers are not allowed for nested `MenuItem` elements (except those open for extension)
  - Slight behavior change: `Menu` behaves as a modal.
- Internal `ListItem` of `@stratakit/structures` is replaced with MUI [`List`](https://mui.com/material-ui/react-list/)
  - Requires re-design or additional custom styling.

## Preview

https://itwin.github.io/design-system/1129/tests/tree