### PR TITLE
MUI checkbox styling

### DIFF
--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -108,7 +108,16 @@ export default function Page() {
 						<Checkbox />
 						<Checkbox defaultChecked />
 						<Checkbox indeterminate />
+						<Checkbox disabled />
+						<Checkbox disabled defaultChecked />
+						<Checkbox disabled indeterminate />
+					</Stack>
+
+					<Stack spacing={1} direction="row">
+						<Switch />
 						<Switch defaultChecked />
+						<Switch disabled />
+						<Switch disabled defaultChecked />
 					</Stack>
 
 					<Stack spacing={1} direction="row">

--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -108,6 +108,9 @@ export default function Page() {
 						<Checkbox />
 						<Checkbox defaultChecked />
 						<Checkbox indeterminate />
+						<Checkbox color="error" />
+						<Checkbox color="error" defaultChecked />
+						<Checkbox color="error" indeterminate />
 						<Checkbox disabled />
 						<Checkbox disabled defaultChecked />
 						<Checkbox disabled indeterminate />

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -19,6 +19,9 @@ import {
 	WarningIcon,
 } from "./Icon.js";
 
+// Simple span elements for checkbox icons (no styling)
+const CheckboxSymbol = () => <span className="MuiCheckbox-symbol" />;
+
 /**
  * Creates a StrataKit theme for MUI. Should be used with MUI's `ThemeProvider`.
  *
@@ -110,6 +113,9 @@ function createTheme() {
 			MuiCheckbox: {
 				defaultProps: {
 					disableRipple: true, // Checkbox doesn't inherit from ButtonBase
+					icon: <CheckboxSymbol />,
+					checkedIcon: <CheckboxSymbol />,
+					indeterminateIcon: <CheckboxSymbol />,
 				},
 			},
 			MuiLink: {

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -106,7 +106,9 @@
 			var(--xyz-checkbox-bg--checked) 100%,
 			var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-strong-hover-\%)
 		);
+		--xyz-checkbox-bg--disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
 		--xyz-checkbox-color--default: var(--stratakit-color-icon-neutral-emphasis);
+		--xyz-checkbox-color--disabled: var(--stratakit-color-icon-neutral-disabled);
 		--xyz-checkbox-border-color--default: var(--stratakit-color-border-shadow-base);
 		--xyz-checkbox-border-color--hover: color-mix(
 			in oklch,
@@ -122,11 +124,14 @@
 		--xyz-checkbox-mask-image--unchecked: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');
 		--xyz-checkbox-mask-image--checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M11.73 5.47a.75.75 0 0 1 0 1.06l-4.4 4.4a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06L6.8 9.34l3.87-3.87a.75.75 0 0 1 1.06 0Z"/></svg>');
 		--xyz-checkbox-mask-image--indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M4.25 8A.75.75 0 0 1 5 7.25h6.5a.75.75 0 0 1 0 1.5H5A.75.75 0 0 1 4.25 8Z"/></svg>');
-		--xyz-checkbox-box-shadow: 0px 0px 0px 1px var(--xyz-checkbox-border-color) inset;
+		--xyz-checkbox-box-shadow--default:
+			var(--stratakit-shadow-control-button-base-inset), 0px 0px 0px 1px
+			var(--xyz-checkbox-border-color) inset, var(--stratakit-shadow-control-button-base-drop);
 
 		--xyz-checkbox-bg: var(--xyz-checkbox-bg--default);
 		--xyz-checkbox-color: var(--xyz-checkbox-color--default);
 		--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--default);
+		--xyz-checkbox-box-shadow: var(--xyz-checkbox-box-shadow--default);
 		--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--unchecked);
 
 		&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
@@ -154,17 +159,31 @@
 			}
 		}
 
+		&:where(.Mui-disabled) {
+			--xyz-checkbox-bg: var(--xyz-checkbox-bg--disabled);
+			--xyz-checkbox-color: var(--xyz-checkbox-color--disabled);
+			--xyz-checkbox-box-shadow: none;
+		}
+
 		&:where(.Mui-focusVisible) {
 			outline: 2px solid var(--stratakit-color-border-accent-strong);
 		}
 
 		@media (forced-colors: active) {
+			--xyz-checkbox-border: 1px solid CanvasText;
+
 			&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
 				&,
 				&:hover {
 					--xyz-checkbox-bg: SelectedItem;
-					--xyz-checkbox-color: GrayText;
+					--xyz-checkbox-color: SelectedItemText;
 				}
+			}
+
+			&:where(.Mui-disabled) {
+				--xyz-checkbox-bg: Canvas;
+				--xyz-checkbox-color: GrayText;
+				--xyz-checkbox-border: 1px solid GrayText;
 			}
 		}
 	}
@@ -179,9 +198,8 @@
 		transition: all 150ms ease-out;
 		transition-property: background-color, border-color, box-shadow, --🥝Checkbox-border-color;
 		position: relative;
-		box-shadow:
-			var(--stratakit-shadow-control-button-base-inset), var(--xyz-checkbox-box-shadow),
-			var(--stratakit-shadow-control-button-base-drop);
+		box-shadow: var(--xyz-checkbox-box-shadow);
+		border: var(--xyz-checkbox-border);
 
 		&::after {
 			content: "";
@@ -191,10 +209,10 @@
 			mask-image: var(--xyz-checkbox-mask-image, initial);
 			mask-repeat: no-repeat;
 			mask-position: center;
-		}
 
-		@media (forced-colors: active) {
-			border: 1px solid CanvasText;
+			@media (forced-colors: active) {
+				background-color: var(--xyz-checkbox-color);
+			}
 		}
 	}
 

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -129,13 +129,15 @@
 		--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--default);
 		--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--unchecked);
 
-		&:hover {
-			--xyz-checkbox-bg: var(--xyz-checkbox-bg--hover);
-			--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--hover);
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				--xyz-checkbox-bg: var(--xyz-checkbox-bg--hover);
+				--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--hover);
 
-			&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
-				--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked-hover);
-				--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked-hover);
+				&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
+					--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked-hover);
+					--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked-hover);
+				}
 			}
 		}
 

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -108,6 +108,7 @@
 		);
 		--xyz-checkbox-bg--disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
 		--xyz-checkbox-color--default: var(--stratakit-color-icon-neutral-emphasis);
+		--xyz-checkbox-color--error: var(--stratakit-color-icon-neutral-primary);
 		--xyz-checkbox-color--disabled: var(--stratakit-color-icon-neutral-disabled);
 		--xyz-checkbox-border-color--default: var(--stratakit-color-border-shadow-base);
 		--xyz-checkbox-border-color--hover: color-mix(
@@ -121,6 +122,7 @@
 			var(--xyz-checkbox-border-color--checked) 100%,
 			var(--stratakit-color-glow-hue) var(--stratakit-color-border-glow-strong-hover-\%)
 		);
+		--xyz-checkbox-border-color--invalid: var(--stratakit-color-border-critical-base);
 		--xyz-checkbox-mask-image--unchecked: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');
 		--xyz-checkbox-mask-image--checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M11.73 5.47a.75.75 0 0 1 0 1.06l-4.4 4.4a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06L6.8 9.34l3.87-3.87a.75.75 0 0 1 1.06 0Z"/></svg>');
 		--xyz-checkbox-mask-image--indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M4.25 8A.75.75 0 0 1 5 7.25h6.5a.75.75 0 0 1 0 1.5H5A.75.75 0 0 1 4.25 8Z"/></svg>');
@@ -134,9 +136,23 @@
 		--xyz-checkbox-box-shadow: var(--xyz-checkbox-box-shadow--default);
 		--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--unchecked);
 
-		&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				--xyz-checkbox-bg: var(--xyz-checkbox-bg--hover);
+				--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--hover);
+			}
+		}
+
+		&:where(.Mui-checked, .MuiCheckbox-indeterminate):where(:not(.MuiCheckbox-colorError)) {
 			--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked);
 			--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked);
+
+			@media (any-hover: hover) {
+				&:where(:hover) {
+					--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked-hover);
+					--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked-hover);
+				}
+			}
 		}
 
 		&:where(.Mui-checked) {
@@ -147,16 +163,9 @@
 			--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--indeterminate);
 		}
 
-		@media (any-hover: hover) {
-			&:where(:hover) {
-				--xyz-checkbox-bg: var(--xyz-checkbox-bg--hover);
-				--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--hover);
-
-				&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
-					--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked-hover);
-					--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked-hover);
-				}
-			}
+		&:where(.MuiCheckbox-colorError) {
+			--xyz-checkbox-color: var(--xyz-checkbox-color--error);
+			--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--invalid);
 		}
 
 		&:where(.Mui-disabled) {
@@ -172,12 +181,17 @@
 		@media (forced-colors: active) {
 			--xyz-checkbox-border: 1px solid CanvasText;
 
-			&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
+			&:where(.Mui-checked, .MuiCheckbox-indeterminate):where(:not(.MuiCheckbox-colorError)) {
 				&,
 				&:hover {
 					--xyz-checkbox-bg: SelectedItem;
 					--xyz-checkbox-color: SelectedItemText;
 				}
+			}
+
+			&:where(.MuiCheckbox-colorError) {
+				--xyz-checkbox-bg: Mark;
+				--xyz-checkbox-color: MarkText;
 			}
 
 			&:where(.Mui-disabled) {

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -94,14 +94,105 @@
 	}
 
 	.MuiCheckbox-root {
-		&:where(.MuiCheckbox-colorPrimary) {
-			&:where(.Mui-checked, .MuiCheckbox-indeterminate):where(:not(.Mui-disabled)) {
-				color: var(--stratakit-mui-palette-primary-dark);
+		--xyz-checkbox-bg--default: var(--stratakit-color-bg-neutral-base);
+		--xyz-checkbox-bg--hover: color-mix(
+			in oklch,
+			var(--xyz-checkbox-bg--default) 100%,
+			var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%)
+		);
+		--xyz-checkbox-bg--checked: var(--stratakit-color-bg-accent-base);
+		--xyz-checkbox-bg--checked-hover: color-mix(
+			in oklch,
+			var(--xyz-checkbox-bg--checked) 100%,
+			var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-strong-hover-\%)
+		);
+		--xyz-checkbox-color--default: var(--stratakit-color-icon-neutral-emphasis);
+		--xyz-checkbox-border-color--default: var(--stratakit-color-border-shadow-base);
+		--xyz-checkbox-border-color--hover: color-mix(
+			in oklch,
+			var(--xyz-checkbox-border-color--default) 100%,
+			var(--stratakit-color-glow-hue) var(--stratakit-color-border-glow-base-hover-\%)
+		);
+		--xyz-checkbox-border-color--checked: var(--stratakit-color-border-shadow-strong);
+		--xyz-checkbox-border-color--checked-hover: color-mix(
+			in oklch,
+			var(--xyz-checkbox-border-color--checked) 100%,
+			var(--stratakit-color-glow-hue) var(--stratakit-color-border-glow-strong-hover-\%)
+		);
+		--xyz-checkbox-mask-image--unchecked: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');
+		--xyz-checkbox-mask-image--checked: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M11.73 5.47a.75.75 0 0 1 0 1.06l-4.4 4.4a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06L6.8 9.34l3.87-3.87a.75.75 0 0 1 1.06 0Z"/></svg>');
+		--xyz-checkbox-mask-image--indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M4.25 8A.75.75 0 0 1 5 7.25h6.5a.75.75 0 0 1 0 1.5H5A.75.75 0 0 1 4.25 8Z"/></svg>');
+		--xyz-checkbox-box-shadow: 0px 0px 0px 1px var(--xyz-checkbox-border-color) inset;
+
+		--xyz-checkbox-bg: var(--xyz-checkbox-bg--default);
+		--xyz-checkbox-color: var(--xyz-checkbox-color--default);
+		--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--default);
+		--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--unchecked);
+
+		&:hover {
+			--xyz-checkbox-bg: var(--xyz-checkbox-bg--hover);
+			--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--hover);
+
+			&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
+				--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked-hover);
+				--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked-hover);
 			}
+		}
+
+		&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
+			--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked);
+			--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked);
+		}
+
+		&:where(.Mui-checked) {
+			--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--checked);
+		}
+
+		&:where(.MuiCheckbox-indeterminate) {
+			--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--indeterminate);
 		}
 
 		&:where(.Mui-focusVisible) {
 			outline: 2px solid var(--stratakit-color-border-accent-strong);
+		}
+
+		@media (forced-colors: active) {
+			&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
+				&,
+				&:hover {
+					--xyz-checkbox-bg: SelectedItem;
+					--xyz-checkbox-color: GrayText;
+				}
+			}
+		}
+	}
+
+	.MuiCheckbox-symbol {
+		inline-size: 1rem;
+		block-size: 1rem;
+
+		background-color: var(--xyz-checkbox-bg);
+		border-radius: 4px;
+		color: var(--xyz-checkbox-color);
+		transition: all 150ms ease-out;
+		transition-property: background-color, border-color, box-shadow, --🥝Checkbox-border-color;
+		position: relative;
+		box-shadow:
+			var(--stratakit-shadow-control-button-base-inset), var(--xyz-checkbox-box-shadow),
+			var(--stratakit-shadow-control-button-base-drop);
+
+		&::after {
+			content: "";
+			position: absolute;
+			inset: 0px;
+			background-color: currentColor;
+			mask-image: var(--xyz-checkbox-mask-image, initial);
+			mask-repeat: no-repeat;
+			mask-position: center;
+		}
+
+		@media (forced-colors: active) {
+			border: 1px solid CanvasText;
 		}
 	}
 

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -129,18 +129,6 @@
 		--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--default);
 		--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--unchecked);
 
-		@media (any-hover: hover) {
-			&:where(:hover) {
-				--xyz-checkbox-bg: var(--xyz-checkbox-bg--hover);
-				--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--hover);
-
-				&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
-					--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked-hover);
-					--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked-hover);
-				}
-			}
-		}
-
 		&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
 			--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked);
 			--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked);
@@ -152,6 +140,18 @@
 
 		&:where(.MuiCheckbox-indeterminate) {
 			--xyz-checkbox-mask-image: var(--xyz-checkbox-mask-image--indeterminate);
+		}
+
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				--xyz-checkbox-bg: var(--xyz-checkbox-bg--hover);
+				--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--hover);
+
+				&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
+					--xyz-checkbox-bg: var(--xyz-checkbox-bg--checked-hover);
+					--xyz-checkbox-border-color: var(--xyz-checkbox-border-color--checked-hover);
+				}
+			}
 		}
 
 		&:where(.Mui-focusVisible) {


### PR DESCRIPTION
Used [the MUI Checkbox Customization documentation](https://mui.com/material-ui/react-checkbox/#customization) for inspiration.
- Hid the SVG and display `span.MuiCheckbox-symbol` instead.
- Styled to match the checkbox prior to MUI.

[Deploy preview](https://supreme-barnacle-pl8jn8m.pages.github.io/1133/mui/)