### PR TITLE
`Root`: fix `synchronizeColorScheme` default

### DIFF
--- a/.changeset/wicked-towns-hunt.md
+++ b/.changeset/wicked-towns-hunt.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/foundations": patch
+---
+
+Fixed the default value of `Root`'s `synchronizeColorScheme` prop to actually be `true`, as mentioned in the docs.

--- a/apps/test-app/app/root.tsx
+++ b/apps/test-app/app/root.tsx
@@ -79,7 +79,11 @@ export default function App() {
 
 	return (
 		<QueryClientProvider client={queryClient}>
-			<Root colorScheme={colorScheme} density="dense">
+			<Root
+				colorScheme={colorScheme}
+				density="dense"
+				synchronizeColorScheme={false}
+			>
 				<Outlet />
 			</Root>
 		</QueryClientProvider>

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -107,7 +107,7 @@ export const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 
 	const {
 		children,
-		synchronizeColorScheme = false,
+		synchronizeColorScheme = true,
 		unstable_htmlSanitizer = identity,
 		portalContainer: portalContainerProp,
 		...rest


### PR DESCRIPTION
This was somehow missed from https://github.com/iTwin/design-system/pull/952 😅

This change is somewhat important for `@stratakit/mui` (which does not expose `synchronizeColorScheme`). I noticed it when working on iTwinUI theme bridge: https://github.com/iTwin/iTwinUI/pull/2660.