### PR TITLE
move focus styles into `@layer reset`

### DIFF
--- a/.changeset/wild-tigers-burn.md
+++ b/.changeset/wild-tigers-burn.md
@@ -1,0 +1,6 @@
+---
+"@stratakit/foundations": patch
+"@stratakit/mui": patch
+---
+
+Global focus styles have been moved from `@layer stratakit` to `@layer reset`.

--- a/packages/foundations/src/~global.css
+++ b/packages/foundations/src/~global.css
@@ -30,8 +30,3 @@ body {
 	background-color: var(--🥝selection-color-bg);
 	color: var(--🥝selection-color-text);
 }
-
-*:focus-visible {
-	outline: var(--🥝focus-outline);
-	outline-offset: var(--🥝focus-outline-offset);
-}

--- a/packages/foundations/src/~reset.css
+++ b/packages/foundations/src/~reset.css
@@ -79,3 +79,8 @@
 :where(dialog:not([open], [popover]), [popover]:not(:popover-open)) {
 	display: none !important;
 }
+
+*:focus-visible {
+	outline: var(--🥝focus-outline);
+	outline-offset: var(--🥝focus-outline-offset);
+}


### PR DESCRIPTION
After #1123, global focus styles were taking precedence over component-level focus styles in many places (see https://github.com/iTwin/iTwinUI/pull/2660#discussion_r2631873465). This PR moves these focus styles from `@layer stratakit` down to the lowest layer `@layer reset`, giving priority to indetermediate layers such as `@layer mui` and `@layer itwinui`.

I don't love this change because a CSS _reset_ should not have opinionated styles that rely on custom properties, but it does get the job done (i.e. allowing `outline-color` and `outline-offset` customizations).