### PR TITLE
`revert-layer` MUI focus outline

### DIFF
--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -198,3 +198,16 @@
 		}
 	}
 }
+
+@layer mui {
+	/**
+	 * MUI components set `outline: 0`, overriding StrataKit's global focus outline.
+	 * This ruleset reverts the MUI override, allowing `@layer reset` focus outline to apply.
+	 */
+	*:focus-visible {
+		/* artificially increasing specificity */
+		&:not(#a#b) {
+			outline: revert-layer;
+		}
+	}
+}


### PR DESCRIPTION
This addresses https://github.com/iTwin/design-system/pull/1135#discussion_r2635367185.

Focus outlines now use `var(--stratakit-color-border-accent-strong)` instead of `currentColor`.