### PR TITLE
update `IconButton` border-radius

### DIFF
--- a/.changeset/shaky-papers-follow.md
+++ b/.changeset/shaky-papers-follow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `border-radius` of `IconButton` component.

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -111,6 +111,10 @@
 		}
 	}
 
+	.MuiIconButton-root {
+		border-radius: 4px;
+	}
+
 	.MuiLink-root {
 		font-weight: 500;
 		text-decoration-color: currentColor;


### PR DESCRIPTION
`IconButton` no longer uses MUI's "round" shape (`border-radius: 50%`).

Currently hardcoding `4px` but can be swapped out with tokens (when we add them in the future).