### PR TITLE
update default `Button` variant

### DIFF
--- a/.changeset/dry-swans-report.md
+++ b/.changeset/dry-swans-report.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `Button` to use `variant="contained"` by default.

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -120,6 +120,7 @@ function createTheme() {
 			MuiButton: {
 				defaultProps: {
 					color: "secondary",
+					variant: "contained",
 				},
 			},
 			MuiChip: {


### PR DESCRIPTION
MUI defaults to `variant="text"`, which is not what we want in StrataKit. `variant="contained"` works better as it's the equivalent to `variant="solid"` (the previous default).

Note: `IconButton` does not seem to have a `variant` prop.