### PR TITLE
test-app: fix inherited `font-size` in `/mui` route

### DIFF
--- a/apps/test-app/app/root.tsx
+++ b/apps/test-app/app/root.tsx
@@ -10,6 +10,7 @@ import {
 	Outlet,
 	Scripts,
 	ScrollRestoration,
+	useLocation,
 	useMatches,
 } from "react-router";
 import { Root } from "@stratakit/foundations";
@@ -32,7 +33,7 @@ export const links: LinksFunction = () => {
 			href: "data:image/svg+xml,<svg viewBox='0 -16 20 20' xmlns='http://www.w3.org/2000/svg'><text>🥝</text></svg>",
 			type: "image/svg+xml",
 		},
-		{ rel: "manifest", href: "/manifest.json", crossorigin: "use-credentials" },
+		{ rel: "manifest", href: "/manifest.json", crossOrigin: "use-credentials" },
 	];
 };
 
@@ -72,6 +73,7 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
 
 export default function App() {
 	const colorScheme = useColorScheme();
+	const location = useLocation();
 
 	React.useEffect(function signalPageLoad() {
 		document.body.dataset.loaded = "true";
@@ -79,13 +81,23 @@ export default function App() {
 
 	return (
 		<QueryClientProvider client={queryClient}>
-			<Root
-				colorScheme={colorScheme}
-				density="dense"
-				synchronizeColorScheme={false}
-			>
-				<Outlet />
-			</Root>
+			{(() => {
+				// `Root` from `@stratakit/foundations` only supports `density="dense"` at the moment,
+				// and should therefore not be used around MUI components (which use a looser density).
+				if (location.pathname.startsWith("/mui")) {
+					return <Outlet />;
+				}
+
+				return (
+					<Root
+						colorScheme={colorScheme}
+						density="dense"
+						synchronizeColorScheme={false}
+					>
+						<Outlet />
+					</Root>
+				);
+			})()}
 		</QueryClientProvider>
 	);
 }


### PR DESCRIPTION
_Extracted out of #1115._

This updates the `root.tsx` layout to remove `Root` (from `@stratakit/foundations`) for the `/mui` route only, while keeping it for the rest of the routes.

The main effect of this change is that the `font-size` is no longer set to `0.75rem`. Instead, it is set to `0.875rem` (by the `Root` from `@stratakit/mui`).

Eventually, we'll probably want to use `Root` from `@stratakit/mui` everywhere, but that might require other changes, so this is the smaller, safer change right now.

---

Related PR: https://github.com/iTwin/design-system/pull/1126