### PR TITLE
map MUI palette back to CSS variables

### DIFF
--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -19,6 +19,8 @@ import {
 	WarningIcon,
 } from "./Icon.js";
 
+import type { ColorSystemOptions } from "@mui/material/styles";
+
 /**
  * Creates a StrataKit theme for MUI. Should be used with MUI's `ThemeProvider`.
  *
@@ -34,6 +36,24 @@ import {
  * ```
  */
 function createTheme() {
+	// Map the JS palette back to MUI's own CSS variables, which will then be mapped to the correct StrataKit tokens in CSS.
+	// (This is a fallback for any code that uses MUI's theme.palette values directly instead of CSS variables)
+	const palette = {
+		primary: { main: "var(--stratakit-mui-palette-primary-main)" },
+		secondary: { main: "var(--stratakit-mui-palette-secondary-main)" },
+
+		error: { main: "var(--stratakit-mui-palette-error-main)" },
+		warning: { main: "var(--stratakit-mui-palette-warning-main)" },
+		info: { main: "var(--stratakit-mui-palette-info-main)" },
+		success: { main: "var(--stratakit-mui-palette-success-main)" },
+
+		grey: Object.fromEntries(
+			["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"].map(
+				(shade) => [shade, `var(--stratakit-mui-palette-grey-${shade})`],
+			),
+		),
+	} satisfies ColorSystemOptions["palette"];
+
 	return createMuiTheme({
 		cssVariables: {
 			nativeColor: true,
@@ -41,8 +61,8 @@ function createTheme() {
 			cssVarPrefix: "stratakit-mui",
 		},
 		colorSchemes: {
-			light: true,
-			dark: true,
+			light: { palette },
+			dark: { palette },
 		},
 		typography: {
 			fontFamily: "var(--stratakit-font-family-sans)",


### PR DESCRIPTION
This PR updates the MUI theme to set the most common `palette` values (in JS) to MUI's own CSS vars. Without this, the JS theme uses the old hex values (since it only gets set in `.css`).

Ideally this shouldn't be necessary, but there are edge cases where some MUI components (such as `LinearProgress`) try to use the raw JS values when `color-mix`ing. After a couple hours of reading the MUI source code, I couldn't work out why exactly this happens, but this PR solves it.

I'm setting the values back to the corresponding `--stratakit-mui` vars, whose actual values will continue to be set in the `.css` file.

After this PR, we (hopefully) shouldn't see the "Material blue" anywhere.