### PR TITLE
fix `disabled` button styles

### DIFF
--- a/.changeset/spotty-cases-itch.md
+++ b/.changeset/spotty-cases-itch.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `ButtonBase` disabled styles to use `cursor: not-allowed` and not prevent `pointer-events`.

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -71,6 +71,14 @@
 		align-items: center; /* Fix vertical alignment of differently sized icons */
 	}
 
+	.MuiButtonBase-root {
+		&:where(.Mui-disabled) {
+			cursor: not-allowed;
+			pointer-events: auto; /* Revert MUI's disabled pointer-events */
+			background-color: transparent; /* To prevent hover styles from leaking through */
+		}
+	}
+
 	.MuiButton-root {
 		&:where(.MuiButton-colorSecondary) {
 			--variant-containedBg: var(--stratakit-color-bg-neutral-base);
@@ -90,6 +98,12 @@
 		&:where(.MuiButton-colorPrimary) {
 			--variant-outlinedColor: var(--stratakit-color-text-accent-strong);
 			--variant-textColor: var(--stratakit-color-text-accent-strong);
+		}
+
+		&:where(.MuiButton-contained) {
+			&:where(.Mui-disabled) {
+				background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR updates the styles for MUI disabled buttons.

1. Changes to **ButtonBase** (which is used internally by various components):
   1.1. Reverted `pointer-events`, which I believe is used by MUI to prevent hover styles from taking effect.
   1.2. Added `cursor: not-allowed` (see [MUI docs](https://mui.com/material-ui/react-button/#cursor-not-allowed))
   1.3. Added `background-color: transparent` to fix hover styles (result of 1.1).
2. Changes to **Button**:
   2.1. Re-set `background-color` for contained variant to combat 1.3

Note: Disabled buttons can now be hovered but they still cannot be focused. This PR is just the very first step towards fixing disabled buttons.