### PR TITLE
use `describeChild` by default in `Tooltip`

### DIFF
--- a/.changeset/gentle-glasses-eat.md
+++ b/.changeset/gentle-glasses-eat.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Updated the default value of `Tooltip`'s `describeChild` prop to `true`.

--- a/examples/mui/Badge.default.tsx
+++ b/examples/mui/Badge.default.tsx
@@ -14,7 +14,7 @@ import emailIcon from "@stratakit/icons/email.svg";
 export default () => {
 	const descriptionId = React.useId();
 	return (
-		<Tooltip title="Inbox">
+		<Tooltip title="Inbox" describeChild={false}>
 			<IconButton aria-describedby={descriptionId}>
 				<Badge badgeContent={4} color="primary">
 					<Icon href={`${emailIcon}#icon-large`} size="large" />

--- a/examples/mui/Fab.default.tsx
+++ b/examples/mui/Fab.default.tsx
@@ -11,7 +11,7 @@ import addIcon from "@stratakit/icons/add.svg";
 
 export default () => {
 	return (
-		<Tooltip title="Add documents">
+		<Tooltip title="Add documents" describeChild={false}>
 			<Fab>
 				<Icon href={addIcon} />
 			</Fab>

--- a/examples/mui/IconButton._colors.tsx
+++ b/examples/mui/IconButton._colors.tsx
@@ -22,6 +22,7 @@ export default () => {
 		<Tooltip
 			key={color}
 			title={`${color.charAt(0).toUpperCase()}${color.slice(1)}`}
+			describeChild={false}
 		>
 			<IconButton color={color}>
 				<Icon href={placeholderIcon} />

--- a/examples/mui/IconButton.default.tsx
+++ b/examples/mui/IconButton.default.tsx
@@ -11,7 +11,7 @@ import downloadIcon from "@stratakit/icons/download.svg";
 
 export default () => {
 	return (
-		<Tooltip title="Download">
+		<Tooltip title="Download" describeChild={false}>
 			<IconButton>
 				<Icon href={downloadIcon} />
 			</IconButton>

--- a/examples/mui/Snackbar.default.tsx
+++ b/examples/mui/Snackbar.default.tsx
@@ -27,7 +27,7 @@ export default () => {
 				onClose={handleClose}
 				message="Note archived"
 				action={
-					<Tooltip title="Close">
+					<Tooltip title="Close" describeChild={false}>
 						<IconButton color="inherit" onClick={handleClose}>
 							<Icon href={closeIcon} />
 						</IconButton>

--- a/examples/mui/ToggleButton.default.tsx
+++ b/examples/mui/ToggleButton.default.tsx
@@ -16,23 +16,23 @@ import textAlignRightIcon from "@stratakit/icons/text-align-right.svg";
 export default () => {
 	return (
 		<ToggleButtonGroup value="center" aria-label="text alignment">
-			<Tooltip title="Left aligned">
+			<Tooltip title="Left aligned" describeChild={false}>
 				<ToggleButton value="left">
 					<Icon href={textAlignLeftIcon} />
 				</ToggleButton>
 			</Tooltip>
-			<Tooltip title="Centered">
+			<Tooltip title="Centered" describeChild={false}>
 				<ToggleButton value="center">
 					<Icon href={textAlignCenterIcon} />
 				</ToggleButton>
 			</Tooltip>
-			<Tooltip title="Right aligned">
+			<Tooltip title="Right aligned" describeChild={false}>
 				<ToggleButton value="right">
 					<Icon href={textAlignRightIcon} />
 				</ToggleButton>
 			</Tooltip>
-			<Tooltip title="Justified">
-				<ToggleButton value="justify" disabled>
+			<Tooltip title="Justified" describeChild={false}>
+				<ToggleButton value="justify">
 					<Icon href={textAlignJustifyIcon} />
 				</ToggleButton>
 			</Tooltip>

--- a/examples/mui/Tooltip.default.tsx
+++ b/examples/mui/Tooltip.default.tsx
@@ -3,18 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import IconButton from "@mui/material/IconButton";
+import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
-import { Icon } from "@stratakit/mui";
-
-import downloadIcon from "@stratakit/icons/download.svg";
 
 export default () => {
 	return (
-		<Tooltip title="Download">
-			<IconButton>
-				<Icon href={downloadIcon} />
-			</IconButton>
+		<Tooltip title="Save is disabled until you finish reading the documentation">
+			<Button disabled>Save</Button>
 		</Tooltip>
 	);
 };

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -169,6 +169,11 @@ function createTheme() {
 					IconComponent: ArrowDownIcon,
 				},
 			},
+			MuiTooltip: {
+				defaultProps: {
+					describeChild: true,
+				},
+			},
 		},
 	});
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -42,3 +42,13 @@ declare module "@mui/material/TextField" {
 		} & Omit<TextFieldProps, "variant">,
 	): React.JSX.Element;
 }
+
+declare module "@mui/material/Tooltip" {
+	interface TooltipOwnProps {
+		/**
+		 * The default value with `@stratakit/mui` is `true`.
+		 * Use `describeChild={false}` if you want to label the child element.
+		 */
+		describeChild?: boolean;
+	}
+}


### PR DESCRIPTION
_Follow-up to #1156_

### Changes

This PR updates the default value of Tooltip's [`describeChild`](https://mui.com/material-ui/api/tooltip/#tooltip-prop-describeChild) prop to `true`.

- Updated `types.d.ts` to clarify default value. (JSDocs will unfortunately get merged tho)
- Updated existing examples to use `describeChild={false}` where appropriate.
  - Also updated default Tooltip example to use `Button` instead of `IconButton`.
- Added `minor` changeset (potential breaking change).

### Notes/observations

The new default is more appropriate, since a tooltip component is primarily meant for hint text. It is unexpected and problematic for a tooltip to override the child element's accessible name (using `aria-label`). This new default also matches existing defaults from iTwinUI (`ariaStrategy`) and old StrataKit (`type`).

We should also probably add a `label` prop to `IconButton` so that consumers don't have to think about this MUI quirk. However, I think there is still potential for consumers who aren't aware of this prop to misuse `Tooltip`+`IconButton`. Clear documentation can help with this.

**Important observation:** While MUI correctly sets `aria-describedby` pointing to the tooltip element (albeit only when the tooltip is visible), it surprisingly also adds a `title` attribute to the button. Fortunately, this doesn't cause a problem because the contents of the button take preference over the `title` attribute (see [Accessible name calculation](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#accessiblenamecalculation)).