### PR TITLE
remove extra `IconButton` status colors

### DIFF
--- a/.changeset/cozy-buttons-change.md
+++ b/.changeset/cozy-buttons-change.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Removed the following values from `IconButton`'s `color` prop: `"info"`, `"success"` and `"warning"`.

--- a/examples/mui/IconButton._colors.tsx
+++ b/examples/mui/IconButton._colors.tsx
@@ -15,9 +15,6 @@ const colors = [
 	"primary",
 	"secondary",
 	"error",
-	"info",
-	"success",
-	"warning",
 ] as const satisfies IconButtonProps["color"][];
 
 export default () => {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -27,6 +27,14 @@ declare module "@mui/material/Button" {
 	}
 }
 
+declare module "@mui/material/IconButton" {
+	interface IconButtonPropsColorOverrides {
+		info: false;
+		success: false;
+		warning: false;
+	}
+}
+
 declare module "@mui/material/TextField" {
 	export default function TextField(
 		props: {


### PR DESCRIPTION
Same as https://github.com/iTwin/design-system/pull/1152 but for `IconButton`.

One interesting difference from `Button` is that `IconButton` supports both `color="default"` and `color="secondary"` (as well as `color="inherit"`). We should consider removing some of these colors in the future.