### PR TITLE
update colors in a few components

### DIFF
--- a/.changeset/odd-meteors-clean.md
+++ b/.changeset/odd-meteors-clean.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated colors in `Accordion`, `Card` and `Chip` components.

--- a/.changeset/solid-jokes-report.md
+++ b/.changeset/solid-jokes-report.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `AppBar` component to use neutral colors and no box-shadow.

--- a/examples/mui/AppBar.default.tsx
+++ b/examples/mui/AppBar.default.tsx
@@ -22,9 +22,7 @@ export default () => {
 				<Typography variant="h6" component="div" flexGrow={1}>
 					News
 				</Typography>
-				<Button color="inherit" variant="text">
-					Login
-				</Button>
+				<Button variant="text">Login</Button>
 			</Toolbar>
 		</AppBar>
 	);

--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -23,7 +23,7 @@ export default () => {
 					alt=""
 				/>
 				<CardContent>
-					<Typography gutterBottom variant="h3" component="div">
+					<Typography gutterBottom variant="h6" component="div">
 						Stadium
 					</Typography>
 					<Typography variant="body2" color="text.secondary">

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -67,8 +67,19 @@
 		--stratakit-mui-palette-grey-A700: --primitive("color.gray.700");
 	}
 
+	.MuiAccordion-root {
+		background-color: transparent;
+	}
+
 	.MuiAlert-icon {
 		align-items: center; /* Fix vertical alignment of differently sized icons */
+	}
+
+	.MuiAppBar-root {
+		background-color: var(--stratakit-color-bg-page-base);
+		box-shadow: none;
+		border-block-end: 1px solid var(--stratakit-color-border-page-base);
+		color: var(--stratakit-color-text-neutral-primary);
 	}
 
 	.MuiButtonBase-root {
@@ -86,12 +97,14 @@
 			--variant-outlinedColor: var(--stratakit-color-text-neutral-primary);
 			--variant-textColor: var(--stratakit-color-text-neutral-primary);
 
-			&:where(:hover) {
-				--variant-containedBg: color-mix(
-					in oklch,
-					var(--stratakit-color-bg-neutral-base) 100%,
-					var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%)
-				);
+			@media (any-hover: hover) {
+				&:where(:hover) {
+					--variant-containedBg: color-mix(
+						in oklch,
+						var(--stratakit-color-bg-neutral-base) 100%,
+						var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%)
+					);
+				}
 			}
 		}
 
@@ -107,6 +120,10 @@
 		}
 	}
 
+	.MuiCard-root {
+		background-color: var(--stratakit-color-bg-elevation-base);
+	}
+
 	.MuiCheckbox-root {
 		&:where(.MuiCheckbox-colorPrimary) {
 			&:where(.Mui-checked, .MuiCheckbox-indeterminate):where(:not(.Mui-disabled)) {
@@ -119,6 +136,13 @@
 		}
 	}
 
+	.MuiChip-root {
+		&:where(.MuiChip-filledDefault.MuiChip-colorDefault) {
+			background-color: var(--stratakit-color-bg-neutral-base);
+			border: 1px solid var(--stratakit-color-border-neutral-base);
+		}
+	}
+
 	.MuiDialogActions-root {
 		&:where(.MuiDialogActions-spacing) {
 			padding-block: var(--stratakit-space-x4);
@@ -127,7 +151,7 @@
 	}
 
 	.MuiFormLabel-colorPrimary {
-		&.Mui-focused {
+		&:where(.Mui-focused) {
 			color: var(--stratakit-mui-palette-primary-dark);
 		}
 	}


### PR DESCRIPTION
A few small styling changes to bring MUI components slightly closer to the Strata visual language.
- **Accordion**: Removed `background-color` so it blends with the surface.
- **AppBar**: Now using neutral colors and sits flat on the page. Example no longer needs `color="inherit"`.
- **Card**: Now uses elevated `background-color`. Also decreased heading font-size in example.
- **Chip**: `"filled"` variant now looks similar to the old `"solid"` variant.

Also added a missing `:where()` and `@media (any-hover: hover)`.

### Screenshots

| Component | Before | After |
| --- | --- | --- |
| Accordion | <img width="209" height="69" alt="image" src="https://github.com/user-attachments/assets/cca79bfc-6c72-415c-a3c0-947e8581ee1d" /> | <img width="233" height="82" alt="image" src="https://github.com/user-attachments/assets/cd0d88f3-dafd-48db-a6c1-02d7f9a9d454" /> |
| AppBar | <img width="180" height="90" alt="image" src="https://github.com/user-attachments/assets/eb2238f8-a53d-4432-b882-9e917ddbde21" /> | <img width="210" height="90" alt="image" src="https://github.com/user-attachments/assets/6d264acb-ae90-46d7-a77d-6996b7388afd" /> |
| Card | <img width="200" alt="image" src="https://github.com/user-attachments/assets/7fd38150-7043-445c-b284-30d6e77c7b20" /> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/34106e66-b8c3-44d2-a0c9-89568130025d" /> |
| Chip | <img width="131" height="53" alt="image" src="https://github.com/user-attachments/assets/8a197fab-5ad3-4610-8be7-f2366b044126" />  | <img width="134" height="65" alt="image" src="https://github.com/user-attachments/assets/a42405fd-4c52-4e18-a0cb-2d7ea4c21a1e" /> |