### PR TITLE
remove `license-remove.svg` alias

### DIFF
--- a/.changeset/lazy-moose-ask.md
+++ b/.changeset/lazy-moose-ask.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/icons": minor
+---
+
+Removed `license-remove.svg` which was previously deprecated and aliased to `license-minus.svg`.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,7 +5,6 @@
 	"license": "MIT",
 	"exports": {
 		"./*.svg": "./icons/*.svg",
-		"./license-remove.svg": "./icons/license-minus.svg",
 		"./icons-list.json": "./icons-list.json"
 	},
 	"files": [


### PR DESCRIPTION
Follow-up to #1084. This removes the subpath alias for the next breaking release.

Together with this, we can bump the version of `@stratakit/icons` used by `@stratakit/mui`.