### PR TITLE
auto-add MUI label

### DIFF
--- a/.github/workflows/pr-labels.js
+++ b/.github/workflows/pr-labels.js
@@ -44,6 +44,7 @@ const LABELS = {
 	TREE: "component: Tree",
 	API_BRIDGE: "API bridge",
 	GITHUB_ACTIONS: "github_actions",
+	MUI: "MUI",
 };
 
 const LABEL_MAP = {
@@ -90,6 +91,7 @@ const LABEL_MAP = {
 		"packages/structures/src/TreeItem",
 	],
 	[LABELS.GITHUB_ACTIONS]: [".github/workflows"],
+	[LABELS.MUI]: ["packages/mui"],
 };
 
 /**


### PR DESCRIPTION
Small update to the `pr-labels` workflow to automatically add the https://github.com/iTwin/design-system/labels/MUI label to any PR that changes files inside `packages/mui/`.

We will likely also need a larger update for more granular per-component labels, but this is good for now.