### PR TITLE
map MUI component color tokens

### DIFF
--- a/.changeset/light-windows-vanish.md
+++ b/.changeset/light-windows-vanish.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated global color mappings for various components, e.g. `Alert`, `Avatar`, `LinearProgress`, `Skeleton`, `Snackbar`, `TableCell`.

--- a/packages/mui/src/styles.css
+++ b/packages/mui/src/styles.css
@@ -14,6 +14,7 @@
 		--stratakit-mui-palette-text-primary: var(--stratakit-color-text-neutral-primary);
 		--stratakit-mui-palette-text-secondary: var(--stratakit-color-text-neutral-secondary);
 		--stratakit-mui-palette-text-disabled: var(--stratakit-color-text-neutral-disabled);
+		--stratakit-mui-palette-text-icon: var(--stratakit-color-icon-neutral-primary);
 
 		--stratakit-mui-palette-primary-main: var(--stratakit-color-bg-accent-base);
 		--stratakit-mui-palette-primary-dark: var(--stratakit-color-bg-accent-faded);
@@ -65,6 +66,55 @@
 		--stratakit-mui-palette-grey-A200: --primitive("color.gray.200");
 		--stratakit-mui-palette-grey-A400: --primitive("color.gray.400");
 		--stratakit-mui-palette-grey-A700: --primitive("color.gray.700");
+
+		--stratakit-mui-palette-Alert-errorColor: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-Alert-infoColor: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-Alert-successColor: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-Alert-warningColor: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-Alert-errorFilledBg: var(--stratakit-color-bg-critical-transparent);
+		--stratakit-mui-palette-Alert-infoFilledBg: var(--stratakit-color-bg-info-transparent);
+		--stratakit-mui-palette-Alert-successFilledBg: var(--stratakit-color-bg-positive-transparent);
+		--stratakit-mui-palette-Alert-warningFilledBg: var(--stratakit-color-bg-attention-transparent);
+		--stratakit-mui-palette-Alert-errorFilledColor: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-Alert-infoFilledColor: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-Alert-successFilledColor: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-Alert-warningFilledColor: var(--stratakit-color-text-neutral-primary);
+		--stratakit-mui-palette-Alert-errorIconColor: var(--stratakit-color-icon-critical-base);
+		--stratakit-mui-palette-Alert-infoIconColor: var(--stratakit-color-icon-info-base);
+		--stratakit-mui-palette-Alert-successIconColor: var(--stratakit-color-icon-positive-base);
+		--stratakit-mui-palette-Alert-warningIconColor: var(--stratakit-color-icon-attention-base);
+
+		--stratakit-mui-palette-AppBar-defaultBg: var(--stratakit-color-bg-page-base);
+		--stratakit-mui-palette-AppBar-darkBg: var(--stratakit-color-bg-page-base);
+		--stratakit-mui-palette-AppBar-darkColor: var(--stratakit-color-text-neutral-primary);
+
+		--stratakit-mui-palette-Avatar-defaultBg: var(--stratakit-color-bg-mono-base);
+
+		--stratakit-mui-palette-Button-inheritContainedBg: var(--stratakit-color-bg-neutral-base);
+		--stratakit-mui-palette-Button-inheritContainedHoverBg: var(--stratakit-color-bg-neutral-base);
+
+		--stratakit-mui-palette-Chip-defaultBorder: var(--stratakit-color-border-neutral-base);
+		--stratakit-mui-palette-Chip-defaultAvatarColor: var(--stratakit-color-text-neutral-emphasis);
+		--stratakit-mui-palette-Chip-defaultIconColor: var(--stratakit-color-icon-neutral-primary);
+
+		--stratakit-mui-palette-LinearProgress-primaryBg: var(--stratakit-color-bg-accent-muted);
+		--stratakit-mui-palette-LinearProgress-secondaryBg: var(--stratakit-color-border-page-base);
+		--stratakit-mui-palette-LinearProgress-infoBg: var(--stratakit-color-bg-info-muted);
+		--stratakit-mui-palette-LinearProgress-successBg: var(--stratakit-color-bg-positive-muted);
+		--stratakit-mui-palette-LinearProgress-warningBg: var(--stratakit-color-bg-attention-muted);
+		--stratakit-mui-palette-LinearProgress-errorBg: var(--stratakit-color-bg-critical-muted);
+
+		--stratakit-mui-palette-Skeleton-bg: var(--stratakit-color-bg-glow-on-surface-disabled);
+
+		--stratakit-mui-palette-SnackbarContent-bg: var(--stratakit-color-bg-elevation-emphasis);
+		--stratakit-mui-palette-SnackbarContent-color: var(--stratakit-color-text-neutral-emphasis);
+
+		--stratakit-mui-palette-StepConnector-border: var(--stratakit-color-border-neutral-muted);
+		--stratakit-mui-palette-StepContent-border: var(--stratakit-color-border-neutral-muted);
+
+		--stratakit-mui-palette-TableCell-border: var(--stratakit-color-border-neutral-muted);
+
+		--stratakit-mui-palette-Tooltip-bg: var(--stratakit-color-bg-elevation-emphasis);
 	}
 
 	.MuiAccordion-root {
@@ -325,7 +375,6 @@
 	}
 
 	.MuiTooltip-tooltip {
-		--stratakit-mui-palette-Tooltip-bg: var(--stratakit-color-bg-elevation-emphasis);
 		box-shadow: var(--stratakit-shadow-control-tooltip-base);
 	}
 


### PR DESCRIPTION
MUI has a bunch of component color tokens that are set globally. These were not handled in https://github.com/iTwin/design-system/pull/1118.

This PR maps _most_ (but not all) of these component colors tokens to more appropriate values. For example, Table cell borders are now white (in dark theme), Snackbar is now black (in both themes).

Some tokens were deliberately skipped (e.g. standard Alert, Switch) because they will not be used or be restyled entirely. These unmapped components tokens will continue to use the stock MUI theme tokens, which already point to the StrataKit theme tokens as fallback.