### PR TITLE
Fix cleanup of `DropdownMenu.Submenu`

### DIFF
--- a/.changeset/puny-signs-throw.md
+++ b/.changeset/puny-signs-throw.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fixed `DropdownMenu.Submenu` component to avoid removal of parent portal popover when unmounting.

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -488,12 +488,17 @@ const DropdownMenuSubmenu = forwardRef<"div", DropdownMenuSubmenuProps>(
 
 		const parent = useMenuContext();
 		const popoverElement = useStoreState(parent, "popoverElement");
+		const portalElement = React.useCallback(() => {
+			if (!popoverElement?.isConnected) return null;
+			return popoverElement;
+		}, [popoverElement]);
+
 		return (
 			<MenuProvider store={store}>
 				<Menu
 					store={store}
 					portal
-					portalElement={popoverElement}
+					portalElement={portalElement}
 					preserveTabOrder={false}
 					{...props}
 					gutter={2}


### PR DESCRIPTION
This PR fixes https://github.com/iTwin/design-system/issues/1169 by making sure that the parent menu portal is connected to avoid removal of parent popover element in the cleanup. See https://github.com/ariakit/ariakit/blob/2c0885b30c040771e94c7d8246180a89cbca4d35/packages/ariakit-react-core/src/portal/portal.tsx#L99