### PR TITLE
remove extra `Slider` colors

### DIFF
--- a/.changeset/violet-gifts-kick.md
+++ b/.changeset/violet-gifts-kick.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Removed all values from `Slider`'s `color` prop (except the default `"primary"`).

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -70,6 +70,16 @@ declare module "@mui/material/IconButton" {
 	}
 }
 
+declare module "@mui/material/Slider" {
+	interface SliderPropsColorOverrides {
+		secondary: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+}
+
 declare module "@mui/material/TextField" {
 	export default function TextField(
 		props: {


### PR DESCRIPTION
Disables all the extra `color` values for `Slider`. StrataKit sliders are only designed for `"primary"` (aurora) colors.