### PR TITLE
remove `color="inherit"` from `Button` and `IconButton`

### DIFF
--- a/.changeset/cozy-buttons-change.md
+++ b/.changeset/cozy-buttons-change.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Removed the following values from `IconButton`'s `color` prop: `"info"`, `"success"` and `"warning"`.
+Removed the following values from `IconButton`'s `color` prop: `"info"`, `"success"`, `"warning"`, and `"inherit"`.

--- a/.changeset/loose-taxes-see.md
+++ b/.changeset/loose-taxes-see.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Removed the following values from `Button`'s `color` prop: `"info"`, `"success"` and `"warning"`.
+Removed the following values from `Button`'s `color` prop: `"info"`, `"success"`, `"warning"`, and `"inherit"`.

--- a/examples/mui/AppBar.default.tsx
+++ b/examples/mui/AppBar.default.tsx
@@ -16,7 +16,7 @@ export default () => {
 	return (
 		<AppBar position="static">
 			<Toolbar>
-				<IconButton size="large" edge="start" color="inherit" aria-label="menu">
+				<IconButton size="large" edge="start" aria-label="menu">
 					<Icon href={`${svgMenu}#icon-large`} size="large" />
 				</IconButton>
 				<Typography variant="h6" component="div" flexGrow={1}>

--- a/examples/mui/Snackbar.default.tsx
+++ b/examples/mui/Snackbar.default.tsx
@@ -28,7 +28,7 @@ export default () => {
 				message="Note archived"
 				action={
 					<Tooltip title="Close" describeChild={false}>
-						<IconButton color="inherit" onClick={handleClose}>
+						<IconButton onClick={handleClose}>
 							<Icon href={svgDismiss} />
 						</IconButton>
 					</Tooltip>

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -30,6 +30,7 @@ declare module "@mui/material/Button" {
 		info: false;
 		success: false;
 		warning: false;
+		inherit: false;
 	}
 
 	interface ButtonOwnProps {
@@ -67,6 +68,7 @@ declare module "@mui/material/IconButton" {
 		info: false;
 		success: false;
 		warning: false;
+		inherit: false;
 	}
 }
 


### PR DESCRIPTION
Leftover from #1152 and #1158. See https://github.com/iTwin/design-system/pull/1152#pullrequestreview-3649936493.

After #1159 and #1170, there are no remaining examples where `color="inherit"` is used, so it can be removed.