### PR TITLE
remove `variant="standard"` from `Alert` and change default

### DIFF
--- a/.changeset/cool-heads-grin.md
+++ b/.changeset/cool-heads-grin.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Removed `variant="standard"` from `Alert` and changed the default to `variant="outlined"`.

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -88,6 +88,7 @@ function createTheme() {
 			},
 			MuiAlert: {
 				defaultProps: {
+					variant: "outlined",
 					iconMapping: {
 						error: <ErrorIcon />,
 						info: <InfoIcon />,

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -10,6 +10,21 @@
 import type { TextFieldProps, TextFieldVariants } from "@mui/material";
 import type * as React from "react";
 
+declare module "@mui/material/Alert" {
+	interface AlertPropsVariantOverrides {
+		standard: false;
+	}
+
+	interface AlertOwnProps {
+		/**
+		 * The default variant with `@stratakit/mui` is `"outlined"`.
+		 *
+		 * @default 'outlined'
+		 */
+		variant?: "filled" | "outlined";
+	}
+}
+
 declare module "@mui/material/Button" {
 	interface ButtonPropsColorOverrides {
 		info: false;


### PR DESCRIPTION
MUI `Alert` has 3 variants, whereas Strata only has 2 (`"outline"` and `"solid"` in old terminology).

This PR changes the default to `variant="outlined"` and removes `variant="standard"`.