### PR TITLE
fix `Link` colors

### DIFF
--- a/.changeset/flat-masks-mate.md
+++ b/.changeset/flat-masks-mate.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `Link` color contrast.

--- a/examples/mui/Link._colors.tsx
+++ b/examples/mui/Link._colors.tsx
@@ -7,7 +7,6 @@ import Link from "@mui/material/Link";
 
 type LinkProps = React.ComponentProps<typeof Link>;
 const colors = [
-	"default",
 	"primary",
 	"secondary",
 	"error",

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -154,6 +154,32 @@ function createTheme() {
 				defaultProps: {
 					color: "textPrimary",
 				},
+				variants: [
+					{
+						props: { color: "primary" },
+						style: { color: "var(--stratakit-color-text-accent-strong)" },
+					},
+					{
+						props: { color: "secondary" },
+						style: { color: "var(--stratakit-color-text-neutral-primary)" },
+					},
+					{
+						props: { color: "error" },
+						style: { color: "var(--stratakit-color-text-critical-base)" },
+					},
+					{
+						props: { color: "info" },
+						style: { color: "var(--stratakit-color-text-info-base)" },
+					},
+					{
+						props: { color: "success" },
+						style: { color: "var(--stratakit-color-text-positive-base)" },
+					},
+					{
+						props: { color: "warning" },
+						style: { color: "var(--stratakit-color-text-attention-base)" },
+					},
+				],
 			},
 			MuiOutlinedInput: {
 				defaultProps: {


### PR DESCRIPTION
Similar to #1178 but for `Link`. Now using the stronger foreground colors for all values of the `color` prop.

Unfortunately, `Link` does not have any classes that I can target in CSS, so I had to make this change in the JS theme.

| Before | After |
| --- | --- |
| <img width="250" alt="screenshot" src="https://github.com/user-attachments/assets/204e4a3c-bb67-4598-8c25-427c2e2ff49e" /> | <img width="250" alt="screenshot" src="https://github.com/user-attachments/assets/cddc38b7-c2fc-4180-9ea3-633b0c0aebe9" /> |

Note: `"default"` is not a supported value so removed it from the example.