### PR TITLE
remove extra `color` values from form controls

### DIFF
--- a/.changeset/neat-hairs-dig.md
+++ b/.changeset/neat-hairs-dig.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Removed all values for the `color` prop from form controls (i.e. `Checkbox`, `FormLabel`, `Radio`, `Select`, `Switch` and `TextField` components).

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -43,6 +43,17 @@ declare module "@mui/material/Button" {
 	}
 }
 
+declare module "@mui/material/Checkbox" {
+	interface CheckboxPropsColorOverrides {
+		secondary: false;
+		default: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+}
+
 declare module "@mui/material/Fab" {
 	interface FabPropsColorOverrides {
 		info: false;
@@ -63,12 +74,43 @@ declare module "@mui/material/Fab" {
 	}
 }
 
+declare module "@mui/material/FormLabel" {
+	interface FormLabelPropsColorOverrides {
+		secondary: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+}
+
 declare module "@mui/material/IconButton" {
 	interface IconButtonPropsColorOverrides {
 		info: false;
 		success: false;
 		warning: false;
 		inherit: false;
+	}
+}
+
+declare module "@mui/material/InputBase" {
+	interface InputBasePropsColorOverrides {
+		secondary: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+}
+
+declare module "@mui/material/Radio" {
+	interface RadioPropsColorOverrides {
+		secondary: false;
+		default: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
 	}
 }
 
@@ -82,7 +124,26 @@ declare module "@mui/material/Slider" {
 	}
 }
 
+declare module "@mui/material/Switch" {
+	interface SwitchPropsColorOverrides {
+		secondary: false;
+		default: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+}
+
 declare module "@mui/material/TextField" {
+	interface TextFieldPropsColorOverrides {
+		secondary: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+
 	export default function TextField(
 		props: {
 			/** @deprecated DO NOT USE */ variant?: TextFieldVariants;


### PR DESCRIPTION
The `color` prop is pervasive in various MUI components. This PR updates the `types.d.ts` file to remove all the color values from `Checkbox`, `FormLabel`, `Radio`, `Switch`, `Select`, and `TextField`.

There are other components that still have the `color` prop (for example, `Chip`). I'm not touching those at the moment.