### PR TITLE
fix stylesheet cleanup race condition

### DIFF
--- a/.changeset/shiny-meals-push.md
+++ b/.changeset/shiny-meals-push.md
@@ -1,0 +1,6 @@
+---
+"@stratakit/foundations": patch
+"@stratakit/mui": patch
+---
+
+Fixed a race condition where stylesheets could be prematurely removed in cases where multiple components that use the same styles were conditionally rendered.


### PR DESCRIPTION
When working on #1187, I ran into an edge case where styles were loaded and then removed. This was happening because the component that originally loaded the styles was unmounted while other components that need the same styles were still on the page.

The `loadStyles` function now counts "references" for each key. Stylesheets are only removed when this count becomes zero, i.e. when the last remaining consumer unmounts.