### PR TITLE
update repo name

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-	"changelog": ["./changelog-github.js", { "repo": "iTwin/design-system" }],
+	"changelog": ["./changelog-github.js", { "repo": "iTwin/stratakit" }],
 	"commit": false,
 	"fixed": [],
 	"linked": [],

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-*       @iTwin/design-system-developers
+*       @iTwin/stratakit-developers

--- a/.github/workflows/changeset-release.yaml
+++ b/.github/workflows/changeset-release.yaml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    if: github.repository == 'iTwin/design-system'
+    if: github.repository == 'iTwin/stratakit'
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To clone and build the repo locally, you'll need [Git](https://git-scm.com), [No
 
 1. [Clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository). You can do this from the command line or using the Github Desktop app.
 
-2. Go to the directory where you cloned the repo. e.g. `cd design-system`.
+2. Go to the directory where you cloned the repo. e.g. `cd stratakit`.
 
 3. Run `pnpm install` from that directory.
 
@@ -22,7 +22,7 @@ To clone and build the repo locally, you'll need [Git](https://git-scm.com), [No
 
 This repo includes a [devcontainer](https://containers.dev/) configuration that compatible IDEs can use to automatically set up your development environment. To use this locally, you'll need Docker or an equivalent container runtime installed on your machine.
 
-Alternatively, you can get started without installing anything locally by creating a [GitHub Codespace](https://docs.github.com/en/codespaces/overview), which uses the same devcontainer configuration but runs entirely in the cloud: [Open repository in Codespace](https://codespaces.new/iTwin/design-system).
+Alternatively, you can get started without installing anything locally by creating a [GitHub Codespace](https://docs.github.com/en/codespaces/overview), which uses the same devcontainer configuration but runs entirely in the cloud: [Open repository in Codespace](https://codespaces.new/iTwin/stratakit).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ StrataKit is maintained by:
 - [@GerardasB](https://github.com/GerardasB)
 - [@FlyersPh9](https://github.com/FlyersPh9)
 
-With special thanks to [@msllrs](https://github.com/msllrs), [@ahilhorst](https://github.com/ahilhorst), [@Heydon](https://github.com/Heydon), [@knowler](https://github.com/knowler), [@r100-stack](https://github.com/r100-stack), [@VeroniqueVezina](https://github.com/VeroniqueVezina), [@mglancybentley](https://github.com/mglancybentley), and all other [contributors](https://github.com/iTwin/design-system/graphs/contributors).
+With special thanks to [@msllrs](https://github.com/msllrs), [@ahilhorst](https://github.com/ahilhorst), [@Heydon](https://github.com/Heydon), [@knowler](https://github.com/knowler), [@r100-stack](https://github.com/r100-stack), [@VeroniqueVezina](https://github.com/VeroniqueVezina), [@mglancybentley](https://github.com/mglancybentley), and all other [contributors](https://github.com/iTwin/stratakit/graphs/contributors).
 
 ## Contributing
 
-Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/design-system/issues).
+Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/stratakit/issues).
 
 If you're interested in contributing code, please read [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more information.

--- a/apps/test-app/app/index.tsx
+++ b/apps/test-app/app/index.tsx
@@ -36,7 +36,7 @@ export default function Index() {
 
 			<ul className={styles.list}>
 				<li>
-					<Anchor href="https://github.com/iTwin/design-system">
+					<Anchor href="https://github.com/iTwin/stratakit">
 						GitHub source
 					</Anchor>
 				</li>

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -36,7 +36,7 @@ export default defineConfig({
 				{
 					icon: "github",
 					label: "GitHub",
-					href: "https://github.com/iTwin/design-system",
+					href: "https://github.com/iTwin/stratakit",
 				},
 			],
 			sidebar: [
@@ -53,8 +53,7 @@ export default defineConfig({
 				{ label: "Contributing", slug: "contributing" },
 			],
 			editLink: {
-				baseUrl:
-					"https://github.com/iTwin/design-system/edit/main/apps/website/",
+				baseUrl: "https://github.com/iTwin/stratakit/edit/main/apps/website/",
 			},
 			lastUpdated: true,
 			customCss: ["./src/styles/index.css"],

--- a/apps/website/src/components/PageTitle.astro
+++ b/apps/website/src/components/PageTitle.astro
@@ -6,10 +6,10 @@ const { entry } = Astro.locals.starlightRoute;
 const status = entry.data.status;
 const links = entry.data.links || {};
 
-const demoBase = "https://itwin.github.io/design-system/";
+const demoBase = "https://itwin.github.io/stratakit/";
 const demoUrl = links.demo ? demoBase + links.demo : null;
 
-const githubBase = "https://github.com/iTwin/design-system/blob/main/";
+const githubBase = "https://github.com/iTwin/stratakit/blob/main/";
 const githubUrl = links.github?.startsWith("https://")
 	? links.github
 	: links.github

--- a/apps/website/src/content/docs/changelog.md
+++ b/apps/website/src/content/docs/changelog.md
@@ -4,8 +4,8 @@ title: Changelog
 
 Every change to StrataKit is documented in the `CHANGELOG.md` files of the individual packages.
 
-- [`@stratakit/mui` changelog](https://github.com/iTwin/design-system/blob/main/packages/mui/CHANGELOG.md)
-- [`@stratakit/icons` changelog](https://github.com/iTwin/design-system/blob/main/packages/icons/CHANGELOG.md)
-- [`@stratakit/foundations` changelog](https://github.com/iTwin/design-system/blob/main/packages/foundations/CHANGELOG.md)
-- [`@stratakit/bricks` changelog](https://github.com/iTwin/design-system/blob/main/packages/bricks/CHANGELOG.md)
-- [`@stratakit/structures` changelog](https://github.com/iTwin/design-system/blob/main/packages/structures/CHANGELOG.md)
+- [`@stratakit/mui` changelog](https://github.com/iTwin/stratakit/blob/main/packages/mui/CHANGELOG.md)
+- [`@stratakit/icons` changelog](https://github.com/iTwin/stratakit/blob/main/packages/icons/CHANGELOG.md)
+- [`@stratakit/foundations` changelog](https://github.com/iTwin/stratakit/blob/main/packages/foundations/CHANGELOG.md)
+- [`@stratakit/bricks` changelog](https://github.com/iTwin/stratakit/blob/main/packages/bricks/CHANGELOG.md)
+- [`@stratakit/structures` changelog](https://github.com/iTwin/stratakit/blob/main/packages/structures/CHANGELOG.md)

--- a/apps/website/src/content/docs/getting-started.md
+++ b/apps/website/src/content/docs/getting-started.md
@@ -5,4 +5,4 @@ description: Learn how to set up StrataKit in your project.
 
 <!-- TODO: Add link to starter sandbox. -->
 
-This page is under construction. See `README.md` files of [`@stratakit/mui`](https://github.com/iTwin/design-system/tree/main/packages/mui#readme) and [`@stratakit/icons`](https://github.com/iTwin/design-system/tree/main/packages/icons#readme) packages for now.
+This page is under construction. See `README.md` files of [`@stratakit/mui`](https://github.com/iTwin/stratakit/tree/main/packages/mui#readme) and [`@stratakit/icons`](https://github.com/iTwin/stratakit/tree/main/packages/icons#readme) packages for now.

--- a/apps/website/src/content/docs/icons.mdx
+++ b/apps/website/src/content/docs/icons.mdx
@@ -18,7 +18,7 @@ This page lists all the icons available in [`@stratakit/icons`](https://www.npmj
     ```
 
     :::note
-    Importing icons in JavaScript requires bundler configuration. See [`README.md`](https://github.com/iTwin/design-system/tree/main/packages/icons#bundler-configuration) for details.
+    Importing icons in JavaScript requires bundler configuration. See [`README.md`](https://github.com/iTwin/stratakit/tree/main/packages/icons#bundler-configuration) for details.
     :::
 
 2.  Pass the URL to the [`<Icon>`](/components/icon) component, or directly to the [`<use>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/use) element:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "design-system",
+	"name": "stratakit",
 	"private": true,
 	"type": "module",
 	"version": "0.0.0",

--- a/packages/bricks/CHANGELOG.md
+++ b/packages/bricks/CHANGELOG.md
@@ -2,31 +2,31 @@
 
 ## 0.5.4
 
-- [#1122](https://github.com/iTwin/design-system/pull/1122): Moved `@stratakit/foundations` from `peerDependencies` to direct `dependencies`.
-- [#1123](https://github.com/iTwin/design-system/pull/1123): Renamed `@layer itwinui` to `@layer stratakit`.
+- [#1122](https://github.com/iTwin/stratakit/pull/1122): Moved `@stratakit/foundations` from `peerDependencies` to direct `dependencies`.
+- [#1123](https://github.com/iTwin/stratakit/pull/1123): Renamed `@layer itwinui` to `@layer stratakit`.
 - Updated dependencies:
   - @stratakit/foundations@0.4.4
 
 ## 0.5.3
 
-- [#1108](https://github.com/iTwin/design-system/pull/1108): Decoupled the styles for `@stratakit/bricks` and `@stratakit/structures` from `@stratakit/foundations` so that the latter does not indirectly depend on the former two. This change also reduces the need for these packages to remain in lockstep.
+- [#1108](https://github.com/iTwin/stratakit/pull/1108): Decoupled the styles for `@stratakit/bricks` and `@stratakit/structures` from `@stratakit/foundations` so that the latter does not indirectly depend on the former two. This change also reduces the need for these packages to remain in lockstep.
 - Updated dependencies:
   - @stratakit/foundations@0.4.3
 
 ## 0.5.2
 
-- [#1094](https://github.com/iTwin/design-system/pull/1094): `Label` component will now set an explicit `line-height`.
-- [#1102](https://github.com/iTwin/design-system/pull/1102): "Popups" will now respect device-specific close actions (such as back gesture on Android). Affected components include: `Tooltip`.
-- [#1090](https://github.com/iTwin/design-system/pull/1090): `Tooltip` will now be triggered when long pressing buttons on touch devices (except in Safari).
+- [#1094](https://github.com/iTwin/stratakit/pull/1094): `Label` component will now set an explicit `line-height`.
+- [#1102](https://github.com/iTwin/stratakit/pull/1102): "Popups" will now respect device-specific close actions (such as back gesture on Android). Affected components include: `Tooltip`.
+- [#1090](https://github.com/iTwin/stratakit/pull/1090): `Tooltip` will now be triggered when long pressing buttons on touch devices (except in Safari).
 - Updated dependencies:
   - @stratakit/foundations@0.4.2
 
 ## 0.5.1
 
-- [#1072](https://github.com/iTwin/design-system/pull/1072): Added `bleed` prop to `Divider` component to extend it to the edges of its first ancestor container.
-- [#1068](https://github.com/iTwin/design-system/pull/1068): Added `icon` prop to `Badge`.
-- [#1060](https://github.com/iTwin/design-system/pull/1060): Added error icon to `Field.ErrorMessage`.
-- [#1018](https://github.com/iTwin/design-system/pull/1018): Updated `Select` trigger styling to match the latest design from Figma.
+- [#1072](https://github.com/iTwin/stratakit/pull/1072): Added `bleed` prop to `Divider` component to extend it to the edges of its first ancestor container.
+- [#1068](https://github.com/iTwin/stratakit/pull/1068): Added `icon` prop to `Badge`.
+- [#1060](https://github.com/iTwin/stratakit/pull/1060): Added error icon to `Field.ErrorMessage`.
+- [#1018](https://github.com/iTwin/stratakit/pull/1018): Updated `Select` trigger styling to match the latest design from Figma.
 - Updated dependencies:
   - @stratakit/foundations@0.4.1
 
@@ -34,51 +34,51 @@
 
 ### Breaking changes
 
-- [#956](https://github.com/iTwin/design-system/pull/956): Removed `isActive` from `IconButton` component. This has been replaced by the `active` prop.
-- [#950](https://github.com/iTwin/design-system/pull/950): Removed `tone="critical"` from `Anchor` component.
+- [#956](https://github.com/iTwin/stratakit/pull/956): Removed `isActive` from `IconButton` component. This has been replaced by the `active` prop.
+- [#950](https://github.com/iTwin/stratakit/pull/950): Removed `tone="critical"` from `Anchor` component.
 
 ### Non-breaking changes
 
-- [#983](https://github.com/iTwin/design-system/pull/983): `Anchor` will now inherit the surrounding `font-size`.
-- [#1041](https://github.com/iTwin/design-system/pull/1041): Updated the type of `render` function for `Field.Control` to omit `children`, so that it no longer raises an error when used with `TextBox.Input`.
-- [#1040](https://github.com/iTwin/design-system/pull/1040): Added invalid state styling to `Checkbox` and `Radio`.
-- [#1035](https://github.com/iTwin/design-system/pull/1035): Fixed indeterminate state styling for `Checkbox` and `Radio` components (hover and disabled visuals now apply correctly).
-- [#1056](https://github.com/iTwin/design-system/pull/1056): Added `forced-colors` styling to `Field.ErrorMessage`.
-- [#1058](https://github.com/iTwin/design-system/pull/1058): Fixed improper `forced-colors` styling of `TextBox`.
-- [#982](https://github.com/iTwin/design-system/pull/982): Updated `background-color` variable used by `TextBox`.
-- [#1003](https://github.com/iTwin/design-system/pull/1003): Enabled React Compiler for production build. In React 18 apps, `react-compiler-runtime` dependency will be used.
+- [#983](https://github.com/iTwin/stratakit/pull/983): `Anchor` will now inherit the surrounding `font-size`.
+- [#1041](https://github.com/iTwin/stratakit/pull/1041): Updated the type of `render` function for `Field.Control` to omit `children`, so that it no longer raises an error when used with `TextBox.Input`.
+- [#1040](https://github.com/iTwin/stratakit/pull/1040): Added invalid state styling to `Checkbox` and `Radio`.
+- [#1035](https://github.com/iTwin/stratakit/pull/1035): Fixed indeterminate state styling for `Checkbox` and `Radio` components (hover and disabled visuals now apply correctly).
+- [#1056](https://github.com/iTwin/stratakit/pull/1056): Added `forced-colors` styling to `Field.ErrorMessage`.
+- [#1058](https://github.com/iTwin/stratakit/pull/1058): Fixed improper `forced-colors` styling of `TextBox`.
+- [#982](https://github.com/iTwin/stratakit/pull/982): Updated `background-color` variable used by `TextBox`.
+- [#1003](https://github.com/iTwin/stratakit/pull/1003): Enabled React Compiler for production build. In React 18 apps, `react-compiler-runtime` dependency will be used.
 - Updated dependencies:
   - @stratakit/foundations@0.4.0
 
 ## 0.4.5
 
-- [#975](https://github.com/iTwin/design-system/pull/975): Fixed an overflow issue in `Tooltip`. Long words will now correctly break across multiple lines.
+- [#975](https://github.com/iTwin/stratakit/pull/975): Fixed an overflow issue in `Tooltip`. Long words will now correctly break across multiple lines.
 - Updated dependencies:
   - @stratakit/foundations@0.3.5
 
 ## 0.4.4
 
-- [#892](https://github.com/iTwin/design-system/pull/892): Added invalid state styling to `TextBox`.
-- [#955](https://github.com/iTwin/design-system/pull/955): Fixed `IconButton` active state semantics. It will now use `aria-current` instead of `aria-pressed` when rendered as an anchor.
+- [#892](https://github.com/iTwin/stratakit/pull/892): Added invalid state styling to `TextBox`.
+- [#955](https://github.com/iTwin/stratakit/pull/955): Fixed `IconButton` active state semantics. It will now use `aria-current` instead of `aria-pressed` when rendered as an anchor.
 - Updated dependencies:
   - @stratakit/foundations@0.3.4
 
 ## 0.4.3
 
-- [#945](https://github.com/iTwin/design-system/pull/945): The `"critical"` tone value for `Anchor` has been deprecated and will be removed in a future release.
+- [#945](https://github.com/iTwin/stratakit/pull/945): The `"critical"` tone value for `Anchor` has been deprecated and will be removed in a future release.
 - Updated dependencies:
   - @stratakit/foundations@0.3.3
 
 ## 0.4.2
 
-- [#938](https://github.com/iTwin/design-system/pull/938): Explicitly set the `Avatar`'s icon color to prevent accidentally inheriting the wrong color.
-- [#934](https://github.com/iTwin/design-system/pull/934): Fixed visual inconsistencies between convenience and composition methods of `TextBox`.
+- [#938](https://github.com/iTwin/stratakit/pull/938): Explicitly set the `Avatar`'s icon color to prevent accidentally inheriting the wrong color.
+- [#934](https://github.com/iTwin/stratakit/pull/934): Fixed visual inconsistencies between convenience and composition methods of `TextBox`.
 - Updated dependencies:
   - @stratakit/foundations@0.3.2
 
 ## 0.4.1
 
-- [#926](https://github.com/iTwin/design-system/pull/926): Added new `active` prop to `IconButton` and deprecated the existing `isActive` prop.
+- [#926](https://github.com/iTwin/stratakit/pull/926): Added new `active` prop to `IconButton` and deprecated the existing `isActive` prop.
 
   The `active` prop is consistent with the naming convention followed by other boolean props in StrataKit.
 
@@ -87,31 +87,31 @@
 
 ## 0.4.0
 
-- [#913](https://github.com/iTwin/design-system/pull/913): Updated internal CSS selectors in every component.
-- [#904](https://github.com/iTwin/design-system/pull/904): Updated color of `Divider` component to match the latest design specification.
+- [#913](https://github.com/iTwin/stratakit/pull/913): Updated internal CSS selectors in every component.
+- [#904](https://github.com/iTwin/stratakit/pull/904): Updated color of `Divider` component to match the latest design specification.
 - Updated dependencies:
   - @stratakit/foundations@0.3.0
 
 ## 0.3.4
 
-- [#881](https://github.com/iTwin/design-system/pull/881): Updated CSS to use `--stratakit-space-` variables instead of hardcoded values in all components.
+- [#881](https://github.com/iTwin/stratakit/pull/881): Updated CSS to use `--stratakit-space-` variables instead of hardcoded values in all components.
   - Replaced hardcoded `rem` spacing values with new `px`-based variables in many components.
-- [#881](https://github.com/iTwin/design-system/pull/881): In `Anchor`, changed hover state's `text-underline-offset` from `3px` to `4px`.
-- [#866](https://github.com/iTwin/design-system/pull/866): Fixed regression in `ProgressBar`'s `reduced-motion` animation.
-- [#866](https://github.com/iTwin/design-system/pull/866): Slowed down `reduced-motion` animation in `Spinner` and `ProgressBar`.
+- [#881](https://github.com/iTwin/stratakit/pull/881): In `Anchor`, changed hover state's `text-underline-offset` from `3px` to `4px`.
+- [#866](https://github.com/iTwin/stratakit/pull/866): Fixed regression in `ProgressBar`'s `reduced-motion` animation.
+- [#866](https://github.com/iTwin/stratakit/pull/866): Slowed down `reduced-motion` animation in `Spinner` and `ProgressBar`.
 - Updated dependencies:
   - @stratakit/foundations@0.2.3
 
 ## 0.3.3
 
-- [#863](https://github.com/iTwin/design-system/pull/863): Update the `background-color` for the "hover" and "pressed" states of `<Button variant="ghost">` and `<Button variant="outline">`.
-- [#852](https://github.com/iTwin/design-system/pull/852): Removed spinner slowed down animation after 4 counts.
+- [#863](https://github.com/iTwin/stratakit/pull/863): Update the `background-color` for the "hover" and "pressed" states of `<Button variant="ghost">` and `<Button variant="outline">`.
+- [#852](https://github.com/iTwin/stratakit/pull/852): Removed spinner slowed down animation after 4 counts.
 - Updated dependencies:
   - @stratakit/foundations@0.2.2
 
 ## 0.3.2
 
-- [#757](https://github.com/iTwin/design-system/pull/757): Added compositional `Anchor.Root` component. This new component can be used when you need fine grained configuration.
+- [#757](https://github.com/iTwin/stratakit/pull/757): Added compositional `Anchor.Root` component. This new component can be used when you need fine grained configuration.
 
   To use the compositional components, import them from the `/Anchor` subpath:
 
@@ -121,19 +121,19 @@
   <Anchor.Root href="https://www.example.com">Example</Anchor.Root>;
   ```
 
-- [#800](https://github.com/iTwin/design-system/pull/800): Added `<Anchor.Text>` and `<Anchor.ExternalMarker />` for composition API.
-- [#836](https://github.com/iTwin/design-system/pull/836): Added `tone="accent"` to `<Button variant="ghost">`.
-- [#837](https://github.com/iTwin/design-system/pull/837): Added `tone="accent"` to `<Button variant="outline">`.
-- [#831](https://github.com/iTwin/design-system/pull/831): Updated `isActive` state styling for `IconButton`.
-- [#831](https://github.com/iTwin/design-system/pull/831): Made `isActive` prop available to all variants of `IconButton`.
-- [#798](https://github.com/iTwin/design-system/pull/798): Adjusted `Field` styling to use `justify-content: stretch` for textlike controls in stacked layout.
+- [#800](https://github.com/iTwin/stratakit/pull/800): Added `<Anchor.Text>` and `<Anchor.ExternalMarker />` for composition API.
+- [#836](https://github.com/iTwin/stratakit/pull/836): Added `tone="accent"` to `<Button variant="ghost">`.
+- [#837](https://github.com/iTwin/stratakit/pull/837): Added `tone="accent"` to `<Button variant="outline">`.
+- [#831](https://github.com/iTwin/stratakit/pull/831): Updated `isActive` state styling for `IconButton`.
+- [#831](https://github.com/iTwin/stratakit/pull/831): Made `isActive` prop available to all variants of `IconButton`.
+- [#798](https://github.com/iTwin/stratakit/pull/798): Adjusted `Field` styling to use `justify-content: stretch` for textlike controls in stacked layout.
 
 - Updated dependencies:
   - @stratakit/foundations@0.2.1
 
 ## 0.3.1
 
-- [#773](https://github.com/iTwin/design-system/pull/773): Added [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) for individual components. These new exports allow StrataKit to expose both convenience and compositional APIs of the same component.
+- [#773](https://github.com/iTwin/stratakit/pull/773): Added [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) for individual components. These new exports allow StrataKit to expose both convenience and compositional APIs of the same component.
 
   ```tsx
   // Convenience import
@@ -154,7 +154,7 @@
   </Chip.Root>;
   ```
 
-  Compositional components are useful for building custom components that require more control over the structure and behavior, while convenience components provide a ready-to-use solution for common use cases. See [#405](https://github.com/iTwin/design-system/discussions/405) for more details.
+  Compositional components are useful for building custom components that require more control over the structure and behavior, while convenience components provide a ready-to-use solution for common use cases. See [#405](https://github.com/iTwin/stratakit/discussions/405) for more details.
 
   APIs exported from the barrel file are not changed in this release. Some exported components are compositional, while others are convenience components.
 
@@ -165,8 +165,8 @@
   <Chip />;
   ```
 
-- [#792](https://github.com/iTwin/design-system/pull/792): Removed `aria-hidden` from the `Tooltip` element.
-- [#801](https://github.com/iTwin/design-system/pull/801): Fixed padding for `Textbox.Textarea` when used with an icon.
+- [#792](https://github.com/iTwin/stratakit/pull/792): Removed `aria-hidden` from the `Tooltip` element.
+- [#801](https://github.com/iTwin/stratakit/pull/801): Fixed padding for `Textbox.Textarea` when used with an icon.
 
 - Updated dependencies:
   - @stratakit/foundations@0.2.0
@@ -175,21 +175,21 @@
 
 ### Breaking changes
 
-- [#758](https://github.com/iTwin/design-system/pull/758): Removed `onToggle` prop from `Switch` types to prevent misuse of unapplicable props.
-- [#742](https://github.com/iTwin/design-system/pull/742): Removed `size="small"` from `ProgressBar`.
+- [#758](https://github.com/iTwin/stratakit/pull/758): Removed `onToggle` prop from `Switch` types to prevent misuse of unapplicable props.
+- [#742](https://github.com/iTwin/stratakit/pull/742): Removed `size="small"` from `ProgressBar`.
 
 ### Non-breaking changes
 
-- [#755](https://github.com/iTwin/design-system/pull/755): Updated the code for icons used internally by components.
-- [#767](https://github.com/iTwin/design-system/pull/767): Removed unused `children` prop from 'AvatarProps` type.
-- [#745](https://github.com/iTwin/design-system/pull/745): Fixed a `ref` type of `Field.Label` component to use the `HTMLLabelElement` instead of `HTMLDivElement`.
+- [#755](https://github.com/iTwin/stratakit/pull/755): Updated the code for icons used internally by components.
+- [#767](https://github.com/iTwin/stratakit/pull/767): Removed unused `children` prop from 'AvatarProps` type.
+- [#745](https://github.com/iTwin/stratakit/pull/745): Fixed a `ref` type of `Field.Label` component to use the `HTMLLabelElement` instead of `HTMLDivElement`.
 - Updated dependencies:
   - @stratakit/foundations@0.1.6
 
 ## 0.2.1
 
-- [#736](https://github.com/iTwin/design-system/pull/736): Updated the `label` prop type in the `<Badge />` component from `string` to `ReactNode`.
-- [#740](https://github.com/iTwin/design-system/pull/740): Added `types` field to `package.json` file for better TypeScript support and TS icon on `npm`.
+- [#736](https://github.com/iTwin/stratakit/pull/736): Updated the `label` prop type in the `<Badge />` component from `string` to `ReactNode`.
+- [#740](https://github.com/iTwin/stratakit/pull/740): Added `types` field to `package.json` file for better TypeScript support and TS icon on `npm`.
 - Updated dependencies:
   - @stratakit/foundations@0.1.5
 
@@ -197,7 +197,7 @@
 
 ### Breaking changes
 
-- [#704](https://github.com/iTwin/design-system/pull/704): The following components have been moved from `@stratakit/bricks` into `@stratakit/structures`.
+- [#704](https://github.com/iTwin/stratakit/pull/704): The following components have been moved from `@stratakit/bricks` into `@stratakit/structures`.
   - `unstable_AccordionItem`
   - `unstable_Banner`
   - `Chip`
@@ -208,7 +208,7 @@
   - `unstable_Toolbar`
   - `Tree`
 
-- [#708](https://github.com/iTwin/design-system/pull/708): The previously-deprecated `Root` and `Icon` components have been removed from `@stratakit/bricks`, since they were moved to `@stratakit/foundations`.
+- [#708](https://github.com/iTwin/stratakit/pull/708): The previously-deprecated `Root` and `Icon` components have been removed from `@stratakit/bricks`, since they were moved to `@stratakit/foundations`.
 
 ### Non-breaking changes
 
@@ -217,28 +217,28 @@
 
 ## 0.1.2
 
-- [#686](https://github.com/iTwin/design-system/pull/686): Corrected font weight of `AccordionItem.Label` to 500/medium.
-- [#689](https://github.com/iTwin/design-system/pull/689): Corrected the text size of `Description`, `Field.Description`, and `Field.ErrorMessage` to use `caption-lg`.
-- [#694](https://github.com/iTwin/design-system/pull/694): Fixed `<Switch>` animation so it plays smoothly on all platforms.
+- [#686](https://github.com/iTwin/stratakit/pull/686): Corrected font weight of `AccordionItem.Label` to 500/medium.
+- [#689](https://github.com/iTwin/stratakit/pull/689): Corrected the text size of `Description`, `Field.Description`, and `Field.ErrorMessage` to use `caption-lg`.
+- [#694](https://github.com/iTwin/stratakit/pull/694): Fixed `<Switch>` animation so it plays smoothly on all platforms.
 - Updated dependencies:
   - @stratakit/foundations@0.1.2
 
 ## 0.1.1
 
-- [#528](https://github.com/iTwin/design-system/pull/528): Added new `unstable_AccordionItem` component for showing/hiding content.
-- [#484](https://github.com/iTwin/design-system/pull/484): Added new `unstable_Banner` component for highlighting information.
-- [#678](https://github.com/iTwin/design-system/pull/678): Added new `placement` prop to `Tooltip`.
-- [#639](https://github.com/iTwin/design-system/pull/639): Improved live regions in `unstable_ErrorRegion` component. Live region announcements will only be made when a new item is added.
+- [#528](https://github.com/iTwin/stratakit/pull/528): Added new `unstable_AccordionItem` component for showing/hiding content.
+- [#484](https://github.com/iTwin/stratakit/pull/484): Added new `unstable_Banner` component for highlighting information.
+- [#678](https://github.com/iTwin/stratakit/pull/678): Added new `placement` prop to `Tooltip`.
+- [#639](https://github.com/iTwin/stratakit/pull/639): Improved live regions in `unstable_ErrorRegion` component. Live region announcements will only be made when a new item is added.
 - Styling changes
-  - [#676](https://github.com/iTwin/design-system/pull/676): Added a small gap between `Kbd`'s children for better spacing.
-  - [#659](https://github.com/iTwin/design-system/pull/659): Fixed responsive design issues in `unstable_ErrorRegion` (again).
+  - [#676](https://github.com/iTwin/stratakit/pull/676): Added a small gap between `Kbd`'s children for better spacing.
+  - [#659](https://github.com/iTwin/stratakit/pull/659): Fixed responsive design issues in `unstable_ErrorRegion` (again).
 - Updated dependencies:
   - @stratakit/foundations@0.1.1
 
 ## @stratakit/bricks@0.1.0
 
 - **breaking**: Package name changed to `@stratakit/bricks`.
-- Added `@stratakit/foundations` as a peer dependency. See [#640](https://github.com/iTwin/design-system/pull/640).
+- Added `@stratakit/foundations` as a peer dependency. See [#640](https://github.com/iTwin/stratakit/pull/640).
 - Deprecated `Root` and `Icon` components (moved into `@stratakit/foundations`).
 - New features:
   - Added `value` prop to `ProgressBar` component.
@@ -251,4 +251,4 @@
 
 ## @itwin/itwinui-react@​5.0.0-alpha.X
 
-Changelog entries for `@itwin/itwinui-react@5.0.0-alpha.14` and older can be found in the [`CHANGELOG.md` for `@stratakit/bricks@0.1.0`](https://github.com/iTwin/design-system/blob/%40stratakit/bricks%400.1.0/packages/bricks/CHANGELOG.md).
+Changelog entries for `@itwin/itwinui-react@5.0.0-alpha.14` and older can be found in the [`CHANGELOG.md` for `@stratakit/bricks@0.1.0`](https://github.com/iTwin/stratakit/blob/%40stratakit/bricks%400.1.0/packages/bricks/CHANGELOG.md).

--- a/packages/bricks/README.md
+++ b/packages/bricks/README.md
@@ -5,7 +5,7 @@ Small, modular components for StrataKit.
 Bricks can be assembled to create larger, more functional experiences.
 
 > [!CAUTION]
-> `@stratakit/bricks` is currently in **maintenance mode**. See [#1116](https://github.com/iTwin/design-system/discussions/1116) for details.
+> `@stratakit/bricks` is currently in **maintenance mode**. See [#1116](https://github.com/iTwin/stratakit/discussions/1116) for details.
 
 ## Installation
 
@@ -31,6 +31,6 @@ For more details on using specific features, refer to the inline documentation a
 
 ## Contributing
 
-Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/design-system/issues).
+Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/stratakit/issues).
 
-If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/design-system/blob/main/CONTRIBUTING.md) for more information.
+If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md) for more information.

--- a/packages/bricks/package.json
+++ b/packages/bricks/package.json
@@ -153,10 +153,10 @@
 	],
 	"description": "Small, modular components for StrataKit",
 	"author": "Bentley Systems",
-	"homepage": "https://github.com/iTwin/design-system",
+	"homepage": "https://github.com/iTwin/stratakit",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/iTwin/design-system.git",
+		"url": "https://github.com/iTwin/stratakit.git",
 		"directory": "packages/bricks"
 	},
 	"keywords": [

--- a/packages/foundations/CHANGELOG.md
+++ b/packages/foundations/CHANGELOG.md
@@ -2,24 +2,24 @@
 
 ## 0.4.6
 
-- [#1188](https://github.com/iTwin/design-system/pull/1188): Fixed a race condition where stylesheets could be prematurely removed in cases where multiple components that use the same styles were conditionally rendered.
+- [#1188](https://github.com/iTwin/stratakit/pull/1188): Fixed a race condition where stylesheets could be prematurely removed in cases where multiple components that use the same styles were conditionally rendered.
 
 ## 0.4.5
 
-- [#1134](https://github.com/iTwin/design-system/pull/1134): Fixed the default value of `Root`'s `synchronizeColorScheme` prop to actually be `true`, as mentioned in the docs.
-- [#1135](https://github.com/iTwin/design-system/pull/1135): Global focus styles have been moved from `@layer stratakit` to `@layer reset`.
+- [#1134](https://github.com/iTwin/stratakit/pull/1134): Fixed the default value of `Root`'s `synchronizeColorScheme` prop to actually be `true`, as mentioned in the docs.
+- [#1135](https://github.com/iTwin/stratakit/pull/1135): Global focus styles have been moved from `@layer stratakit` to `@layer reset`.
 
 ## 0.4.4
 
-- [#1124](https://github.com/iTwin/design-system/pull/1124): Added `-webkit-font-smoothing: antialiased` to the CSS reset.
-- [#1123](https://github.com/iTwin/design-system/pull/1123): Renamed `@layer itwinui` to `@layer stratakit`.
-- [#1121](https://github.com/iTwin/design-system/pull/1121): Removed `adoptedStyleSheets` fallback for older browsers.
-- [#1121](https://github.com/iTwin/design-system/pull/1121): Removed `oklch` fallbacks for older browsers.
-- [#1126](https://github.com/iTwin/design-system/pull/1126): `Root` component no longer requires `density` prop. When `density` is not specified, `font-size: 0.75rem` will _not_ be used globally.
+- [#1124](https://github.com/iTwin/stratakit/pull/1124): Added `-webkit-font-smoothing: antialiased` to the CSS reset.
+- [#1123](https://github.com/iTwin/stratakit/pull/1123): Renamed `@layer itwinui` to `@layer stratakit`.
+- [#1121](https://github.com/iTwin/stratakit/pull/1121): Removed `adoptedStyleSheets` fallback for older browsers.
+- [#1121](https://github.com/iTwin/stratakit/pull/1121): Removed `oklch` fallbacks for older browsers.
+- [#1126](https://github.com/iTwin/stratakit/pull/1126): `Root` component no longer requires `density` prop. When `density` is not specified, `font-size: 0.75rem` will _not_ be used globally.
 
 ## 0.4.3
 
-- [#1108](https://github.com/iTwin/design-system/pull/1108): Decoupled the styles for `@stratakit/bricks` and `@stratakit/structures` from `@stratakit/foundations` so that the latter does not indirectly depend on the former two. This change also reduces the need for these packages to remain in lockstep.
+- [#1108](https://github.com/iTwin/stratakit/pull/1108): Decoupled the styles for `@stratakit/bricks` and `@stratakit/structures` from `@stratakit/foundations` so that the latter does not indirectly depend on the former two. This change also reduces the need for these packages to remain in lockstep.
 
 ## 0.4.2
 
@@ -33,7 +33,7 @@
 
 ### Breaking changes
 
-- [#973](https://github.com/iTwin/design-system/pull/973), [#1057](https://github.com/iTwin/design-system/pull/1057): Renamed a few CSS variables for better consistency and accuracy:
+- [#973](https://github.com/iTwin/stratakit/pull/973), [#1057](https://github.com/iTwin/stratakit/pull/1057): Renamed a few CSS variables for better consistency and accuracy:
   - `--stratakit-color-icon-neutral-hover` is now `--stratakit-color-icon-neutral-primary`.
   - `--stratakit-color-bg-page-zebra` is now `--stratakit-color-bg-control-table-zebra`.
   - `--stratakit-color-brand-logo` is now `--stratakit-color-brand-logo-fill`.
@@ -54,10 +54,10 @@
   + var(--stratakit-color-icon-neutral-primary)
   ```
 
-- [#960](https://github.com/iTwin/design-system/pull/960): The global focus outline is now given priority in the CSS cascade. This is a precautionary measure to prevent third party styles from removing the focus outline.
-- [#952](https://github.com/iTwin/design-system/pull/952): Changed the default value of `Root`'s `synchronizeColorScheme` prop to `true`.
+- [#960](https://github.com/iTwin/stratakit/pull/960): The global focus outline is now given priority in the CSS cascade. This is a precautionary measure to prevent third party styles from removing the focus outline.
+- [#952](https://github.com/iTwin/stratakit/pull/952): Changed the default value of `Root`'s `synchronizeColorScheme` prop to `true`.
 
-- [#958](https://github.com/iTwin/design-system/pull/958): The `Root` component will no longer detect the [root node](https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode) automatically. By default, it will use `document`. When rendering in shadow DOM or a popout window, you will need to pass the `rootNode` prop to the `Root` component.
+- [#958](https://github.com/iTwin/stratakit/pull/958): The `Root` component will no longer detect the [root node](https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode) automatically. By default, it will use `document`. When rendering in shadow DOM or a popout window, you will need to pass the `rootNode` prop to the `Root` component.
 
   ```tsx
   <Root rootNode={/* shadowRoot or popoutWindow.document */}>
@@ -65,14 +65,14 @@
 
 ### Non-breaking changes
 
-- [#973](https://github.com/iTwin/design-system/pull/973), [#1057](https://github.com/iTwin/design-system/pull/1057): Added new CSS variables:
+- [#973](https://github.com/iTwin/stratakit/pull/973), [#1057](https://github.com/iTwin/stratakit/pull/1057): Added new CSS variables:
   - `--stratakit-color-bg-on-surface-neutral-active-hover`
   - `--stratakit-color-border-control-navrail-item`
   - `--stratakit-color-text-control-placeholder`
   - `--stratakit-color-brand-logo-stroke`
   - `--stratakit-shadow-brand-logo-base`
-- [#1027](https://github.com/iTwin/design-system/pull/1027): Updated the fallback logic of `Icon` component to correctly handle relative non-HTTP URLs.
-- [#1003](https://github.com/iTwin/design-system/pull/1003): Enabled React Compiler for production build. In React 18 apps, `react-compiler-runtime` dependency will be used.
+- [#1027](https://github.com/iTwin/stratakit/pull/1027): Updated the fallback logic of `Icon` component to correctly handle relative non-HTTP URLs.
+- [#1003](https://github.com/iTwin/stratakit/pull/1003): Enabled React Compiler for production build. In React 18 apps, `react-compiler-runtime` dependency will be used.
 
 ## 0.3.5
 
@@ -84,23 +84,23 @@
 
 ## 0.3.3
 
-- [#944](https://github.com/iTwin/design-system/pull/944): The CSS reset has been updated to use `display: inline-block` for SVG elements.
+- [#944](https://github.com/iTwin/stratakit/pull/944): The CSS reset has been updated to use `display: inline-block` for SVG elements.
 - Updated internal code for `@stratakit/bricks@0.4.3` and `@stratakit/structures@0.4.3`.
 
 ## 0.3.2
 
-- [#928](https://github.com/iTwin/design-system/pull/928): Added `@layer reset` fallback to the top of `<head>` element to ensure correct layer order.
+- [#928](https://github.com/iTwin/stratakit/pull/928): Added `@layer reset` fallback to the top of `<head>` element to ensure correct layer order.
 - Updated internal code for `@stratakit/bricks@0.4.2` and `@stratakit/structures@0.4.2`.
 
 ## 0.3.1
 
-- [#925](https://github.com/iTwin/design-system/pull/925): Added `portalContainer` prop to the `Root` component.
+- [#925](https://github.com/iTwin/stratakit/pull/925): Added `portalContainer` prop to the `Root` component.
 
 ## 0.3.0
 
 ### Breaking changes
 
-- [#888](https://github.com/iTwin/design-system/pull/888): `Icon` component no longer automatically adjusts the URL based on `size`.
+- [#888](https://github.com/iTwin/stratakit/pull/888): `Icon` component no longer automatically adjusts the URL based on `size`.
 
   `#icon-large` must now be explicitly added to the URL to select the large icons from `@stratakit/icons`. For example:
 
@@ -111,7 +111,7 @@
 
 ### Non-breaking changes
 
-- [#888](https://github.com/iTwin/design-system/pull/888): `Icon` component now supports URLs containing an explicit hash.
+- [#888](https://github.com/iTwin/stratakit/pull/888): `Icon` component now supports URLs containing an explicit hash.
 
   ```tsx
   import placeholderIcon from "@stratakit/icons/placeholder.svg";
@@ -119,8 +119,8 @@
   <Icon href={`${placeholderIcon}#icon-large`} size="large" />;
   ```
 
-- [#913](https://github.com/iTwin/design-system/pull/913): Updated internal CSS selectors in every component.
-- [#912](https://github.com/iTwin/design-system/pull/912): Token updates:
+- [#913](https://github.com/iTwin/stratakit/pull/913): Updated internal CSS selectors in every component.
+- [#912](https://github.com/iTwin/stratakit/pull/912): Token updates:
   - Added new CSS variable: `--stratakit-color-bg-glow-on-surface-accent-active-hover`.
   - Updated the value of `--stratakit-color-bg-page-base-depth` in light theme.
 
@@ -130,26 +130,26 @@
 
 ## 0.2.3
 
-- [#873](https://github.com/iTwin/design-system/pull/873): Added initial set of spacing tokens (e.g. `--stratakit-space-x1`, `--stratakit-space-x2`, etc).
+- [#873](https://github.com/iTwin/stratakit/pull/873): Added initial set of spacing tokens (e.g. `--stratakit-space-x1`, `--stratakit-space-x2`, etc).
 - Updated internal code for `@stratakit/structures@0.3.1`.
 
 ## 0.2.2
 
-- [#861](https://github.com/iTwin/design-system/pull/861): Small changes to some colors in light theme.
-- [#861](https://github.com/iTwin/design-system/pull/861): Added new CSS variable: `--stratakit-color-bg-control-select`.
+- [#861](https://github.com/iTwin/stratakit/pull/861): Small changes to some colors in light theme.
+- [#861](https://github.com/iTwin/stratakit/pull/861): Added new CSS variable: `--stratakit-color-bg-control-select`.
 - Updated internal code for `@stratakit/bricks@0.3.3` and `@stratakit/structures@0.3.0`.
 
 ## 0.2.1
 
-- [#824](https://github.com/iTwin/design-system/pull/824): Added a new `unstable_loadStyles` function for loading all foundations CSS without using React.
-- [#824](https://github.com/iTwin/design-system/pull/824): Turned `react` and `react-dom` into _optional_ peer dependencies.
+- [#824](https://github.com/iTwin/stratakit/pull/824): Added a new `unstable_loadStyles` function for loading all foundations CSS without using React.
+- [#824](https://github.com/iTwin/stratakit/pull/824): Turned `react` and `react-dom` into _optional_ peer dependencies.
 - Updated internal code for `@stratakit/bricks@0.3.2` and `@stratakit/structures@0.2.4`.
 
 ## 0.2.0
 
 ### Breaking changes
 
-- [#762](https://github.com/iTwin/design-system/pull/762): The prefix for all CSS variables has changed to `--stratakit`.
+- [#762](https://github.com/iTwin/stratakit/pull/762): The prefix for all CSS variables has changed to `--stratakit`.
 
   To handle this breaking change, replace all instances of "--ids" with "--stratakit". For example:
 
@@ -160,10 +160,10 @@
 
 ### Non-breaking changes
 
-- [#783](https://github.com/iTwin/design-system/pull/783): Several changes to the CSS reset, affecting `<button>`, `<fieldset>`, `<p>` and heading (`<h1>`, `<h2>`, etc) elements.
-- [#811](https://github.com/iTwin/design-system/pull/811): Added a global `color-scheme` style, matching the `colorScheme` passed to `<Root>`.
-- [#568](https://github.com/iTwin/design-system/pull/568): Added a global `scrollbar-color` style.
-- [#784](https://github.com/iTwin/design-system/pull/784): Added new CSS variables:
+- [#783](https://github.com/iTwin/stratakit/pull/783): Several changes to the CSS reset, affecting `<button>`, `<fieldset>`, `<p>` and heading (`<h1>`, `<h2>`, etc) elements.
+- [#811](https://github.com/iTwin/stratakit/pull/811): Added a global `color-scheme` style, matching the `colorScheme` passed to `<Root>`.
+- [#568](https://github.com/iTwin/stratakit/pull/568): Added a global `scrollbar-color` style.
+- [#784](https://github.com/iTwin/stratakit/pull/784): Added new CSS variables:
   - `--stratakit-color-border-control-checkbox`
   - `--stratakit-color-border-control-radio`
   - `--stratakit-color-border-control-textbox`
@@ -171,16 +171,16 @@
 
 ## 0.1.6
 
-- [#770](https://github.com/iTwin/design-system/pull/770): An error will now be thrown when multiple instances of `@stratakit/foundations` are detected.
+- [#770](https://github.com/iTwin/stratakit/pull/770): An error will now be thrown when multiple instances of `@stratakit/foundations` are detected.
 
 ## 0.1.5
 
-- [#740](https://github.com/iTwin/design-system/pull/740): Added `types` field to `package.json` file for better TypeScript support and TS icon on `npm`.
+- [#740](https://github.com/iTwin/stratakit/pull/740): Added `types` field to `package.json` file for better TypeScript support and TS icon on `npm`.
 
 ## 0.1.4
 
-- [#719](https://github.com/iTwin/design-system/pull/719): Updated `Icon` component to catch errors when making network requests.
-- [#650](https://github.com/iTwin/design-system/pull/650): Added global `::selection` styling.
+- [#719](https://github.com/iTwin/stratakit/pull/719): Updated `Icon` component to catch errors when making network requests.
+- [#650](https://github.com/iTwin/stratakit/pull/650): Added global `::selection` styling.
 
 ## 0.1.3
 

--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -78,6 +78,6 @@ Build tools such as [Vite](https://vite.dev/guide/assets.html#importing-asset-as
 
 ## Contributing
 
-Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/design-system/issues).
+Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/stratakit/issues).
 
-If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/design-system/blob/main/CONTRIBUTING.md) for more information.
+If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md) for more information.

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -27,10 +27,10 @@
 	],
 	"description": "Foundational pieces of StrataKit",
 	"author": "Bentley Systems",
-	"homepage": "https://github.com/iTwin/design-system",
+	"homepage": "https://github.com/iTwin/stratakit",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/iTwin/design-system.git",
+		"url": "https://github.com/iTwin/stratakit.git",
 		"directory": "packages/foundations"
 	},
 	"keywords": [

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Breaking changes
 
-- [#1163](https://github.com/iTwin/design-system/pull/1163): Removed `license-remove.svg` which was previously deprecated and aliased to `license-minus.svg`.
+- [#1163](https://github.com/iTwin/stratakit/pull/1163): Removed `license-remove.svg` which was previously deprecated and aliased to `license-minus.svg`.
 
 ## 0.2.2
 
-- [#1104](https://github.com/iTwin/design-system/pull/1104): Added new icons:
+- [#1104](https://github.com/iTwin/stratakit/pull/1104): Added new icons:
   - `microscope.svg`
   - `scene.svg`
   - `thumbs-down.svg`
@@ -16,7 +16,7 @@
 
 ## 0.2.1
 
-- [#1084](https://github.com/iTwin/design-system/pull/1084): Renamed `license-remove.svg` to `license-minus.svg`.
+- [#1084](https://github.com/iTwin/stratakit/pull/1084): Renamed `license-remove.svg` to `license-minus.svg`.
 
   `license-remove.svg` is now considered deprecated and will be removed in a future release.
 
@@ -24,7 +24,7 @@
 
 ### Breaking changes
 
-- [#1015](https://github.com/iTwin/design-system/pull/1015): Some icons have been renamed for better clarity and consistency.
+- [#1015](https://github.com/iTwin/stratakit/pull/1015): Some icons have been renamed for better clarity and consistency.
 
   | Old name                       | New name                     |
   | ------------------------------ | ---------------------------- |
@@ -46,7 +46,7 @@
 
 ### Non-breaking changes
 
-- [#1042](https://github.com/iTwin/design-system/pull/1042): Added new icons:
+- [#1042](https://github.com/iTwin/stratakit/pull/1042): Added new icons:
   - `ai-chat-add.svg`
   - `ai-chat.svg`
   - `area-island-traffic.svg`
@@ -76,7 +76,7 @@
 
 ## 0.1.5
 
-- [#911](https://github.com/iTwin/design-system/pull/911): Added new icons:
+- [#911](https://github.com/iTwin/stratakit/pull/911): Added new icons:
   - `dimension-angle.svg`
   - `dimension-linear.svg`
   - `dimension-ordinate.svg`
@@ -89,7 +89,7 @@
 
 ## 0.1.4
 
-- [#896](https://github.com/iTwin/design-system/pull/896): Added icons:
+- [#896](https://github.com/iTwin/stratakit/pull/896): Added icons:
   - `area-parking.svg`
   - `boundary-property.svg`
   - `equals.svg`
@@ -108,7 +108,7 @@
 
 ## 0.1.3
 
-- [#850](https://github.com/iTwin/design-system/pull/850): Added icons:
+- [#850](https://github.com/iTwin/stratakit/pull/850): Added icons:
   - `drone.svg`
   - `error.svg`
   - `regenerate.svg`
@@ -122,7 +122,7 @@
 
 ## 0.1.2
 
-- [#754](https://github.com/iTwin/design-system/pull/754): Added icons:
+- [#754](https://github.com/iTwin/stratakit/pull/754): Added icons:
   - `inspection.svg`
   - `power-bi.svg`
   - `document-pdf.svg`
@@ -182,14 +182,14 @@
   - `document.svg`
   - `retry.svg`
 
-- [#755](https://github.com/iTwin/design-system/pull/755): All icons have been updated.
+- [#755](https://github.com/iTwin/stratakit/pull/755): All icons have been updated.
   - Small adjustments to size and negative space for better visual alignment.
   - Some icons redrawn using new shapes.
   - Simplified attributes on the `<path>` elements.
 
 ## 0.1.1
 
-- [#733](https://github.com/iTwin/design-system/pull/733): Added snapping related icons:
+- [#733](https://github.com/iTwin/stratakit/pull/733): Added snapping related icons:
   - `snap-bisector.svg`
   - `snap-endpoint.svg`
   - `snap-center.svg`
@@ -207,9 +207,9 @@
 ## @stratakit/icons@0.1.0
 
 - **breaking**: Package name changed to `@stratakit/icons`.
-- [#649](https://github.com/iTwin/design-system/pull/649): **breaking**: Fixed typo in `visibility-invert.svg`.
+- [#649](https://github.com/iTwin/stratakit/pull/649): **breaking**: Fixed typo in `visibility-invert.svg`.
 
 ## @itwin/itwinui-icons@5.0.0-alpha.7
 
-- **breaking**: Removed `dismiss.svg` and `panel-left.svg`. See [#539](https://github.com/iTwin/design-system/pull/539).
+- **breaking**: Removed `dismiss.svg` and `panel-left.svg`. See [#539](https://github.com/iTwin/stratakit/pull/539).
 - Added 19 new icons.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -123,6 +123,6 @@ esbuild.build({
 
 ## Contributing
 
-Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/design-system/issues).
+Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/stratakit/issues).
 
-If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/design-system/blob/main/CONTRIBUTING.md) for more information.
+If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md) for more information.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -15,10 +15,10 @@
 	],
 	"description": "A standalone SVG icon library for StrataKit",
 	"author": "Bentley Systems",
-	"homepage": "https://github.com/iTwin/design-system",
+	"homepage": "https://github.com/iTwin/stratakit",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/iTwin/design-system.git",
+		"url": "https://github.com/iTwin/stratakit.git",
 		"directory": "packages/icons"
 	},
 	"keywords": [

--- a/packages/mui/CHANGELOG.md
+++ b/packages/mui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.1
 
-- [#1188](https://github.com/iTwin/design-system/pull/1188): Fixed a race condition where stylesheets could be prematurely removed in cases where multiple components that use the same styles were conditionally rendered.
+- [#1188](https://github.com/iTwin/stratakit/pull/1188): Fixed a race condition where stylesheets could be prematurely removed in cases where multiple components that use the same styles were conditionally rendered.
 - Updated dependencies:
   - @stratakit/foundations@0.4.6
 
@@ -12,46 +12,46 @@
 
 This release includes a few API changes in MUI components. Make sure to include `@stratakit/mui/types.d.ts` in your project to get the correct types.
 
-- [#1157](https://github.com/iTwin/design-system/pull/1157): Updated the default value of `Tooltip`'s `describeChild` prop to `true`.
+- [#1157](https://github.com/iTwin/stratakit/pull/1157): Updated the default value of `Tooltip`'s `describeChild` prop to `true`.
 - `color` prop:
-  - [#1152](https://github.com/iTwin/design-system/pull/1152), [#1158](https://github.com/iTwin/design-system/pull/1158): Removed the following values from the `color` prop of `Button` and `IconButton` components: `"info"`, `"success"`, `"warning"`, and `"inherit"`.
-  - [#1183](https://github.com/iTwin/design-system/pull/1183): Removed all values for the `color` prop from form controls (i.e. `Checkbox`, `FormLabel`, `Radio`, `Select`, `Switch` and `TextField` components).
-  - [#1161](https://github.com/iTwin/design-system/pull/1161): Removed the following values from `Fab`'s `color` prop: `"info"`, `"success"`, `"warning"`, `"error"`, `"default"`, and `"inherit"`. The default value is now `"primary"`.
-  - [#1176](https://github.com/iTwin/design-system/pull/1176): Removed all values from `Slider`'s `color` prop (except the default `"primary"`).
+  - [#1152](https://github.com/iTwin/stratakit/pull/1152), [#1158](https://github.com/iTwin/stratakit/pull/1158): Removed the following values from the `color` prop of `Button` and `IconButton` components: `"info"`, `"success"`, `"warning"`, and `"inherit"`.
+  - [#1183](https://github.com/iTwin/stratakit/pull/1183): Removed all values for the `color` prop from form controls (i.e. `Checkbox`, `FormLabel`, `Radio`, `Select`, `Switch` and `TextField` components).
+  - [#1161](https://github.com/iTwin/stratakit/pull/1161): Removed the following values from `Fab`'s `color` prop: `"info"`, `"success"`, `"warning"`, `"error"`, `"default"`, and `"inherit"`. The default value is now `"primary"`.
+  - [#1176](https://github.com/iTwin/stratakit/pull/1176): Removed all values from `Slider`'s `color` prop (except the default `"primary"`).
 
 - `variant` prop:
-  - [#1179](https://github.com/iTwin/design-system/pull/1179): Removed `variant="standard"` from `Alert` and changed the default to `variant="outlined"`.
-  - [#1153](https://github.com/iTwin/design-system/pull/1153): Deprecated the `variant` prop in `TextField`.
+  - [#1179](https://github.com/iTwin/stratakit/pull/1179): Removed `variant="standard"` from `Alert` and changed the default to `variant="outlined"`.
+  - [#1153](https://github.com/iTwin/stratakit/pull/1153): Deprecated the `variant` prop in `TextField`.
 
 ### Non-breaking changes
 
-- [#1139](https://github.com/iTwin/design-system/pull/1139): Removed floating label and re-styled inputs to match the height of buttons.
-- [#1162](https://github.com/iTwin/design-system/pull/1162): Fixed input `outline` and label `color` on focus.
-- [#1170](https://github.com/iTwin/design-system/pull/1170): Updated global color mappings for various components, e.g. `Alert`, `Avatar`, `LinearProgress`, `Skeleton`, `Snackbar`, `TableCell`.
-- [#1171](https://github.com/iTwin/design-system/pull/1171): Fixed `ButtonGroup` default props to use `color="secondary"` and `disableRipple`.
-- [#1180](https://github.com/iTwin/design-system/pull/1180): Fixed `Link` color contrast.
-- [#1178](https://github.com/iTwin/design-system/pull/1178): Fixed `IconButton` color contrast.
-- [#1160](https://github.com/iTwin/design-system/pull/1160): Updated padding for `Dialog` actions.
-- [#1175](https://github.com/iTwin/design-system/pull/1175): Updated padding for `Card` actions.
-- [#1159](https://github.com/iTwin/design-system/pull/1159): Updated colors in `Accordion`, `Card` and `Chip` components.
-- [#1159](https://github.com/iTwin/design-system/pull/1159): Updated `AppBar` component to use neutral colors and no box-shadow.
-- [#1156](https://github.com/iTwin/design-system/pull/1156): Updated `ButtonBase` disabled styles to use `cursor: not-allowed` and not prevent `pointer-events`.
+- [#1139](https://github.com/iTwin/stratakit/pull/1139): Removed floating label and re-styled inputs to match the height of buttons.
+- [#1162](https://github.com/iTwin/stratakit/pull/1162): Fixed input `outline` and label `color` on focus.
+- [#1170](https://github.com/iTwin/stratakit/pull/1170): Updated global color mappings for various components, e.g. `Alert`, `Avatar`, `LinearProgress`, `Skeleton`, `Snackbar`, `TableCell`.
+- [#1171](https://github.com/iTwin/stratakit/pull/1171): Fixed `ButtonGroup` default props to use `color="secondary"` and `disableRipple`.
+- [#1180](https://github.com/iTwin/stratakit/pull/1180): Fixed `Link` color contrast.
+- [#1178](https://github.com/iTwin/stratakit/pull/1178): Fixed `IconButton` color contrast.
+- [#1160](https://github.com/iTwin/stratakit/pull/1160): Updated padding for `Dialog` actions.
+- [#1175](https://github.com/iTwin/stratakit/pull/1175): Updated padding for `Card` actions.
+- [#1159](https://github.com/iTwin/stratakit/pull/1159): Updated colors in `Accordion`, `Card` and `Chip` components.
+- [#1159](https://github.com/iTwin/stratakit/pull/1159): Updated `AppBar` component to use neutral colors and no box-shadow.
+- [#1156](https://github.com/iTwin/stratakit/pull/1156): Updated `ButtonBase` disabled styles to use `cursor: not-allowed` and not prevent `pointer-events`.
 - Updated dependencies:
   - @stratakit/icons@0.3.0
 
 ## 0.1.3
 
-- [#1150](https://github.com/iTwin/design-system/pull/1150): Added a new `/types.d.ts` file for augmenting the types from MUI. This file should be included in all projects that rely on `@stratakit/mui`.
-- [#1146](https://github.com/iTwin/design-system/pull/1146): Updated `Button` to use `variant="contained"` by default.
+- [#1150](https://github.com/iTwin/stratakit/pull/1150): Added a new `/types.d.ts` file for augmenting the types from MUI. This file should be included in all projects that rely on `@stratakit/mui`.
+- [#1146](https://github.com/iTwin/stratakit/pull/1146): Updated `Button` to use `variant="contained"` by default.
 
 ## 0.1.2
 
-- [#1137](https://github.com/iTwin/design-system/pull/1137): Updated `border-radius` of `IconButton` component.
+- [#1137](https://github.com/iTwin/stratakit/pull/1137): Updated `border-radius` of `IconButton` component.
 
 ## 0.1.1
 
-- [#1131](https://github.com/iTwin/design-system/pull/1131): Fixed the values for **warning** palette.
-- [#1135](https://github.com/iTwin/design-system/pull/1135): Global focus styles have been moved from `@layer stratakit` to `@layer reset`.
+- [#1131](https://github.com/iTwin/stratakit/pull/1131): Fixed the values for **warning** palette.
+- [#1135](https://github.com/iTwin/stratakit/pull/1135): Global focus styles have been moved from `@layer stratakit` to `@layer reset`.
 - Updated dependencies:
   - @stratakit/foundations@0.4.5
 

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -12,7 +12,7 @@ npm add @stratakit/mui
 
 Additional setup/considerations:
 
-- `@stratakit/mui` has a direct dependency on [`@stratakit/foundations`](https://www.npmjs.com/package/@stratakit/foundations) and [`@stratakit/icons`](https://www.npmjs.com/package/@stratakit/icons), the latter of which requires [bundler configuration](https://github.com/iTwin/design-system/tree/main/packages/icons#bundler-configuration) to ensure that `.svg` files are not inlined.
+- `@stratakit/mui` has a direct dependency on [`@stratakit/foundations`](https://www.npmjs.com/package/@stratakit/foundations) and [`@stratakit/icons`](https://www.npmjs.com/package/@stratakit/icons), the latter of which requires [bundler configuration](https://github.com/iTwin/stratakit/tree/main/packages/icons#bundler-configuration) to ensure that `.svg` files are not inlined.
 - You should ensure that [StrataKit fonts](#fonts) are loaded in your application.
 - [`/types.d.ts`](#typescript) must be included in your project to ensure that the module augmentation for MUI components is picked up by TypeScript.
 - If you are trying to use this package alongside iTwinUI, you will also need to set up the [theme bridge](https://github.com/iTwin/iTwinUI/wiki/StrataKit-theme-bridge).
@@ -46,7 +46,7 @@ import svgPlaceholder from "@stratakit/icons/placeholder.svg";
 ```
 
 > [!NOTE]
-> `@stratakit/icons` requires [bundler configuration](https://github.com/iTwin/design-system/tree/main/packages/icons#bundler-configuration) to ensure that `.svg` files are not inlined.
+> `@stratakit/icons` requires [bundler configuration](https://github.com/iTwin/stratakit/tree/main/packages/icons#bundler-configuration) to ensure that `.svg` files are not inlined.
 
 ## Fonts
 
@@ -101,6 +101,6 @@ Alternatively, if your project relies on the implicit inclusion of visible `@typ
 
 ## Contributing
 
-Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/design-system/issues).
+Are you interested in helping StrataKit grow? You can submit feature requests or bugs by creating [issues](https://github.com/iTwin/stratakit/issues).
 
-If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/design-system/blob/main/CONTRIBUTING.md) for more information.
+If you're interested in contributing code, please read [`CONTRIBUTING.md`](https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md) for more information.

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -26,10 +26,10 @@
 	],
 	"description": "StrataKit theme for Material UI",
 	"author": "Bentley Systems",
-	"homepage": "https://github.com/iTwin/design-system",
+	"homepage": "https://github.com/iTwin/stratakit",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/iTwin/design-system.git",
+		"url": "https://github.com/iTwin/stratakit.git",
 		"directory": "packages/mui"
 	},
 	"keywords": [

--- a/packages/structures/CHANGELOG.md
+++ b/packages/structures/CHANGELOG.md
@@ -2,26 +2,26 @@
 
 ## 0.5.5
 
-- [#1174](https://github.com/iTwin/design-system/pull/1174): Fixed `DropdownMenu.Submenu` component to avoid removal of parent portal popover when unmounting.
+- [#1174](https://github.com/iTwin/stratakit/pull/1174): Fixed `DropdownMenu.Submenu` component to avoid removal of parent portal popover when unmounting.
 
 ## 0.5.4
 
-- [#1122](https://github.com/iTwin/design-system/pull/1122): Moved `@stratakit/foundations` from `peerDependencies` to direct `dependencies`.
-- [#1123](https://github.com/iTwin/design-system/pull/1123): Renamed `@layer itwinui` to `@layer stratakit`.
+- [#1122](https://github.com/iTwin/stratakit/pull/1122): Moved `@stratakit/foundations` from `peerDependencies` to direct `dependencies`.
+- [#1123](https://github.com/iTwin/stratakit/pull/1123): Renamed `@layer itwinui` to `@layer stratakit`.
 - Updated dependencies:
   - @stratakit/foundations@0.4.4
   - @stratakit/bricks@0.5.4
 
 ## 0.5.3
 
-- [#1108](https://github.com/iTwin/design-system/pull/1108): Decoupled the styles for `@stratakit/bricks` and `@stratakit/structures` from `@stratakit/foundations` so that the latter does not indirectly depend on the former two. This change also reduces the need for these packages to remain in lockstep.
+- [#1108](https://github.com/iTwin/stratakit/pull/1108): Decoupled the styles for `@stratakit/bricks` and `@stratakit/structures` from `@stratakit/foundations` so that the latter does not indirectly depend on the former two. This change also reduces the need for these packages to remain in lockstep.
 - Updated dependencies:
   - @stratakit/foundations@0.4.3
   - @stratakit/bricks@0.5.3
 
 ## 0.5.2
 
-- [#1078](https://github.com/iTwin/design-system/pull/1078): Added `DropdownMenu.Group` component used to group menu items within a dropdown menu.
+- [#1078](https://github.com/iTwin/stratakit/pull/1078): Added `DropdownMenu.Group` component used to group menu items within a dropdown menu.
 
   ```tsx
   <DropdownMenu.Provider>
@@ -40,12 +40,12 @@
   </DropdownMenu.Provider>
   ```
 
-- [#1089](https://github.com/iTwin/design-system/pull/1089): Updated the `NavigationRail.ToggleButton` component to use `aria-pressed` instead of `aria-expanded`, to better reflect how it affects the NavigationRail's appearance.
-- [#1092](https://github.com/iTwin/design-system/pull/1092): Increased the target size of `NavigationRail.ToggleButton` component.
-- [#1102](https://github.com/iTwin/design-system/pull/1102): "Popups" will now respect device-specific close actions (such as back gesture on Android). Affected components include: `DropdownMenu`, `Dialog` and `Popover`.
+- [#1089](https://github.com/iTwin/stratakit/pull/1089): Updated the `NavigationRail.ToggleButton` component to use `aria-pressed` instead of `aria-expanded`, to better reflect how it affects the NavigationRail's appearance.
+- [#1092](https://github.com/iTwin/stratakit/pull/1092): Increased the target size of `NavigationRail.ToggleButton` component.
+- [#1102](https://github.com/iTwin/stratakit/pull/1102): "Popups" will now respect device-specific close actions (such as back gesture on Android). Affected components include: `DropdownMenu`, `Dialog` and `Popover`.
 
-- [#1074](https://github.com/iTwin/design-system/pull/1074): Visual updates to `Table` and `Tree` active + hover states.
-- [#1103](https://github.com/iTwin/design-system/pull/1103): `DropdownMenu.Submenu` will now remain mounted in the DOM as long as the parent DropdownMenu is open.
+- [#1074](https://github.com/iTwin/stratakit/pull/1074): Visual updates to `Table` and `Tree` active + hover states.
+- [#1103](https://github.com/iTwin/stratakit/pull/1103): `DropdownMenu.Submenu` will now remain mounted in the DOM as long as the parent DropdownMenu is open.
 
 - Updated dependencies:
   - @stratakit/bricks@0.5.2
@@ -53,7 +53,7 @@
 
 ## 0.5.1
 
-- [#1075](https://github.com/iTwin/design-system/pull/1075): Added a new `unstable_NavigationList` component that displays a vertical list of links for secondary navigation.
+- [#1075](https://github.com/iTwin/stratakit/pull/1075): Added a new `unstable_NavigationList` component that displays a vertical list of links for secondary navigation.
 
   Includes the following subcomponents:
   - `<NavigationList.Root>`
@@ -79,11 +79,11 @@
   />
   ```
 
-- [#1079](https://github.com/iTwin/design-system/pull/1079): Increased the click target area of non-selectable `Tree.Item`s.
+- [#1079](https://github.com/iTwin/stratakit/pull/1079): Increased the click target area of non-selectable `Tree.Item`s.
   - If `selected` is undefined, the `Tree.Item` will expand/collapse when clicked.
   - If `selected` is defined, the `Tree.Item` will continue to toggle selection when clicked.
 
-- [#1064](https://github.com/iTwin/design-system/pull/1064): Added new `unstable_Popover` component that displays custom content in a non-modal window overlay that is placed relative to a trigger element.
+- [#1064](https://github.com/iTwin/stratakit/pull/1064): Added new `unstable_Popover` component that displays custom content in a non-modal window overlay that is placed relative to a trigger element.
 
   ```tsx
   <Popover content={<>Popover content</>}>
@@ -99,11 +99,11 @@
 
 ### Breaking changes
 
-- [#1036](https://github.com/iTwin/design-system/pull/1036): Changed `items` prop type of `ErrorRegion.Root` component from `ReactNode` to `ReactNode[]`.
+- [#1036](https://github.com/iTwin/stratakit/pull/1036): Changed `items` prop type of `ErrorRegion.Root` component from `ReactNode` to `ReactNode[]`.
 
   `items` prop is used to determine error region visibility.
 
-- [#1038](https://github.com/iTwin/design-system/pull/1038): Removed unintentionally exposed `TreeItem` [subpath export](https://nodejs.org/api/packages.html#subpath-exports). Tree item components are available under the `Tree` subpath or the main entry point of the package.
+- [#1038](https://github.com/iTwin/stratakit/pull/1038): Removed unintentionally exposed `TreeItem` [subpath export](https://nodejs.org/api/packages.html#subpath-exports). Tree item components are available under the `Tree` subpath or the main entry point of the package.
 
   ```diff
   - import * as TreeItem from "@stratakit/structures/TreeItem";
@@ -116,11 +116,11 @@
   + <Tree.ItemAction />
   ```
 
-- [#1037](https://github.com/iTwin/design-system/pull/1037): Require `aria-label` or `aria-labelledby` prop in `ErrorRegion.Root` component.
+- [#1037](https://github.com/iTwin/stratakit/pull/1037): Require `aria-label` or `aria-labelledby` prop in `ErrorRegion.Root` component.
 
 ### Non-breaking changes
 
-- [#1003](https://github.com/iTwin/design-system/pull/1003): Enabled React Compiler for production build. In React 18 apps, `react-compiler-runtime` dependency will be used.
+- [#1003](https://github.com/iTwin/stratakit/pull/1003): Enabled React Compiler for production build. In React 18 apps, `react-compiler-runtime` dependency will be used.
 - Updated dependencies:
   - @stratakit/bricks@0.5.0
   - @stratakit/foundations@0.4.0
@@ -128,29 +128,29 @@
 ## 0.4.5
 
 - `unstable_NavigationRail` changes:
-  - [#962](https://github.com/iTwin/design-system/pull/962): Added `expanded` and `setExpanded` props for controlling the expanded/collapsed state.
-  - [#962](https://github.com/iTwin/design-system/pull/962): Added `defaultExpanded` prop for specifying the _initial_ expanded/collapsed state.
+  - [#962](https://github.com/iTwin/stratakit/pull/962): Added `expanded` and `setExpanded` props for controlling the expanded/collapsed state.
+  - [#962](https://github.com/iTwin/stratakit/pull/962): Added `defaultExpanded` prop for specifying the _initial_ expanded/collapsed state.
 - `unstable_ErrorRegion` changes:
-  - [#963](https://github.com/iTwin/design-system/pull/963): Avoid attempting to set the default accessible name of the [`<section>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section) when `label={undefined}`.
-  - [#979](https://github.com/iTwin/design-system/pull/979): Updated the visibility logic to be based on the `items` array. Previously recommended `label={undefined}` pattern is now deprecated.
-  - [#978](https://github.com/iTwin/design-system/pull/978): Log a console warning if `aria-label` or `aria-labelledby` is not provided to `ErrorRegion.Root`.
-  - [#979](https://github.com/iTwin/design-system/pull/979): Log a console warning if `items` prop is not an array. Previously supported `ReactNode` type is now deprecated.
-- [#953](https://github.com/iTwin/design-system/pull/953): Changed the default value of `Tabs.Provider`'s `selectOnMove` prop to `false`.
-- [#969](https://github.com/iTwin/design-system/pull/969): Fixed an issue where `unstable_Banner` would not track changes to the `tone` prop.
+  - [#963](https://github.com/iTwin/stratakit/pull/963): Avoid attempting to set the default accessible name of the [`<section>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section) when `label={undefined}`.
+  - [#979](https://github.com/iTwin/stratakit/pull/979): Updated the visibility logic to be based on the `items` array. Previously recommended `label={undefined}` pattern is now deprecated.
+  - [#978](https://github.com/iTwin/stratakit/pull/978): Log a console warning if `aria-label` or `aria-labelledby` is not provided to `ErrorRegion.Root`.
+  - [#979](https://github.com/iTwin/stratakit/pull/979): Log a console warning if `items` prop is not an array. Previously supported `ReactNode` type is now deprecated.
+- [#953](https://github.com/iTwin/stratakit/pull/953): Changed the default value of `Tabs.Provider`'s `selectOnMove` prop to `false`.
+- [#969](https://github.com/iTwin/stratakit/pull/969): Fixed an issue where `unstable_Banner` would not track changes to the `tone` prop.
 - Updated dependencies:
   - @stratakit/bricks@0.4.5
   - @stratakit/foundations@0.3.5
 
 ## 0.4.4
 
-- [#954](https://github.com/iTwin/design-system/pull/954): Added "popup indicator" styling to `Toolbar.Item`.
+- [#954](https://github.com/iTwin/stratakit/pull/954): Added "popup indicator" styling to `Toolbar.Item`.
 - Updated dependencies:
   - @stratakit/bricks@0.4.4
   - @stratakit/foundations@0.3.4
 
 ## 0.4.3
 
-- [#933](https://github.com/iTwin/design-system/pull/933): Added `submenu` prop to `DropdownMenu.Item` component and a `DropdownMenu.Submenu` component to support nested dropdown menus.
+- [#933](https://github.com/iTwin/stratakit/pull/933): Added `submenu` prop to `DropdownMenu.Item` component and a `DropdownMenu.Submenu` component to support nested dropdown menus.
 
   ```tsx
   <DropdownMenu.Provider>
@@ -172,21 +172,21 @@
   </DropdownMenu.Provider>
   ```
 
-- [#939](https://github.com/iTwin/design-system/pull/939): Fixed `forced-colors` styling for `NavigationRail.Anchor` in `active` state.
+- [#939](https://github.com/iTwin/stratakit/pull/939): Fixed `forced-colors` styling for `NavigationRail.Anchor` in `active` state.
 - Updated dependencies:
   - @stratakit/bricks@0.4.3
   - @stratakit/foundations@0.3.3
 
 ## 0.4.2
 
-- [#931](https://github.com/iTwin/design-system/pull/931): `Dialog.Content` will now only scroll past a certain viewport height. On smaller viewports, the `Dialog.Root` will be scrollable instead.
+- [#931](https://github.com/iTwin/stratakit/pull/931): `Dialog.Content` will now only scroll past a certain viewport height. On smaller viewports, the `Dialog.Root` will be scrollable instead.
 - Updated dependencies:
   - @stratakit/bricks@0.4.2
   - @stratakit/foundations@0.3.2
 
 ## 0.4.1
 
-- [#851](https://github.com/iTwin/design-system/pull/851): Added `Dialog` component that displays custom content in a window overlay over the primary window or another dialog window. Currently only modal dialog type is supported.
+- [#851](https://github.com/iTwin/stratakit/pull/851): Added `Dialog` component that displays custom content in a window overlay over the primary window or another dialog window. Currently only modal dialog type is supported.
 
   ```tsx
   const [open, setOpen] = useState(false);
@@ -211,7 +211,7 @@
   </Dialog.Root>
   ```
 
-- [#884](https://github.com/iTwin/design-system/pull/884): Added new `unstable_NavigationRail` component intended to serve as the application's top-level navigation (e.g. for switching between pages).
+- [#884](https://github.com/iTwin/stratakit/pull/884): Added new `unstable_NavigationRail` component intended to serve as the application's top-level navigation (e.g. for switching between pages).
 
   ```jsx
   <NavigationRail.Root>
@@ -255,7 +255,7 @@
 
 ### Breaking changes
 
-- [#888](https://github.com/iTwin/design-system/pull/888): `Toolbar.Item` component no longer automatically uses the large version of the icon.
+- [#888](https://github.com/iTwin/stratakit/pull/888): `Toolbar.Item` component no longer automatically uses the large version of the icon.
 
   `#icon-large` must now be explicitly added to the URL to select the large icons from `@stratakit/icons`. For example:
 
@@ -266,7 +266,7 @@
     />
   ```
 
-- [#900](https://github.com/iTwin/design-system/pull/900): Renamed `Tabs.Root` component to `Tabs.Provider`.
+- [#900](https://github.com/iTwin/stratakit/pull/900): Renamed `Tabs.Root` component to `Tabs.Provider`.
 
   ```diff
   - <Tabs.Root>
@@ -279,7 +279,7 @@
 
   This change makes StrataKit's naming convention more consistent. `Root` components always render a DOM element whereas `Provider` components have no underlying DOM element.
 
-- [#900](https://github.com/iTwin/design-system/pull/900): Renamed `DropdownMenu.Root` component to `DropdownMenu.Provider`.
+- [#900](https://github.com/iTwin/stratakit/pull/900): Renamed `DropdownMenu.Root` component to `DropdownMenu.Provider`.
 
   ```diff
   - <DropdownMenu.Root>
@@ -294,7 +294,7 @@
 
 ### Non-breaking changes
 
-- [#903](https://github.com/iTwin/design-system/pull/903): Added proper styling for `Divider` rendered inside a `Toolbar.Group`.
+- [#903](https://github.com/iTwin/stratakit/pull/903): Added proper styling for `Divider` rendered inside a `Toolbar.Group`.
 
   ```tsx
   <Toolbar.Group variant="solid">
@@ -305,34 +305,34 @@
   </Toolbar.Group>
   ```
 
-- [#913](https://github.com/iTwin/design-system/pull/913): Updated internal CSS selectors in every component.
-- [#901](https://github.com/iTwin/design-system/pull/901): Added `orientation` prop to `Toolbar.Group` component. Set the `orientation` prop to `"vertical"` to display the toolbar vertically.
-- [#902](https://github.com/iTwin/design-system/pull/902): Updated active style of a ghost `IconButton` when used in a `Toolbar` component.
+- [#913](https://github.com/iTwin/stratakit/pull/913): Updated internal CSS selectors in every component.
+- [#901](https://github.com/iTwin/stratakit/pull/901): Added `orientation` prop to `Toolbar.Group` component. Set the `orientation` prop to `"vertical"` to display the toolbar vertically.
+- [#902](https://github.com/iTwin/stratakit/pull/902): Updated active style of a ghost `IconButton` when used in a `Toolbar` component.
 - Updated dependencies:
   - @stratakit/foundations@0.3.0
   - @stratakit/bricks@0.4.0
 
 ## 0.3.2
 
-- [#881](https://github.com/iTwin/design-system/pull/881): Updated CSS to use `--stratakit-space-` variables instead of hardcoded values in all components.
+- [#881](https://github.com/iTwin/stratakit/pull/881): Updated CSS to use `--stratakit-space-` variables instead of hardcoded values in all components.
   - Replaced hardcoded `rem` spacing values with new `px`-based variables in many components.
-- [#889](https://github.com/iTwin/design-system/pull/889): Fixed vertical centering of `Toolbar.Item`.
+- [#889](https://github.com/iTwin/stratakit/pull/889): Fixed vertical centering of `Toolbar.Item`.
 - Updated dependencies:
   - @stratakit/bricks@0.3.4
   - @stratakit/foundations@0.2.3
 
 ## 0.3.1
 
-- [#870](https://github.com/iTwin/design-system/pull/870): Fixed an issue where `AccordionItem.Content` was being offset by decorations placed at the end of `AccordionItem.Header`. The content will now only include start indentation, and correctly stretch all the way up to the right edge.
-- [#869](https://github.com/iTwin/design-system/pull/869): Fixed an issue where `Tree` was using Context as a component which doesn't work in React 18.
-- [#872](https://github.com/iTwin/design-system/pull/872): Improved the `Tabs` active stripe animation to make it smoother and more performant.
+- [#870](https://github.com/iTwin/stratakit/pull/870): Fixed an issue where `AccordionItem.Content` was being offset by decorations placed at the end of `AccordionItem.Header`. The content will now only include start indentation, and correctly stretch all the way up to the right edge.
+- [#869](https://github.com/iTwin/stratakit/pull/869): Fixed an issue where `Tree` was using Context as a component which doesn't work in React 18.
+- [#872](https://github.com/iTwin/stratakit/pull/872): Improved the `Tabs` active stripe animation to make it smoother and more performant.
 
 ## 0.3.0
 
 ### Breaking changes
 
-- [#847](https://github.com/iTwin/design-system/pull/847): The `id` prop in `Tabs.Tab` and `tabId` prop in `Tabs.TabPanel` have been made required.
-- [#805](https://github.com/iTwin/design-system/pull/805): Changed `actions` prop of the `Tree.Item` component to no longer automatically inline some of the actions. Instead, newly added `inlineActions` prop can be used to display up to two inline actions. All actions specified in a `actions` prop will be rendered in the action menu.
+- [#847](https://github.com/iTwin/stratakit/pull/847): The `id` prop in `Tabs.Tab` and `tabId` prop in `Tabs.TabPanel` have been made required.
+- [#805](https://github.com/iTwin/stratakit/pull/805): Changed `actions` prop of the `Tree.Item` component to no longer automatically inline some of the actions. Instead, newly added `inlineActions` prop can be used to display up to two inline actions. All actions specified in a `actions` prop will be rendered in the action menu.
 
   ```tsx
   <Tree.Item
@@ -367,7 +367,7 @@
 
 ### Non-breaking changes
 
-- [#821](https://github.com/iTwin/design-system/pull/821): Added compositional `Banner.Root`, `Banner.Icon`, `Banner.Label`, `Banner.Message`, `Banner.Actions`, and `Banner.DismissButton` components. These new components can be used when you need fine grained configuration.
+- [#821](https://github.com/iTwin/stratakit/pull/821): Added compositional `Banner.Root`, `Banner.Icon`, `Banner.Label`, `Banner.Message`, `Banner.Actions`, and `Banner.DismissButton` components. These new components can be used when you need fine grained configuration.
 
   To use the compositional components, import them from the `/unstable_Banner` subpath:
 
@@ -385,7 +385,7 @@
   </Banner.Root>;
   ```
 
-- [#716](https://github.com/iTwin/design-system/pull/716): Added support for placing `<AccordionItem.Marker>` before and `<AccordionItem.Decoration>` after the rest of the content in `<AccordionItem.Header>`.
+- [#716](https://github.com/iTwin/stratakit/pull/716): Added support for placing `<AccordionItem.Marker>` before and `<AccordionItem.Decoration>` after the rest of the content in `<AccordionItem.Header>`.
 
   The `<AccordionItem.Marker>` is now recommended to be placed _before_ the rest of the header content.
 
@@ -398,7 +398,7 @@
   </AccordionItem.Header>
   ```
 
-- [#716](https://github.com/iTwin/design-system/pull/716): Added support for multiple decorations for `AccordionItem` when passed as children in `<AccordionItem.Decoration>`.
+- [#716](https://github.com/iTwin/stratakit/pull/716): Added support for multiple decorations for `AccordionItem` when passed as children in `<AccordionItem.Decoration>`.
 
   ```tsx
   <AccordionItem.Header>
@@ -413,11 +413,11 @@
   </AccordionItem.Header>
   ```
 
-- [#849](https://github.com/iTwin/design-system/pull/849): Add `background-color` change for the `<AccordionItem.Header>` instead of just the `<AccordionItem.Marker>` for the "hover" and "pressed" states of `<AccordionItem.Header>`.
+- [#849](https://github.com/iTwin/stratakit/pull/849): Add `background-color` change for the `<AccordionItem.Header>` instead of just the `<AccordionItem.Marker>` for the "hover" and "pressed" states of `<AccordionItem.Header>`.
 
-- [#829](https://github.com/iTwin/design-system/pull/829): Improved the performance of the `Tree.Item` component by deferring the rendering of actions until the tree item becomes visible on the screen.
+- [#829](https://github.com/iTwin/stratakit/pull/829): Improved the performance of the `Tree.Item` component by deferring the rendering of actions until the tree item becomes visible on the screen.
 
-- [#809](https://github.com/iTwin/design-system/pull/809): Added active and active-hover states to the `Table.Row` component for styling selected rows. To enable selection, render a `Checkbox` component within the row. A row is considered selected when its checkbox is checked.
+- [#809](https://github.com/iTwin/stratakit/pull/809): Added active and active-hover states to the `Table.Row` component for styling selected rows. To enable selection, render a `Checkbox` component within the row. A row is considered selected when its checkbox is checked.
 
   ```tsx
   <Table.Row>
@@ -428,7 +428,7 @@
   </Table.Row>
   ```
 
-- [#854](https://github.com/iTwin/design-system/pull/854): Updated the status icons used internally by various components: `unstable_Banner`, and `unstable_ErrorRegion` and `Tree.Item`.
+- [#854](https://github.com/iTwin/stratakit/pull/854): Updated the status icons used internally by various components: `unstable_Banner`, and `unstable_ErrorRegion` and `Tree.Item`.
 
 - Updated dependencies:
   - @stratakit/bricks@0.3.3
@@ -436,14 +436,14 @@
 
 ## 0.2.4
 
-- [#835](https://github.com/iTwin/design-system/pull/835): Added active-hover state styles to the `Tree.Item` component.
+- [#835](https://github.com/iTwin/stratakit/pull/835): Added active-hover state styles to the `Tree.Item` component.
 - Updated dependencies:
   - @stratakit/bricks@0.3.2
   - @stratakit/foundations@0.2.1
 
 ## 0.2.3
 
-- [#788](https://github.com/iTwin/design-system/pull/788): Updated `Tabs.Tab` component to support optional start and end icons.
+- [#788](https://github.com/iTwin/stratakit/pull/788): Updated `Tabs.Tab` component to support optional start and end icons.
 
   ```tsx
   // Add end icon to a tab.
@@ -453,7 +453,7 @@
   </Tabs.Tab>
   ```
 
-- [#773](https://github.com/iTwin/design-system/pull/773): Added [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) for individual components. These new exports allow StrataKit to expose both convenience and compositional APIs of the same component.
+- [#773](https://github.com/iTwin/stratakit/pull/773): Added [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) for individual components. These new exports allow StrataKit to expose both convenience and compositional APIs of the same component.
 
   ```tsx
   // Convenience import
@@ -474,7 +474,7 @@
   </Chip.Root>;
   ```
 
-  Compositional components are useful for building custom components that require more control over the structure and behavior, while convenience components provide a ready-to-use solution for common use cases. See [#405](https://github.com/iTwin/design-system/discussions/405) for more details.
+  Compositional components are useful for building custom components that require more control over the structure and behavior, while convenience components provide a ready-to-use solution for common use cases. See [#405](https://github.com/iTwin/stratakit/discussions/405) for more details.
 
   APIs exported from the barrel file are not changed in this release. Some exported components are compositional, while others are convenience components.
 
@@ -485,7 +485,7 @@
   <Chip />;
   ```
 
-- [#763](https://github.com/iTwin/design-system/pull/763): Added compositional `Chip.Root`, `Chip.Label` and `Chip.DismissButton` components. These new components can be used when you need fine grained configuration.
+- [#763](https://github.com/iTwin/stratakit/pull/763): Added compositional `Chip.Root`, `Chip.Label` and `Chip.DismissButton` components. These new components can be used when you need fine grained configuration.
 
   To use the compositional components, import them from the `/Chip` subpath:
 
@@ -498,9 +498,9 @@
   </Chip.Root>;
   ```
 
-- [#815](https://github.com/iTwin/design-system/pull/815): Fixed an issue where Toolbar was using Context as a component which doesn't work in React 18.
-- [#781](https://github.com/iTwin/design-system/pull/781): Updated `Chip.Label` component styling when rendered as a button.
-- [#793](https://github.com/iTwin/design-system/pull/793): Added `zustand` as a dependency.
+- [#815](https://github.com/iTwin/stratakit/pull/815): Fixed an issue where Toolbar was using Context as a component which doesn't work in React 18.
+- [#781](https://github.com/iTwin/stratakit/pull/781): Updated `Chip.Label` component styling when rendered as a button.
+- [#793](https://github.com/iTwin/stratakit/pull/793): Added `zustand` as a dependency.
 
 - Updated dependencies:
   - @stratakit/foundations@0.2.0
@@ -508,17 +508,17 @@
 
 ## 0.2.2
 
-- [#756](https://github.com/iTwin/design-system/pull/756): `DropdownMenu.Button` will now ignore `render={undefined}`.
-- [#755](https://github.com/iTwin/design-system/pull/755): Updated the code for icons used internally by components.
+- [#756](https://github.com/iTwin/stratakit/pull/756): `DropdownMenu.Button` will now ignore `render={undefined}`.
+- [#755](https://github.com/iTwin/stratakit/pull/755): Updated the code for icons used internally by components.
 - Updated dependencies:
   - @stratakit/bricks@0.3.0
   - @stratakit/foundations@0.1.6
 
 ## 0.2.1
 
-- [#736](https://github.com/iTwin/design-system/pull/736): Updated the `label` prop type in the `<Chip />` component from `string` to `ReactNode`.
-- [#740](https://github.com/iTwin/design-system/pull/740): Added `types` field to `package.json` file for better TypeScript support and TS icon on `npm`.
-- [#737](https://github.com/iTwin/design-system/pull/737): Fixed console warnings raised from `<Tree.Item>` component.
+- [#736](https://github.com/iTwin/stratakit/pull/736): Updated the `label` prop type in the `<Chip />` component from `string` to `ReactNode`.
+- [#740](https://github.com/iTwin/stratakit/pull/740): Added `types` field to `package.json` file for better TypeScript support and TS icon on `npm`.
+- [#737](https://github.com/iTwin/stratakit/pull/737): Fixed console warnings raised from `<Tree.Item>` component.
 - Updated dependencies:
   - @stratakit/foundations@0.1.5
   - @stratakit/bricks@0.2.1
@@ -527,9 +527,9 @@
 
 ### Breaking changes
 
-- [#720](https://github.com/iTwin/design-system/pull/720): Renamed `onExpandedChange` prop for `unstable_ErrorRegion.Root` to `setOpen`.
+- [#720](https://github.com/iTwin/stratakit/pull/720): Renamed `onExpandedChange` prop for `unstable_ErrorRegion.Root` to `setOpen`.
   Renamed `expanded` prop for `unstable_ErrorRegion.Root` to `open`.
-- [#709](https://github.com/iTwin/design-system/pull/709): `unstable_AccordionItem` breaking changes:
+- [#709](https://github.com/iTwin/stratakit/pull/709): `unstable_AccordionItem` breaking changes:
   - `AccordionItem.Trigger` renamed to `AccordionItem.Header` and no longer represents the underlying `<button>` element (see `AccordionItem.Label`).
   - `AccordionItem.Label` must be wrapped with the new `AccordionItem.Button`.
 
@@ -547,17 +547,17 @@
    </AccordionItem.Root>
   ```
 
-- [#720](https://github.com/iTwin/design-system/pull/720): Renamed `onOpenChange` prop for `unstable_AccordionItem.Root` to `setOpen`.
+- [#720](https://github.com/iTwin/stratakit/pull/720): Renamed `onOpenChange` prop for `unstable_AccordionItem.Root` to `setOpen`.
 
 ### Non-breaking changes
 
-- [#709](https://github.com/iTwin/design-system/pull/709): Introduce `unstable_AccordionItem.Heading` component for wrapping `unstable_AccordionItem.Button` and `unstable_AccordionItem.Button` which represents the underlying `<button>` element.
+- [#709](https://github.com/iTwin/stratakit/pull/709): Introduce `unstable_AccordionItem.Heading` component for wrapping `unstable_AccordionItem.Button` and `unstable_AccordionItem.Button` which represents the underlying `<button>` element.
 - Updated dependencies:
   - @stratakit/foundations@0.1.4
 
 ## 0.1.1
 
-- [#704](https://github.com/iTwin/design-system/pull/704): The following components have been moved from `@stratakit/bricks` into `@stratakit/structures`.
+- [#704](https://github.com/iTwin/stratakit/pull/704): The following components have been moved from `@stratakit/bricks` into `@stratakit/structures`.
   - `unstable_AccordionItem`
   - `unstable_Banner`
   - `Chip`

--- a/packages/structures/package.json
+++ b/packages/structures/package.json
@@ -99,10 +99,10 @@
 	],
 	"description": "Medium-sized component structures for the Strata design system",
 	"author": "Bentley Systems",
-	"homepage": "https://github.com/iTwin/design-system",
+	"homepage": "https://github.com/iTwin/stratakit",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/iTwin/design-system.git",
+		"url": "https://github.com/iTwin/stratakit.git",
 		"directory": "packages/structures"
 	},
 	"keywords": [

--- a/packages/structures/src/Table.tsx
+++ b/packages/structures/src/Table.tsx
@@ -229,7 +229,7 @@ const TableBody = forwardRef<"div", TableBodyProps>((props, forwardedRef) => {
 	return (
 		<Role.div
 			render={render}
-			role={undefined} // Intentionally not using "rowgroup" https://github.com/iTwin/design-system/pull/243#discussion_r1947045668
+			role={undefined} // Intentionally not using "rowgroup" https://github.com/iTwin/stratakit/pull/243#discussion_r1947045668
 			{...props}
 			ref={forwardedRef}
 			className={cx("🥝TableBody", props.className)}


### PR DESCRIPTION
Updates all code references of `iTwin/design-system` to `iTwin/stratakit`, reflecting the repo rename.