### PR TITLE
Add-back `Switch` docs

### DIFF
--- a/apps/website/src/content/docs/components/Switch.md
+++ b/apps/website/src/content/docs/components/Switch.md
@@ -24,6 +24,8 @@ Make sure the **Switch** is suitable for your use case. There may be other, more
 
 ### Checked
 
+Use a `defaultChecked` prop to set the initial checked state. Alternatively, use `checked` and `onChange` props to control the checked state.
+
 ::example{src="mui/Switch.checked"}
 
 ## ✅ Do


### PR DESCRIPTION
Added back docs from https://github.com/iTwin/design-system/blob/docs-original/apps/website/src/content/docs/components/Switch.md with new MUI examples.

[Deploy preview](http://itwin.github.io/stratakit/1205/docs/components/switch/)