### PR TITLE
docs: fix canonical URL

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -51,6 +51,7 @@ jobs:
     env:
       BASE_FOLDER: ${{ needs.paths.outputs.BASE_FOLDER }}
       CLEAN_EXCLUDE: ${{ needs.paths.outputs.PRESERVE_FOLDERS }}
+      GH_PAGES_URL: ${{ vars.GH_PAGES_URL }}
 
     steps:
       - uses: actions/checkout@v6

--- a/apps/test-app/app/index.tsx
+++ b/apps/test-app/app/index.tsx
@@ -41,7 +41,7 @@ export default function Index() {
 					</Anchor>
 				</li>
 				<li>
-					<Anchor href="/docs">Documentation</Anchor>
+					<Anchor href={useHref("/docs")}>Documentation</Anchor>
 				</li>
 			</ul>
 

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -10,10 +10,26 @@ const BASE_URL = process.env.BASE_FOLDER
 	? `/${process.env.BASE_FOLDER}/docs`
 	: "/docs";
 
+const PROD_SITE_URL = process.env.GH_PAGES_URL;
+const DEV_PORT = 4321;
+
+/** `site` URL must only include the origin. */
+const site = PROD_SITE_URL
+	? new URL(PROD_SITE_URL).origin
+	: `http://localhost:${DEV_PORT}`;
+
+/** Combines the pathname from PROD_SITE_URL with BASE_URL. */
+const base = (() => {
+	const sitePathname = PROD_SITE_URL
+		? new URL(PROD_SITE_URL).pathname.replace(/\/$/, "")
+		: "";
+	return `${sitePathname}${BASE_URL}`;
+})();
+
 // https://astro.build/config
 export default defineConfig({
-	site: "https://supreme-barnacle-pl8jn8m.pages.github.io/",
-	base: BASE_URL,
+	site,
+	base,
 	integrations: [
 		starlight({
 			title: "StrataKit Docs",
@@ -78,6 +94,9 @@ export default defineConfig({
 			},
 		},
 		plugins: [vitePluginFixAstroSvg()],
+	},
+	server: {
+		port: DEV_PORT,
 	},
 });
 

--- a/apps/website/src/components/Head.astro
+++ b/apps/website/src/components/Head.astro
@@ -5,12 +5,29 @@ import StrataKit from "./StrataKit.astro";
 import Fonts from "./Fonts.astro";
 import CustomElements from "./CustomElements.astro";
 
-const { head } = Astro.locals.starlightRoute;
+const { head: originalHead } = Astro.locals.starlightRoute;
+
+// Strip BASE_FOLDER from canonical URLs to ensure they always point to the main URL.
+// This is to prevent search engines from indexing temporary preview deployments.
+const BASE_FOLDER = process.env.BASE_FOLDER;
+const fixedHead = originalHead.map((item) => {
+	if (
+		BASE_FOLDER &&
+		item.tag === "link" &&
+		item.attrs?.rel === "canonical" &&
+		typeof item.attrs?.href === "string"
+	) {
+		const url = new URL(item.attrs.href);
+		url.pathname = url.pathname.replace(`/${BASE_FOLDER}`, "");
+		return { ...item, attrs: { ...item.attrs, href: url.toString() } };
+	}
+	return item;
+});
 ---
 
 <StrataKit />
 <Fonts />
 
-{head.map(({ tag: Tag, attrs, content }) => <Tag {...attrs} set:html={content} />)}
+{fixedHead.map(({ tag: Tag, attrs, content }) => <Tag {...attrs} set:html={content} />)}
 
 <CustomElements />

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -15,9 +15,7 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 			actions: [
 				{
 					text: "Getting started",
-					link: import.meta.env.DEV
-						? `${import.meta.env.BASE_URL}/getting-started`
-						: "getting-started",
+					link: "getting-started",
 					icon: "right-arrow",
 				},
 				{


### PR DESCRIPTION
As this repo + the docs website is going public, the content will soon start getting indexed by search engines. For best search results, we need to ensure that the [canonical URL](https://en.wikipedia.org/wiki/Canonical_link_element) is always correct.

### Changes

1. Updated the [`site`](https://docs.astro.build/en/reference/configuration-reference/#site) property to use the existing `GH_PAGES_URL` [workflow variable](https://docs.github.com/en/actions/concepts/workflows-and-actions/variables) instead of hardcoding the temporary private URL.
   - This URL is currently set to `https://supreme-barnacle-pl8jn8m.pages.github.io/` but can be changed to `https://itwin.github.io/stratakit` when the repo becomes public.
   - Added `GH_PAGES_URL` to environment variables in the deploy job.
2. Updated the [`base`](https://docs.astro.build/en/reference/configuration-reference/#base) property to include the `pathname` of `site`. See [comment](https://github.com/iTwin/stratakit/pull/1207#discussion_r2765901841).
3. Updated the `Head` component to strip PR numbers from the canonical URL (to prevent _branch deploy previews_ from getting indexed).
4. Removed conditional value of `hero.actions.link` from [#1201](https://github.com/iTwin/stratakit/pull/1201) (does not seem to be necessary anymore).

### Output

Before:
```html
<link rel="canonical" href="https://supreme-barnacle-pl8jn8m.pages.github.io/1207/docs/getting-started/">
```

After:
```html
<link rel="canonical" href="https://supreme-barnacle-pl8jn8m.pages.github.io/docs/getting-started/">
```

[Deploy preview](https://itwin.github.io/stratakit/1207/docs/getting-started/)