### PR TITLE
fix GHSA-7h2j-956f-4vf2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1753,10 +1753,10 @@ packages:
       }
     engines: { node: 20 || >=22 }
 
-  "@isaacs/brace-expansion@5.0.0":
+  "@isaacs/brace-expansion@5.0.1":
     resolution:
       {
-        integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==,
+        integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==,
       }
     engines: { node: 20 || >=22 }
 
@@ -6649,7 +6649,7 @@ snapshots:
 
   "@isaacs/balanced-match@4.0.1": {}
 
-  "@isaacs/brace-expansion@5.0.0":
+  "@isaacs/brace-expansion@5.0.1":
     dependencies:
       "@isaacs/balanced-match": 4.0.1
 
@@ -8642,7 +8642,7 @@ snapshots:
 
   minimatch@10.1.1:
     dependencies:
-      "@isaacs/brace-expansion": 5.0.0
+      "@isaacs/brace-expansion": 5.0.1
 
   mrmime@2.0.1: {}
 


### PR DESCRIPTION
Bumped `@isaacs/brace-expansion` from 5.0.0 to 5.0.1 to fix https://github.com/advisories/GHSA-7h2j-956f-4vf2 / CVE-2026-25547.

I just want the green checkmark in CI 🥺