### PR TITLE
test-app: StrataKit logo flourish

### DIFF
--- a/apps/test-app/app/~navigation.module.css
+++ b/apps/test-app/app/~navigation.module.css
@@ -22,7 +22,19 @@
 }
 
 .homeLink {
-	margin-inline: calc(-1 * var(--stratakit-space-x1)); /* to counteract the ghost padding */
+	margin-inline: -3.5px; /* for optical alignment */
+}
+
+.strataLogo {
+	--_shadow: drop-shadow(0px 0.5px 0px oklch(0% none none / 0.56))
+		drop-shadow(0px 1px 2px oklch(0% none none / 0.4));
+
+	[data-color-scheme="light"] & {
+		--_shadow: drop-shadow(0px 2px 4px oklch(0% none none / 0.04))
+			drop-shadow(0px 1px 2px oklch(0% none none / 0.24));
+	}
+
+	filter: var(--_shadow);
 }
 
 .appNav {

--- a/apps/test-app/app/~navigation.tsx
+++ b/apps/test-app/app/~navigation.tsx
@@ -23,7 +23,6 @@ import svgMoon from "@stratakit/icons/moon.svg";
 import svgProducts from "@stratakit/icons/products.svg";
 import svgSun from "@stratakit/icons/sun.svg";
 import svgSwatch from "@stratakit/icons/swatch.svg";
-import strataKitLogo from "internal/stratakit-logo.svg";
 import styles from "./~navigation.module.css";
 
 // ----------------------------------------------------------------------------
@@ -98,7 +97,7 @@ export function AppNavigationRail(props: AppNavigationRailProps) {
 					</Button>
 					<IconButton
 						label="Home"
-						icon={<Icon href={`${strataKitLogo}#icon`} size="large" />}
+						icon={<StrataKitLogo />}
 						render={<RegularLink to="/" />}
 						variant="ghost"
 						className={styles.homeLink}
@@ -157,6 +156,53 @@ export function AppNavigationRail(props: AppNavigationRailProps) {
 }
 
 // ----------------------------------------------------------------------------
+
+function StrataKitLogo() {
+	const basePathId = React.useId();
+	const gradientId = React.useId();
+
+	const defs = (
+		<defs>
+			<path
+				id={basePathId}
+				d="M8.03 16.9h9.68l2.42 2.42v.81H6.42L4 17.71v-2.42h2.42zm0-6.45h9.68l2.42 2.42v2.42h-2.42l-1.61-1.61H6.42L4 11.26V8.84h2.42zm12.1-4.03v2.42h-2.42L16.1 7.23H6.42L4 4.8V4h13.71z"
+			/>
+
+			<linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+				<stop offset="0" stopOpacity="0" />
+				<stop offset="1" />
+			</linearGradient>
+		</defs>
+	);
+
+	return (
+		<Icon
+			size="large"
+			className={styles.strataLogo}
+			render={
+				<svg width={24} height={24} fill="none" viewBox="0 0 24 24">
+					{defs}
+					<g>
+						<use
+							href={`#${basePathId}`}
+							fill="var(--stratakit-color-brand-logo-fill)"
+						/>
+						<use
+							href={`#${basePathId}`}
+							fill={`url(#${gradientId})`}
+							fillOpacity=".24"
+						/>
+						<use
+							href={`#${basePathId}`}
+							stroke="var(--stratakit-color-brand-logo-stroke)"
+							strokeWidth={0.5}
+						/>
+					</g>
+				</svg>
+			}
+		/>
+	);
+}
 
 function MuiLogo() {
 	return (


### PR DESCRIPTION
_(Follow-on to #1184 and #1187)_

This PR updates the navigationRail in the test-app to use an improved version of the Strata logo, which has been inlined in the JSX and now includes:
- custom fill (`--stratakit-color-brand-logo-fill`)
- a stroke around the individual lines (`0.5px` with `--stratakit-color-brand-logo-stroke`)
- a linear-gradient across the lines (transparent to `#000 / 24%`)
- a drop-shadow (based on `--stratakit-shadow-brand-logo-base`, which I couldn't use directly because it's a `filter`).

These are the same decorations that we expect products to use with the Bentley logo in the PlatformBar. (We should make it easier to do so and provide some documentation in the future)

### Preview

[Deploy preview](https://itwin.github.io/stratakit/1225)

| Light | Dark |
| --- | --- |
| <img height="200" alt="image" src="https://github.com/user-attachments/assets/bf7c9d6f-e6eb-4425-9334-a74464b2aae6" /> | <img height="200" alt="image" src="https://github.com/user-attachments/assets/4689043e-a0a2-4a4a-b599-d6c231668c70" /> |