### PR TITLE
Add "maintenance mode" badge to `docs/reference` page

### DIFF
--- a/apps/website/src/pages/reference/index.astro
+++ b/apps/website/src/pages/reference/index.astro
@@ -28,7 +28,7 @@ const headings = packages.map((pkg) => ({
 				<>
 					<AnchorHeading level={heading.depth} id={heading.slug}>
 						{heading.text}{" "}
-						{pkg.id !== "structures" && <Badge variant="danger" text="Maintenance mode" />}
+						{pkg.id === "bricks" && <Badge variant="danger" text="Maintenance mode" />}
 					</AnchorHeading>
 					<ul>
 						{pkg.data.apis.map((api) => {


### PR DESCRIPTION
This PR adds "Maintenance mode" badge to `docs/reference` page, similar to `docs/examples`.

[Deploy preview](http://itwin.github.io/stratakit/1230/docs/reference/)