### PR TITLE
Separate files for components CSS

### DIFF
--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -3,6 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+@import "./~components/MuiAutocomplete.css";
+@import "./~components/MuiButton.css";
+@import "./~components/MuiCard.css";
+@import "./~components/MuiCheckbox.css";
+@import "./~components/MuiForm.css";
+@import "./~components/MuiInput.css";
+@import "./~components/MuiTabs.css";
+
 .MuiAccordion-root {
 	background-color: transparent;
 }
@@ -11,247 +19,11 @@
 	align-items: center; /* Fix vertical alignment of differently sized icons */
 }
 
-.MuiAutocomplete-input {
-	:where(.MuiAutocomplete-hasPopupIcon) & {
-		padding-inline-end: calc(9px + 20px); /* 9px gap + 20px dropdown button width */
-	}
-
-	:where(.MuiAutocomplete-hasClearIcon) & {
-		padding-inline-end: calc(
-			9px +
-			20px +
-			24px
-		); /* 9px gap + 20px dropdown button width + 24px clear button width */
-	}
-}
-
-.MuiAutocomplete-tag {
-	margin-inline-start: var(--stratakit-space-x1);
-	margin-inline-end: 0;
-
-	&:where(:nth-child(1 of &)) {
-		margin-inline-start: var(--stratakit-space-x2);
-	}
-
-	&:where(:nth-last-child(1 of &)) {
-		margin-inline-end: var(--stratakit-space-x2);
-	}
-}
-
-.MuiAutocomplete-clearIndicator {
-	visibility: visible;
-}
-
 .MuiAppBar-root {
 	background-color: var(--stratakit-color-bg-page-base);
 	box-shadow: none;
 	border-block-end: 1px solid var(--stratakit-color-border-page-base);
 	color: var(--stratakit-color-text-neutral-primary);
-}
-
-.MuiButtonBase-root {
-	&:where(.Mui-disabled) {
-		cursor: not-allowed;
-		pointer-events: auto; /* Revert MUI's disabled pointer-events */
-		background-color: transparent; /* To prevent hover styles from leaking through */
-	}
-}
-
-.MuiButton-root {
-	&:where(.MuiButton-colorSecondary) {
-		--variant-containedBg: var(--stratakit-color-bg-neutral-base);
-		--variant-containedColor: var(--stratakit-color-text-neutral-primary);
-		--variant-outlinedColor: var(--stratakit-color-text-neutral-primary);
-		--variant-textColor: var(--stratakit-color-text-neutral-primary);
-
-		@media (any-hover: hover) {
-			&:where(:hover) {
-				--variant-containedBg: color-mix(
-					in oklch,
-					var(--stratakit-color-bg-neutral-base) 100%,
-					var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%)
-				);
-			}
-		}
-	}
-
-	&:where(.MuiButton-colorPrimary) {
-		--variant-outlinedColor: var(--stratakit-color-text-accent-strong);
-		--variant-textColor: var(--stratakit-color-text-accent-strong);
-	}
-
-	&:where(.MuiButton-contained) {
-		&:where(.Mui-disabled) {
-			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
-		}
-	}
-}
-
-.MuiCard-root {
-	background-color: var(--stratakit-color-bg-elevation-base);
-}
-
-.MuiCardContent-root {
-	&:where(:has(+ .MuiCardActions-root)) {
-		padding-block-end: 0;
-	}
-}
-
-.MuiCardActions-root {
-	padding: var(--stratakit-space-x4);
-}
-
-:is(.MuiCheckbox-root, .MuiRadio-root) {
-	--_hover-background-color: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
-
-	&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
-		--_hover-background-color: var(--stratakit-color-bg-glow-on-surface-accent-hover);
-	}
-
-	:where(.Mui-error) & {
-		--_hover-background-color: var(--stratakit-color-bg-glow-on-surface-critical-hover);
-	}
-
-	@media (any-hover: hover) {
-		&:where(:not(.Mui-disabled)):hover {
-			background-color: var(--_hover-background-color);
-		}
-	}
-
-	> input {
-		--✨unchecked-svg: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');
-
-		appearance: none;
-		opacity: 1;
-		aspect-ratio: 1;
-		inline-size: 1rem;
-		block-size: 1rem;
-		background-color: var(--stratakit-color-bg-neutral-base);
-		border: 1px solid var(--stratakit-color-border-shadow-base);
-		color: var(--stratakit-color-icon-neutral-emphasis);
-		position: relative;
-		--_check-symbol-mask-image: var(--✨unchecked-svg);
-
-		&::after {
-			content: "";
-			position: absolute;
-			inset: 0px;
-			background-color: currentColor;
-			mask-repeat: no-repeat;
-			mask-position: center;
-			mask-image: var(--_check-symbol-mask-image);
-		}
-
-		:where(.Mui-checked, .MuiCheckbox-indeterminate) & {
-			background-color: var(--stratakit-color-bg-accent-base);
-			border-color: var(--stratakit-color-border-shadow-strong);
-			color: var(--stratakit-color-icon-neutral-emphasis);
-		}
-
-		:where(.Mui-error) & {
-			background-color: var(--stratakit-color-bg-neutral-base);
-			border-color: var(--stratakit-color-border-critical-base);
-			color: var(--stratakit-color-icon-neutral-primary);
-		}
-
-		:where(.Mui-disabled) & {
-			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
-			border-color: var(--stratakit-color-border-glow-on-surface-disabled);
-			color: var(--stratakit-color-icon-neutral-disabled);
-		}
-	}
-
-	&:where(.MuiCheckbox-root) > input {
-		--✨checked-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M11.73 5.47a.75.75 0 0 1 0 1.06l-4.4 4.4a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06L6.8 9.34l3.87-3.87a.75.75 0 0 1 1.06 0Z"/></svg>');
-		--✨indeterminate-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M4.25 8A.75.75 0 0 1 5 7.25h6.5a.75.75 0 0 1 0 1.5H5A.75.75 0 0 1 4.25 8Z"/></svg>');
-
-		border-radius: var(--stratakit-mui-shape-borderRadius);
-
-		:where(.Mui-checked) & {
-			--_check-symbol-mask-image: var(--✨checked-svg);
-		}
-
-		:where(.MuiCheckbox-indeterminate) & {
-			--_check-symbol-mask-image: var(--✨indeterminate-svg);
-		}
-	}
-
-	&:where(.MuiRadio-root) > input {
-		--✨checked-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" ><circle cx="8" cy="8" r="4" /></svg>');
-
-		border-radius: 50%;
-
-		:where(.Mui-checked) & {
-			--_check-symbol-mask-image: var(--✨checked-svg);
-		}
-	}
-}
-
-.MuiFormControl-root {
-	row-gap: var(--stratakit-space-x1);
-}
-
-.MuiFormControlLabel-root:where(.Mui-disabled) {
-	cursor: not-allowed;
-}
-
-.MuiFormControlLabel-label {
-	@apply --typography("body-md");
-}
-
-.MuiFormHelperText-root {
-	inline-size: fit-content;
-	margin: 0;
-	@apply --typography("body-sm");
-
-	&:where(.Mui-error) {
-		color: var(--stratakit-color-text-critical-base);
-		position: relative;
-
-		&::before,
-		&::after {
-			content: "";
-			display: inline-block;
-			block-size: 1lh;
-			aspect-ratio: 1;
-			vertical-align: top;
-		}
-
-		&::before {
-			--_octagon-filled: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="currentColor" d="M10.086 2H5.914a1 1 0 0 0-.707.293L2.293 5.207A1 1 0 0 0 2 5.914v4.237a1 1 0 0 0 .3.715l2.908 2.848a1 1 0 0 0 .7.286h4.178a1 1 0 0 0 .707-.293l2.914-2.914a1 1 0 0 0 .293-.707V5.914a1 1 0 0 0-.293-.707l-2.914-2.914A1 1 0 0 0 10.086 2Z" /></svg>');
-			--_❗: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="black" fill-opacity=".48" d="M8.875 10.625a.875.875 0 1 0-1.75 0 .875.875 0 0 0 1.75 0ZM8 4a1.581 1.581 0 0 1 1.5 2.081l-.789 2.365c-.228.684-1.195.684-1.423 0L6.5 6.081A1.581 1.581 0 0 1 8 4Zm0 .5a1.08 1.08 0 0 0-1.025 1.423l.788 2.365a.25.25 0 0 0 .436.075l.039-.075.788-2.365a1.082 1.082 0 0 0-.89-1.415L8 4.5Zm1.375 6.125a1.375 1.375 0 1 1-2.75 0 1.375 1.375 0 0 1 2.75 0Z" /><path fill="white" d="M8.875 10.625a.875.875 0 1 1-1.75 0 .875.875 0 0 1 1.75 0ZM6.974 5.923l.789 2.366a.25.25 0 0 0 .474 0l.789-2.366a1.081 1.081 0 1 0-2.052 0Z" /></svg>');
-
-			mask: var(--_octagon-filled) no-repeat center;
-			background-color: var(--stratakit-color-bg-critical-base);
-
-			background-image: var(--_❗);
-			background-repeat: no-repeat;
-
-			margin-inline-end: var(--stratakit-space-x1);
-		}
-
-		&::after {
-			--_octagon-outline: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="currentColor" d="M10.086 2a1 1 0 0 1 .707.293l2.914 2.914a1 1 0 0 1 .293.707v4.172l-.005.099a1 1 0 0 1-.288.608l-2.914 2.914-.073.066a1 1 0 0 1-.634.227H5.908l-.097-.005a1 1 0 0 1-.53-.216l-.073-.064-2.908-2.85a1 1 0 0 1-.295-.614l-.005-.1V5.914a1 1 0 0 1 .227-.634l.066-.073 2.914-2.914A1 1 0 0 1 5.914 2h4.172ZM5.914 3 3 5.914v4.237L5.908 13h4.178L13 10.086V5.914L10.086 3H5.914Z" /></svg>');
-
-			position: absolute;
-			inset-inline-start: 0;
-			inset-block-start: 0;
-
-			mask: var(--_octagon-outline) no-repeat center;
-			background-color: var(--stratakit-color-border-glow-strong-default);
-		}
-	}
-}
-
-.MuiFormLabel-root {
-	font-size: var(--stratakit-font-size-14);
-	color: var(--stratakit-color-text-neutral-secondary);
-	position: relative; /* Disable floating label */
-	transform: none; /* Undo inset positioning */
-
-	&:where(.Mui-disabled) {
-		color: var(--stratakit-color-text-neutral-disabled);
-	}
 }
 
 .MuiChip-root {
@@ -279,68 +51,6 @@
 	}
 	&:where(.MuiIconButton-colorError) {
 		color: var(--stratakit-color-icon-critical-base);
-	}
-}
-
-.MuiInputBase-root {
-	padding: 0;
-	font: var(--stratakit-mui-font-body2);
-	border: 1px solid var(--stratakit-color-border-neutral-base);
-
-	&:where(:focus-within) {
-		border-color: var(--stratakit-color-border-accent-strong);
-		outline: var(--🥝focus-outline);
-		outline-offset: var(--🥝focus-outline-offset);
-	}
-
-	&:where(.Mui-error) {
-		border-color: var(--stratakit-color-border-critical-base);
-		--🥝Icon-color: var(--stratakit-color-icon-critical-base);
-	}
-
-	&:where(.Mui-disabled) {
-		border-color: var(--stratakit-color-border-glow-on-surface-disabled);
-		--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
-	}
-
-	:where(fieldset) {
-		display: none;
-	}
-}
-
-.MuiInputBase-input {
-	min-block-size: 36.5px;
-	padding-block: 0;
-	padding-inline: 14px;
-	align-content: center;
-
-	&:where(.MuiInputBase-inputMultiline) {
-		padding-block: 8.25px;
-		align-content: baseline;
-	}
-
-	&:where(.MuiInputBase-inputAdornedStart) {
-		padding-inline-start: 0;
-	}
-
-	&:where(.MuiInputBase-inputAdornedEnd) {
-		padding-inline-end: 0;
-	}
-
-	&:where(:focus-visible) {
-		outline: none !important;
-	}
-}
-
-.MuiInputAdornment-root {
-	&:where(.MuiInputAdornment-positionStart) {
-		margin-inline-start: var(--stratakit-space-x2);
-		margin-inline-end: var(--stratakit-space-x1);
-	}
-
-	&:where(.MuiInputAdornment-positionEnd) {
-		margin-inline-start: var(--stratakit-space-x1);
-		margin-inline-end: var(--stratakit-space-x2);
 	}
 }
 
@@ -402,22 +112,6 @@
 	}
 }
 
-.MuiTab-root {
-	&:where(.Mui-selected) {
-		color: var(--stratakit-color-text-accent-strong);
-	}
-	&:where(:focus-visible) {
-		outline-offset: -4px;
-	}
-}
-.MuiTabs-indicator {
-	background-color: var(--stratakit-color-border-accent-strong);
-}
-
-.MuiTooltip-tooltip {
-	box-shadow: var(--stratakit-shadow-control-tooltip-base);
-}
-
 .MuiSwitch-root {
 	.MuiSwitch-switchBase:where(.MuiSwitch-colorPrimary) {
 		&:where(.Mui-checked):where(:not(.Mui-disabled)) {
@@ -428,4 +122,8 @@
 	&:where(:has(.MuiSwitch-switchBase.Mui-focusVisible)) {
 		outline: 2px solid var(--stratakit-color-border-accent-strong);
 	}
+}
+
+.MuiTooltip-tooltip {
+	box-shadow: var(--stratakit-shadow-control-tooltip-base);
 }

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiAutocomplete-input {
+	:where(.MuiAutocomplete-hasPopupIcon) & {
+		padding-inline-end: calc(9px + 20px); /* 9px gap + 20px dropdown button width */
+	}
+
+	:where(.MuiAutocomplete-hasClearIcon) & {
+		padding-inline-end: calc(
+			9px +
+			20px +
+			24px
+		); /* 9px gap + 20px dropdown button width + 24px clear button width */
+	}
+}
+
+.MuiAutocomplete-tag {
+	margin-inline-start: var(--stratakit-space-x1);
+	margin-inline-end: 0;
+
+	&:where(:nth-child(1 of &)) {
+		margin-inline-start: var(--stratakit-space-x2);
+	}
+
+	&:where(:nth-last-child(1 of &)) {
+		margin-inline-end: var(--stratakit-space-x2);
+	}
+}
+
+.MuiAutocomplete-clearIndicator {
+	visibility: visible;
+}

--- a/packages/mui/src/~components/MuiButton.css
+++ b/packages/mui/src/~components/MuiButton.css
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiButtonBase-root {
+	&:where(.Mui-disabled) {
+		cursor: not-allowed;
+		pointer-events: auto; /* Revert MUI's disabled pointer-events */
+		background-color: transparent; /* To prevent hover styles from leaking through */
+	}
+}
+
+.MuiButton-root {
+	&:where(.MuiButton-colorSecondary) {
+		--variant-containedBg: var(--stratakit-color-bg-neutral-base);
+		--variant-containedColor: var(--stratakit-color-text-neutral-primary);
+		--variant-outlinedColor: var(--stratakit-color-text-neutral-primary);
+		--variant-textColor: var(--stratakit-color-text-neutral-primary);
+
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				--variant-containedBg: color-mix(
+					in oklch,
+					var(--stratakit-color-bg-neutral-base) 100%,
+					var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%)
+				);
+			}
+		}
+	}
+
+	&:where(.MuiButton-colorPrimary) {
+		--variant-outlinedColor: var(--stratakit-color-text-accent-strong);
+		--variant-textColor: var(--stratakit-color-text-accent-strong);
+	}
+
+	&:where(.MuiButton-contained) {
+		&:where(.Mui-disabled) {
+			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
+		}
+	}
+}

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiCard-root {
+	background-color: var(--stratakit-color-bg-elevation-base);
+}
+
+.MuiCardContent-root {
+	&:where(:has(+ .MuiCardActions-root)) {
+		padding-block-end: 0;
+	}
+}
+
+.MuiCardActions-root {
+	padding: var(--stratakit-space-x4);
+}

--- a/packages/mui/src/~components/MuiCheckbox.css
+++ b/packages/mui/src/~components/MuiCheckbox.css
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+:is(.MuiCheckbox-root, .MuiRadio-root) {
+	--_hover-background-color: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
+
+	&:where(.Mui-checked, .MuiCheckbox-indeterminate) {
+		--_hover-background-color: var(--stratakit-color-bg-glow-on-surface-accent-hover);
+	}
+
+	:where(.Mui-error) & {
+		--_hover-background-color: var(--stratakit-color-bg-glow-on-surface-critical-hover);
+	}
+
+	@media (any-hover: hover) {
+		&:where(:not(.Mui-disabled)):hover {
+			background-color: var(--_hover-background-color);
+		}
+	}
+
+	> input {
+		--✨unchecked-svg: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');
+
+		appearance: none;
+		opacity: 1;
+		aspect-ratio: 1;
+		inline-size: 1rem;
+		block-size: 1rem;
+		background-color: var(--stratakit-color-bg-neutral-base);
+		border: 1px solid var(--stratakit-color-border-shadow-base);
+		color: var(--stratakit-color-icon-neutral-emphasis);
+		position: relative;
+		--_check-symbol-mask-image: var(--✨unchecked-svg);
+
+		&::after {
+			content: "";
+			position: absolute;
+			inset: 0px;
+			background-color: currentColor;
+			mask-repeat: no-repeat;
+			mask-position: center;
+			mask-image: var(--_check-symbol-mask-image);
+		}
+
+		:where(.Mui-checked, .MuiCheckbox-indeterminate) & {
+			background-color: var(--stratakit-color-bg-accent-base);
+			border-color: var(--stratakit-color-border-shadow-strong);
+			color: var(--stratakit-color-icon-neutral-emphasis);
+		}
+
+		:where(.Mui-error) & {
+			background-color: var(--stratakit-color-bg-neutral-base);
+			border-color: var(--stratakit-color-border-critical-base);
+			color: var(--stratakit-color-icon-neutral-primary);
+		}
+
+		:where(.Mui-disabled) & {
+			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
+			border-color: var(--stratakit-color-border-glow-on-surface-disabled);
+			color: var(--stratakit-color-icon-neutral-disabled);
+		}
+	}
+
+	&:where(.MuiCheckbox-root) > input {
+		--✨checked-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M11.73 5.47a.75.75 0 0 1 0 1.06l-4.4 4.4a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06L6.8 9.34l3.87-3.87a.75.75 0 0 1 1.06 0Z"/></svg>');
+		--✨indeterminate-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M4.25 8A.75.75 0 0 1 5 7.25h6.5a.75.75 0 0 1 0 1.5H5A.75.75 0 0 1 4.25 8Z"/></svg>');
+
+		border-radius: var(--stratakit-mui-shape-borderRadius);
+
+		:where(.Mui-checked) & {
+			--_check-symbol-mask-image: var(--✨checked-svg);
+		}
+
+		:where(.MuiCheckbox-indeterminate) & {
+			--_check-symbol-mask-image: var(--✨indeterminate-svg);
+		}
+	}
+
+	&:where(.MuiRadio-root) > input {
+		--✨checked-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" ><circle cx="8" cy="8" r="4" /></svg>');
+
+		border-radius: 50%;
+
+		:where(.Mui-checked) & {
+			--_check-symbol-mask-image: var(--✨checked-svg);
+		}
+	}
+}

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiFormControl-root {
+	row-gap: var(--stratakit-space-x1);
+}
+
+.MuiFormControlLabel-root:where(.Mui-disabled) {
+	cursor: not-allowed;
+}
+
+.MuiFormControlLabel-label {
+	@apply --typography("body-md");
+}
+
+.MuiFormHelperText-root {
+	inline-size: fit-content;
+	margin: 0;
+	@apply --typography("body-sm");
+
+	&:where(.Mui-error) {
+		color: var(--stratakit-color-text-critical-base);
+		position: relative;
+
+		&::before,
+		&::after {
+			content: "";
+			display: inline-block;
+			block-size: 1lh;
+			aspect-ratio: 1;
+			vertical-align: top;
+		}
+
+		&::before {
+			--_octagon-filled: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="currentColor" d="M10.086 2H5.914a1 1 0 0 0-.707.293L2.293 5.207A1 1 0 0 0 2 5.914v4.237a1 1 0 0 0 .3.715l2.908 2.848a1 1 0 0 0 .7.286h4.178a1 1 0 0 0 .707-.293l2.914-2.914a1 1 0 0 0 .293-.707V5.914a1 1 0 0 0-.293-.707l-2.914-2.914A1 1 0 0 0 10.086 2Z" /></svg>');
+			--_❗: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="black" fill-opacity=".48" d="M8.875 10.625a.875.875 0 1 0-1.75 0 .875.875 0 0 0 1.75 0ZM8 4a1.581 1.581 0 0 1 1.5 2.081l-.789 2.365c-.228.684-1.195.684-1.423 0L6.5 6.081A1.581 1.581 0 0 1 8 4Zm0 .5a1.08 1.08 0 0 0-1.025 1.423l.788 2.365a.25.25 0 0 0 .436.075l.039-.075.788-2.365a1.082 1.082 0 0 0-.89-1.415L8 4.5Zm1.375 6.125a1.375 1.375 0 1 1-2.75 0 1.375 1.375 0 0 1 2.75 0Z" /><path fill="white" d="M8.875 10.625a.875.875 0 1 1-1.75 0 .875.875 0 0 1 1.75 0ZM6.974 5.923l.789 2.366a.25.25 0 0 0 .474 0l.789-2.366a1.081 1.081 0 1 0-2.052 0Z" /></svg>');
+
+			mask: var(--_octagon-filled) no-repeat center;
+			background-color: var(--stratakit-color-bg-critical-base);
+
+			background-image: var(--_❗);
+			background-repeat: no-repeat;
+
+			margin-inline-end: var(--stratakit-space-x1);
+		}
+
+		&::after {
+			--_octagon-outline: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="currentColor" d="M10.086 2a1 1 0 0 1 .707.293l2.914 2.914a1 1 0 0 1 .293.707v4.172l-.005.099a1 1 0 0 1-.288.608l-2.914 2.914-.073.066a1 1 0 0 1-.634.227H5.908l-.097-.005a1 1 0 0 1-.53-.216l-.073-.064-2.908-2.85a1 1 0 0 1-.295-.614l-.005-.1V5.914a1 1 0 0 1 .227-.634l.066-.073 2.914-2.914A1 1 0 0 1 5.914 2h4.172ZM5.914 3 3 5.914v4.237L5.908 13h4.178L13 10.086V5.914L10.086 3H5.914Z" /></svg>');
+
+			position: absolute;
+			inset-inline-start: 0;
+			inset-block-start: 0;
+
+			mask: var(--_octagon-outline) no-repeat center;
+			background-color: var(--stratakit-color-border-glow-strong-default);
+		}
+	}
+}
+
+.MuiFormLabel-root {
+	font-size: var(--stratakit-font-size-14);
+	color: var(--stratakit-color-text-neutral-secondary);
+	position: relative; /* Disable floating label */
+	transform: none; /* Undo inset positioning */
+
+	&:where(.Mui-disabled) {
+		color: var(--stratakit-color-text-neutral-disabled);
+	}
+}

--- a/packages/mui/src/~components/MuiInput.css
+++ b/packages/mui/src/~components/MuiInput.css
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiInputBase-root {
+	padding: 0;
+	font: var(--stratakit-mui-font-body2);
+	border: 1px solid var(--stratakit-color-border-neutral-base);
+
+	&:where(:focus-within) {
+		border-color: var(--stratakit-color-border-accent-strong);
+		outline: var(--🥝focus-outline);
+		outline-offset: var(--🥝focus-outline-offset);
+	}
+
+	&:where(.Mui-error) {
+		border-color: var(--stratakit-color-border-critical-base);
+		--🥝Icon-color: var(--stratakit-color-icon-critical-base);
+	}
+
+	&:where(.Mui-disabled) {
+		border-color: var(--stratakit-color-border-glow-on-surface-disabled);
+		--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
+	}
+
+	:where(fieldset) {
+		display: none;
+	}
+}
+
+.MuiInputBase-input {
+	min-block-size: 36.5px;
+	padding-block: 0;
+	padding-inline: 14px;
+	align-content: center;
+
+	&:where(.MuiInputBase-inputMultiline) {
+		padding-block: 8.25px;
+		align-content: baseline;
+	}
+
+	&:where(.MuiInputBase-inputAdornedStart) {
+		padding-inline-start: 0;
+	}
+
+	&:where(.MuiInputBase-inputAdornedEnd) {
+		padding-inline-end: 0;
+	}
+
+	&:where(:focus-visible) {
+		outline: none !important;
+	}
+}
+
+.MuiInputAdornment-root {
+	&:where(.MuiInputAdornment-positionStart) {
+		margin-inline-start: var(--stratakit-space-x2);
+		margin-inline-end: var(--stratakit-space-x1);
+	}
+
+	&:where(.MuiInputAdornment-positionEnd) {
+		margin-inline-start: var(--stratakit-space-x1);
+		margin-inline-end: var(--stratakit-space-x2);
+	}
+}

--- a/packages/mui/src/~components/MuiTabs.css
+++ b/packages/mui/src/~components/MuiTabs.css
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiTab-root {
+	&:where(.Mui-selected) {
+		color: var(--stratakit-color-text-accent-strong);
+	}
+	&:where(:focus-visible) {
+		outline-offset: -4px;
+	}
+}
+
+.MuiTabs-indicator {
+	background-color: var(--stratakit-color-border-accent-strong);
+}


### PR DESCRIPTION
- Separate files for component CSS within `/~components/`.  Only components with multiple selectors or many lines, others remain within `~components.css`.  Suggestions comes from https://github.com/iTwin/stratakit/pull/1218#discussion_r2799363026.
- Alphabetically sort those remaining in `~components.css`.