### PR TITLE
test-app: fix basename (again)

### DIFF
--- a/apps/test-app/vite.config.ts
+++ b/apps/test-app/vite.config.ts
@@ -33,13 +33,13 @@ const basename = (() => {
 	if (!GH_PAGES_URL) return undefined;
 
 	const sitePathname = GH_PAGES_URL
-		? new URL(GH_PAGES_URL).pathname.replace(/\/$/, "")
+		? new URL(GH_PAGES_URL).pathname.replace(/^\/|\/$/g, "")
 		: undefined;
 
 	if (!sitePathname && !BASE_FOLDER) return undefined;
 
 	// basename must start with "/" AND end with "/".
-	return `${[sitePathname, BASE_FOLDER].join("/")}/`;
+	return `/${[sitePathname, BASE_FOLDER].filter(Boolean).join("/")}/`;
 })();
 
 const customConditions = isDev ? ["@stratakit/source"] : [];


### PR DESCRIPTION
#1249 fixed the `basename` for branch previews, but the main branch was still broken (it was resulting in two slashes at the end because `BASE_FOLDER` was empty).

The trailing and leading slashes are now removed from the `sitePathname` intermediate variable, and then re-added in the return value. The `join()` operation also uses `filter(Boolean)` to prevent extra slashes.