### PR TITLE
Fix live examples

### DIFF
--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -167,7 +167,7 @@ function starlightLiveExamples() {
 					node.children = [
 						{
 							type: "html",
-							value: `<iframe src=${`${BASE_URL}/examples/${src}?preview`} title="${src} example" height="150"></iframe>`,
+							value: `<iframe src=${`${base}/examples/${src}?preview`} title="${src} example" height="150"></iframe>`,
 						},
 					];
 				}


### PR DESCRIPTION
This PR fixes live example embeddings in the docs site. Currently examples are resolved to `https://itwin.github.io/docs/examples/mui/Accordion.default?preview` instead of `https://itwin.github.io/stratakit/docs/examples/mui/Accordion.default?preview`.

[Deploy preview](https://itwin.github.io/stratakit/1251/docs/components/accordion/)