### PR TITLE
docs: add "View source" link to examples

### DIFF
--- a/apps/website/src/components/ExamplePreview.module.css
+++ b/apps/website/src/components/ExamplePreview.module.css
@@ -22,7 +22,6 @@
 	.toolbar {
 		place-self: end;
 		display: flex;
-		gap: 4px;
 		padding: 4px;
 	}
 }

--- a/apps/website/src/components/ExamplePreview.tsx
+++ b/apps/website/src/components/ExamplePreview.tsx
@@ -7,10 +7,14 @@ import { IconButton } from "@stratakit/bricks";
 import { Root } from "@stratakit/mui";
 import { useColorScheme } from "./~utils.ts";
 
+import svgScript from "@stratakit/icons/script.svg";
 import svgWindowPopout from "@stratakit/icons/window-popout.svg";
 import styles from "./ExamplePreview.module.css";
 
 // ----------------------------------------------------------------------------
+
+/** Base URL for the `examples` workspace package on github */
+const examplesSrcUrl = "https://github.com/iTwin/stratakit/tree/main/examples/";
 
 // Pre-calculate all example modules so Vite can statically analyze them for bundling.
 // This requires that the path to examples dir is hardcoded (i.e. no dynamic expressions).
@@ -51,6 +55,12 @@ export function ExampleEmbed({ src }: { src: string }) {
 							target="_blank"
 						/>
 					}
+				/>
+				<IconButton
+					icon={svgScript}
+					label="View source on GitHub"
+					variant="ghost"
+					render={<a href={`${examplesSrcUrl}${src}.tsx`} target="_blank" />}
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
Follow-on to #1240. This PR updates the ExamplePreview to add a "View source" link in the bottom-end corner. This uses the `IconButton` component, which has a built-in tooltip, rendered as an `<a>` element pointing to the example source file on GitHub.

<img height="150" alt="Screenshot showing a script icon being hovered with a tooltip that says View source on GitHub" src="https://github.com/user-attachments/assets/2f663323-0605-4fd2-994d-79d68e17fd07" />

While this is a surprisingly small change, it was quite a journey getting to this point. I'm crediting @FlyersPh9 for proposing this simple, low-tech solution that gets us 90% of the way there. I'll describe the alternatives below for posterity.

### Alternatives considered

The original UX flow that I was working on involved displaying the source code within the page. The code would be toggled on/off by the same IconButton that is currently linking to the GitHub source (except it would use the disclosure pattern).

The ideal solution would use [Astro content loaders](https://github.com/iTwin/stratakit/blob/7a972af085c4f8e793570b6781dfbfccf4970013/apps/website/src/content.config.ts#L35) for reading the example source, and pass it through Astro's built-in syntax highlighter (which is configured by Starlight to use [Expressive Code](https://expressive-code.com/)). However, the `::example` directives are processed by a Remark plugin which simply renders the `<example-embed>` custom element and does not have access to the Astro rendering pipeline. Making this solution work would likely involve using MDX, which is undesirable due to the complexity it entails.

All the other solutions considered were problematic in different ways:
- Reading the example source in the Astro config and rendering code snippets in the remark plugin. This is undesirable, has major limitations, and would be a backwards move (since we are intentionally moving UI logic out of the config file).
- Lazy-importing example sources using Vite's `?raw` param. I did have a working proof-of-concept implementation, but this bloats up the client bundle size and prevents us from using Astro's syntax highlighting.
- Injecting hidden code snippets into the page using Astro (likely rendering `<template>` elements that can be cloned by `<example-embed>`). This solves both of the previous issues but it does requires precalculating all the examples used on the page, which might not be trivial.
- Using middleware to prepopulate the contents of `<example-embed>`. This gives us full control over what gets generated, meaning we could parse the existing HTML, read from content loaders, inject new elements, etc. But we still lose Astro's built-in syntax highlighting.