### PR TITLE
update pnpm

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - name: Use Node 22.x
         uses: actions/setup-node@v6
@@ -38,7 +38,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - name: Use Node 22.x
         uses: actions/setup-node@v6
@@ -59,7 +59,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - uses: biomejs/setup-biome@v2
 
@@ -96,7 +96,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - name: Use Node 22.x
         uses: actions/setup-node@v6
@@ -129,7 +129,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - run: pnpm install
       - run: pnpm run build
@@ -155,7 +155,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - run: pnpm install
       - run: pnpm run build

--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - name: Use Node 22.x
         uses: actions/setup-node@v6

--- a/.github/workflows/changeset-release.yaml
+++ b/.github/workflows/changeset-release.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - name: Use Node 22.x
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - name: Use Node 22.x
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 10.30.1
 
       - name: Use Node 22.x
         uses: actions/setup-node@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Welcome to the contribution guide for StrataKit! In here you will find all the i
 
 ### Local setup
 
-To clone and build the repo locally, you'll need [Git](https://git-scm.com), [Node 22+](https://nodejs.org/en/download/), and [Pnpm 9](https://pnpm.io/installation) installed on your computer.
+To clone and build the repo locally, you'll need [Git](https://git-scm.com), [Node 22+](https://nodejs.org/en/download/), and [Pnpm 10](https://pnpm.io/installation) installed on your computer.
 
 1. [Clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository). You can do this from the command line or using the Github Desktop app.
 

--- a/apps/test-app/scripts/Dockerfile
+++ b/apps/test-app/scripts/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/playwright:v1.58.1-noble AS base
 RUN --mount=type=cache,target=/root/.npm \
-    npm install -g pnpm@10.17.0
+    npm install -g pnpm@10.30.1
 
 FROM base AS deps
 WORKDIR /kiwi

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
 	"engines": {
 		"node": ">=22.19.0"
 	},
-	"packageManager": "pnpm@10.17.0"
+	"packageManager": "pnpm@10.30.1"
 }


### PR DESCRIPTION
[Pnpm 10.30.1](https://github.com/pnpm/pnpm/releases/tag/v10.30.1) includes a fix for the `pnpm audit` command which started erroring out recently (with a 500 status code).

After this update, `pnpm audit` will correctly fail with a list of vulnerable deps.