### PR TITLE
Component introduction

### DIFF
--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -66,7 +66,7 @@ export default defineConfig({
 					items: [
 						{
 							label: "Overview",
-							slug: "components/introduction",
+							slug: "components/overview",
 						},
 						{
 							label: "MUI components",

--- a/apps/website/src/content/docs/components/overview.md
+++ b/apps/website/src/content/docs/components/overview.md
@@ -21,25 +21,25 @@ The theme includes the following modifications:
 1. **Styling**: The style has been aligned with **StrataKit’s** visual language.
 2. **Typography**: **StrataKit’s** principle font is [Inter](https://rsms.me/inter/), which needs to be [self-hosted](/getting-started/develop/#self-hosting-the-fonts).
 3. **Icons**: Component icons are taken exclusively from **StrataKit’s** own icon collection.
-3. **API**: Some props have been adjusted or removed, and some new props have been added.
-4. **Structure and behavior**: The markup structure and interaction behavior of certain components have been modified to meet **StrataKit** UX and accessibility requirements.
+4. **API**: Some props have been adjusted or removed, and some new props have been added.
+5. **Structure and behavior**: The markup structure and interaction behavior of certain components have been modified to meet **StrataKit** UX and accessibility requirements.
 
 ## StrataKit components
 
 Accompanying specialized components are available in separate packages, such as [@stratakit/structures](https://www.npmjs.com/package/@stratakit/structures).
 
-These components are developed independently, to meet the interface requirements of construction and infrastructure design software. 
+These components are developed independently, to meet the interface requirements of construction and infrastructure design software.
 
 ## Component guidance
 
 All components are accompanied by implementation guidance. This adheres to the following structure:
 
-* **Demo**: What does a typical implementation look like, using common settings?
-* **Use cases**: Is this, or another, component right for my use case? (compares similar components in a table)
-* **StrataKit MUI modifications**: _(where applicable)_: What has been done to bring the **MUI** component in line with **StrataKit**?
-* **Examples**: What variants are there, and to which contexts are they suited?
-* **✅ Do**: What’s needed for an efficient and accessible implementation? What opportunities are there to improve user experience?
-* **🚫 Don’t**: What are some common pitfalls? What are the bad practices to avoid?
+- **Demo**: What does a typical implementation look like, using common settings?
+- **Use cases**: Is this, or another, component right for my use case? (compares similar components in a table)
+- **StrataKit MUI modifications**: _(where applicable)_: What has been done to bring the **MUI** component in line with **StrataKit**?
+- **Examples**: What variants are there, and to which contexts are they suited?
+- **✅ Do**: What’s needed for an efficient and accessible implementation? What opportunities are there to improve user experience?
+- **🚫 Don’t**: What are some common pitfalls? What are the bad practices to avoid?
 
 :::caution[MUI documentation]
 

--- a/apps/website/src/content/docs/guides/migration-from-legacy-stratakit.mdx
+++ b/apps/website/src/content/docs/guides/migration-from-legacy-stratakit.mdx
@@ -103,7 +103,7 @@ Replace legacy StrataKit component usage with their [MUI counterparts](https://m
 | [VisuallyHidden](/reference/bricks/VisuallyHidden)             | -                                                                      |
 
 :::tip
-Read additional [StrataKit MUI component documentation](/components/introduction/) for more details on usage and customization.
+Read additional [StrataKit MUI component documentation](/components/overview/) for more details on usage and customization.
 :::
 
 ### AccordionItem


### PR DESCRIPTION
Added a component "overview", listed before the "MUI components" and "StrataKit components" groups in the sidebar, and describes those two categories of components in the StrataKit catalogue. Includes details about StrataKit MUI modifications, and component statuses (which are currently absent from all metadata).

This is also linked to from the "migration from legacy StrataKit" page.

<details>
<summary>Original notes</summary>

1. This is pretty terse so far, is anything important missing?
2. Since the Components group name is taken, I've added this as the first link _in_ the components group (and italicized the text to differentiate it). I also experimented with using a badge saying something like “read me first” but I wasn't convinced with that.

What do you think?

</details>