### PR TITLE
Add AI policy to `CONTRIBUTING.md` guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,4 +156,10 @@ Before creating a pull request, make sure your changes address a specific issue.
 
 To enable us to quickly review and accept your pull requests, always create one pull request per issue. Never merge multiple requests in one unless they have the same root cause. Be sure to follow best practices and keep code changes as small as possible. Avoid pure formatting changes or random "fixes" that are unrelated to the linked issue.
 
-If artificial intelligence is used to generate any portion of the code, tests, or documentation in your pull request, you are still fully responsible for reviewing the output for correctness and adherence to project standards prior to submission. Please apply the [**AI** GitHub label](https://github.com/iTwin/stratakit/labels/AI) to the pull request.
+### AI use
+
+If artificial intelligence is used to generate any portion of the code, tests, or documentation in your pull request, you are still fully responsible for reviewing the output for correctness and adherence to project standards prior to submission.
+
+AI may not be used to write pull request descriptions, comments, or responses to code reviews. All code review communication must be written directly by the contributor.
+
+If AI was used, clearly disclose where and how it was used in the pull request description.


### PR DESCRIPTION
Contributing guide > Pull requests has a new`<h3>` explaining AI use policy:
- Any AI generated code must be self reviewed before submitting a PR.
- Any PR with AI generated code must be mentioned in PR description.
- AI is forbidden in code review communication.