### PR TITLE
add `render` prop to `Root`

### DIFF
--- a/.changeset/fifty-dodos-reply.md
+++ b/.changeset/fifty-dodos-reply.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added `render` prop to `Root` component.

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -18,6 +18,8 @@ import cx from "classnames";
 import { createTheme } from "./createTheme.js";
 import css from "./styles.css.js";
 
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
 // ----------------------------------------------------------------------------
 
 const theme = createTheme();
@@ -27,7 +29,7 @@ const key = `${packageName}@${__VERSION__}`;
 
 // ----------------------------------------------------------------------------
 
-interface RootProps extends React.ComponentPropsWithoutRef<"div"> {
+interface RootProps extends BaseProps<"div"> {
 	children?: React.ReactNode;
 	/**
 	 * The color scheme to use for all components on the page.


### PR DESCRIPTION
This was originally excluded, likely because `@stratakit/mui` wasn't depending on `@ariakit/react` (which changed after #1212).