### PR TITLE
add `article` and heading semantics to `Card`

### DIFF
--- a/.changeset/upset-baboons-admire.md
+++ b/.changeset/upset-baboons-admire.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+`Card` will now be rendered as an `<article>` element by default. This should be used in combination with a heading inside the card. In cases where `CardHeader` is used, its `title` will be rendered as `<h2>` by default. In other cases, you can use the `Typography` component with `render` prop to specify the heading level.

--- a/apps/website/src/content/docs/components/Card.md
+++ b/apps/website/src/content/docs/components/Card.md
@@ -8,6 +8,11 @@ links:
 
 ::example{src="mui/Card.default"}
 
+## StrataKit MUI modifications
+
+- `Card` is rendered as an `<article>` element by default.
+- `CardHeader`'s `title` is rendered as `<h2>` by default.
+
 ## Examples
 
 ### CardActions
@@ -17,3 +22,11 @@ links:
 ### CardHeader
 
 ::example{src="mui/Card.header"}
+
+## ✅ Do
+
+- Use a heading element to provide a clear title for the card's content.
+
+## 🚫 Don't
+
+- Don't use a **Card** to group unrelated content or actions.

--- a/examples/mui/Card.actions.tsx
+++ b/examples/mui/Card.actions.tsx
@@ -23,7 +23,7 @@ export default () => {
 				alt=""
 			/>
 			<CardContent>
-				<Typography gutterBottom variant="h6" render={<div />}>
+				<Typography gutterBottom variant="h6" render={<h2 />}>
 					Stadium
 				</Typography>
 				<Typography variant="body2" color="text.secondary">

--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -23,7 +23,7 @@ export default () => {
 					alt=""
 				/>
 				<CardContent>
-					<Typography gutterBottom variant="h6" render={<div />}>
+					<Typography gutterBottom variant="h6" render={<h2 />}>
 						Stadium
 					</Typography>
 					<Typography variant="body2" color="text.secondary">

--- a/examples/mui/Card.header.tsx
+++ b/examples/mui/Card.header.tsx
@@ -19,7 +19,7 @@ import styles from "./Card.header.module.css";
 
 export default () => {
 	return (
-		<Card className={styles.card} variant="outlined" role="group">
+		<Card className={styles.card} variant="outlined">
 			<CardHeader
 				title="Stadium"
 				subheader="January 16, 2026"

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -159,11 +159,17 @@ function createTheme() {
 					disableRipple: true, // ButtonGroup overrides Button's disableRipple so we need to set it here as well
 				},
 			},
-			MuiCard: { defaultProps: { component: Role.div } },
+			MuiCard: { defaultProps: { component: withRenderProp(Role, "article") } },
 			MuiCardActionArea: {
 				defaultProps: { component: Role.button },
 			},
 			MuiCardContent: { defaultProps: { component: Role.div } },
+			MuiCardHeader: {
+				defaultProps: {
+					component: Role.div,
+					slotProps: { title: { component: Role.h2 } },
+				},
+			},
 			MuiCardMedia: { defaultProps: { component: Role.div } },
 			MuiCheckbox: {
 				defaultProps: {


### PR DESCRIPTION
### Package changes
- `Card`: Changed default rendered element to [`<article>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article). This was chosen over `role="group"` semantics because it is meaningful on its own and can be automatically labeled by a heading. The default can be overridden using `render` prop.
- `CardHeader`: Changed default rendered element to `<h2>`. The default can be overridden using `slotProps`.

### Example changes
- `Card.default.tsx` and `Card.actions.tsx`: Changed the heading inside to use `<h2>` instead of `<div>`.
- `Card.header.tsx`: Removed unlabelled `role="group"` which was clashing with `article`.

### Open questions

What's the best default heading level? I've used `<h2>`, but it would be more appropriate to use `<h3>` in many cases.

Perhaps we need to (re)explore dynamic heading levels (via `HeadingLevel` Context).