### PR TITLE
fix remnants from #1212

### DIFF
--- a/.changeset/strict-pets-attack.md
+++ b/.changeset/strict-pets-attack.md
@@ -1,5 +1,0 @@
----
-"@stratakit/mui": patch
----
-
-Added dependency on `@base-ui/react`.

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -341,7 +341,7 @@ function createTheme() {
 					},
 				},
 			},
-			// MuiTextField: { defaultProps: { component: Role.input } }, // This dynamically renders as `textarea` when multiline is true
+			MuiTextField: { defaultProps: { component: Role.div } },
 			MuiToggleButton: { defaultProps: { component: Role.button } },
 			MuiToolbar: { defaultProps: { component: Role.div } },
 			MuiTooltip: {


### PR DESCRIPTION
- Removed outdated changeset which mentions `@base-ui/react`.
- Removed code comment about `MuiTextField` because `component` prop actually applies to outer wrapper. The `<input>` or `<textarea>` element does not appear to be easily customizable (unless using `slots.htmlInput`).