### PR TITLE
remove `role="button"` from `CardActionArea`

### DIFF
--- a/.changeset/two-moles-worry.md
+++ b/.changeset/two-moles-worry.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Removed unnecessary `role="button"` from `CardActionArea` to avoid conflicts when it's rendered as a link.

--- a/apps/website/src/content/docs/components/Card.md
+++ b/apps/website/src/content/docs/components/Card.md
@@ -12,6 +12,7 @@ links:
 
 - `Card` is rendered as an `<article>` element by default.
 - `CardHeader`'s `title` is rendered as `<h2>` by default.
+- `CardActionArea` will not have an unnecessary `role="button"` to avoid conflicting semantics when rendered as a link.
 
 ## Examples
 

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -161,7 +161,10 @@ function createTheme() {
 			},
 			MuiCard: { defaultProps: { component: withRenderProp(Role, "article") } },
 			MuiCardActionArea: {
-				defaultProps: { component: Role.button },
+				defaultProps: {
+					component: Role.button,
+					role: undefined, // Remove redundant role which conflicts when CardActionArea is rendered as Link
+				},
 			},
 			MuiCardContent: { defaultProps: { component: Role.div } },
 			MuiCardHeader: {


### PR DESCRIPTION
This fixes the issue where the card link is announced as a button.

A similar change should probably be made in `ButtonBase` to handle all cases, however it is good to have `role="button"` as fallback for when it's rendered as `<div>`, for example. Plus, [MUI explicitly documents `role={undefined}`](https://mui.com/material-ui/integrations/routing/#button:~:text=you%20need%20to%20override%20the%20role%20attribute) for use when buttons are rendered as links. This could perhaps be reinforced in StrataKit docs somewhere.