### PR TITLE
make `CardActionArea` not wrap entire contents of `Card`

### DIFF
--- a/.changeset/small-stamps-film.md
+++ b/.changeset/small-stamps-film.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+`CardActionArea` has been redesigned to not wrap the entire card content. Instead, it should be used in the card's heading or title area. This improves the card's accessibility structure, while still allowing the entire card to be clickable.

--- a/apps/website/src/content/docs/components/Card.md
+++ b/apps/website/src/content/docs/components/Card.md
@@ -13,6 +13,7 @@ links:
 - `Card` is rendered as an `<article>` element by default.
 - `CardHeader`'s `title` is rendered as `<h2>` by default.
 - `CardActionArea` will not have an unnecessary `role="button"` to avoid conflicting semantics when rendered as a link.
+- `CardActionArea` has been redesigned to not wrap the entire card content. Instead, it should be used in the card's heading or title area.
 
 ## Examples
 
@@ -27,7 +28,10 @@ links:
 ## ✅ Do
 
 - Use a heading element to provide a clear title for the card's content.
+- Use `CardActionArea` inside the heading if the entire card should be clickable.
+- Use `CardActions` when the card has multiple actions.
 
 ## 🚫 Don't
 
 - Don't use a **Card** to group unrelated content or actions.
+- Don't wrap the entire contents of the card in a `CardActionArea`.

--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -14,24 +14,22 @@ import styles from "./Card.default.module.css";
 export default () => {
 	return (
 		<Card className={styles.card} variant="outlined">
-			<CardActionArea render={<a href="#" />}>
-				<CardMedia
-					className={styles.media}
-					component="img" // This does not work with `render` prop.
-					height="140"
-					image="https://images.unsplash.com/photo-1489944440615-453fc2b6a9a9"
-					alt=""
-				/>
-				<CardContent>
-					<Typography gutterBottom variant="h6" render={<h2 />}>
-						Stadium
-					</Typography>
-					<Typography variant="body2" color="text.secondary">
-						Stadium is a place for outdoor sports, concerts, or other events and
-						activities.
-					</Typography>
-				</CardContent>
-			</CardActionArea>
+			<CardMedia
+				className={styles.media}
+				component="img" // This does not work with `render` prop.
+				height="140"
+				image="https://images.unsplash.com/photo-1489944440615-453fc2b6a9a9"
+				alt=""
+			/>
+			<CardContent>
+				<Typography gutterBottom variant="h6" render={<h2 />}>
+					<CardActionArea render={<a href="#" />}>Stadium</CardActionArea>
+				</Typography>
+				<Typography variant="body2" color="text.secondary">
+					Stadium is a place for outdoor sports, concerts, or other events and
+					activities.
+				</Typography>
+			</CardContent>
 		</Card>
 	);
 };

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import OutlinedInput from "@mui/material/OutlinedInput";
 import { createTheme as createMuiTheme } from "@mui/material/styles";
+import { MuiCard, MuiCardActionArea } from "./~components/MuiCard.js";
 import {
 	MuiChip,
 	MuiChipDeleteIcon,
@@ -159,10 +160,10 @@ function createTheme() {
 					disableRipple: true, // ButtonGroup overrides Button's disableRipple so we need to set it here as well
 				},
 			},
-			MuiCard: { defaultProps: { component: withRenderProp(Role, "article") } },
+			MuiCard: { defaultProps: { component: MuiCard } },
 			MuiCardActionArea: {
 				defaultProps: {
-					component: Role.button,
+					component: MuiCardActionArea,
 					role: undefined, // Remove redundant role which conflicts when CardActionArea is rendered as Link
 				},
 			},

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -5,12 +5,45 @@
 
 .MuiCard-root {
 	background-color: var(--stratakit-color-bg-elevation-base);
+
+	&:where([data-_sk-actionable]) {
+		cursor: pointer;
+		transition: background-color 150ms ease-out;
+
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				background-color: color-mix(
+					in oklch,
+					var(--stratakit-color-bg-elevation-base) 100%,
+					var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%)
+				);
+			}
+		}
+
+		&:where(:has(.MuiCardActionArea-root.Mui-focusVisible)) {
+			outline: var(--🥝focus-outline);
+			outline-offset: var(--🥝focus-outline-offset);
+		}
+	}
 }
 
 .MuiCardContent-root {
 	&:where(:has(+ .MuiCardActions-root)) {
 		padding-block-end: 0;
 	}
+}
+
+.MuiCardActionArea-root {
+	background-color: unset; /* Background will be set on the Card instead */
+	user-select: auto; /* Allow text selection */
+
+	&:where(.Mui-focusVisible) {
+		outline: none !important; /* Focus outline will be shown around the Card instead */
+	}
+}
+
+.MuiCardActionArea-focusHighlight {
+	display: none;
 }
 
 .MuiCardActions-root {

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { Role } from "@ariakit/react/role";
+import {
+	type BaseProps,
+	forwardRef,
+	useEventHandlers,
+	useMergedRefs,
+} from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+const MuiCardContext = React.createContext<
+	| {
+			actionAreaElement?: HTMLElement | null;
+			setActionAreaElement: (element?: HTMLElement | null) => void;
+	  }
+	| undefined
+>(undefined);
+
+// ----------------------------------------------------------------------------
+
+const MuiCard = forwardRef<"article", BaseProps<"article">>(
+	(props, forwardedRef) => {
+		const { role, ...rest } = props;
+		const [actionAreaElement, setActionAreaElement] = React.useState<
+			HTMLElement | undefined | null
+		>(undefined);
+
+		/** Captures clicks on the card and forwards them to MuiCardActionArea. */
+		const handleActionAreaClick = (event: React.MouseEvent) => {
+			if (!actionAreaElement) return;
+			if (!(event.target instanceof Element)) return;
+
+			// Ignore clicks on interactive elements inside the action area.
+			if (event.target.closest("a, button, [role=button]")) return;
+
+			// Ignore click if text selection is being made.
+			const selection = window.getSelection();
+			if (selection && !selection.isCollapsed) return;
+
+			actionAreaElement.click();
+		};
+
+		return (
+			<MuiCardContext.Provider
+				value={{ actionAreaElement, setActionAreaElement }}
+			>
+				<Role
+					render={<article />}
+					{...rest}
+					data-_sk-actionable={actionAreaElement ? "" : undefined}
+					onClick={useEventHandlers(props.onClick, handleActionAreaClick)}
+					ref={forwardedRef as React.Ref<HTMLDivElement>}
+				/>
+			</MuiCardContext.Provider>
+		);
+	},
+);
+DEV: MuiCard.displayName = "MuiCard";
+
+// ----------------------------------------------------------------------------
+
+const MuiCardActionArea = forwardRef<"button", BaseProps<"button">>(
+	(props, forwardedRef) => {
+		const { role, ...rest } = props;
+
+		const context = React.useContext(MuiCardContext);
+
+		return (
+			<Role.button
+				{...rest}
+				ref={useMergedRefs(context?.setActionAreaElement, forwardedRef)}
+			/>
+		);
+	},
+);
+DEV: MuiCardActionArea.displayName = "MuiCardActionArea";
+
+// ----------------------------------------------------------------------------
+
+export { MuiCard, MuiCardActionArea };


### PR DESCRIPTION
### Changes

In package:
- Added custom components for `Card` and `CardActionArea`, the former of which handles clicks if the latter is present as a descendant.
  - Clicks are ignored if originating from a link or button inside the card, or if text is being selected.
- Moved hover/focus styles from `CardActionArea` to `Card`

In `Card.default` example:
- Moved `CardActionArea` from wrapping everything to only wrapping the heading text (nested within the heading element).

### Testing

- Verified visuals and behavior manually, by hovering, focusing, clicking, etc.
- Verified semantics in accessibility tree and in screen readers. Card is correctly labelled by the heading in VoiceOver (but not in NVDA). In all cases, elements inside the card can be accessed individually and are not collapsed into one long string.

[Deploy preview](https://itwin.github.io/stratakit/1274)