### PR TITLE
Document StrataKit modifications & examples for `Slider`

### DIFF
--- a/apps/website/src/content/docs/components/Slider.md
+++ b/apps/website/src/content/docs/components/Slider.md
@@ -11,7 +11,7 @@ links:
 ## StrataKit MUI modifications
 
 - The `color` prop is not supported.
-- Fully restyled to match the StrataKit visual design language.
+- Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
 
 ## Examples


### PR DESCRIPTION
Documents the following StrataKit modifications of the MUI `Slider`:
- `color` prop is not supported as of #1183.
- `forced-colors` support as of #1254.

Also adds examples for:
- [Marks](https://github.com/iTwin/stratakit/blob/main/examples/mui/Slider.marks.tsx)
- [Range](https://github.com/iTwin/stratakit/blob/main/examples/mui/Slider.range.tsx)
- [Vertical](https://github.com/iTwin/stratakit/blob/main/examples/mui/Slider.vertical.tsx)
