### PR TITLE
fix `Alert` colors

### DIFF
--- a/.changeset/cool-terms-find.md
+++ b/.changeset/cool-terms-find.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed the colors of various permuations of `Alert`.

--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -14,6 +14,7 @@ import { Icon } from "@stratakit/mui";
 import * as NavigationList from "@stratakit/structures/unstable_NavigationList";
 import AccordionActions from "examples/mui/Accordion.actions.tsx";
 import AccordionDefault from "examples/mui/Accordion.default.tsx";
+import AlertPermutations_ from "examples/mui/Alert._permutations.tsx";
 import AlertDefault from "examples/mui/Alert.default.tsx";
 import AlertTitle from "examples/mui/Alert.title.tsx";
 import AppBarDefault from "examples/mui/AppBar.default.tsx";
@@ -124,6 +125,7 @@ const components: Record<string, React.ReactNode> = {
 		<Stack spacing={1} alignSelf="stretch">
 			<AlertDefault />
 			<AlertTitle />
+			{!isProduction && <AlertPermutations_ />}
 		</Stack>
 	),
 	AppBar: (

--- a/apps/website/src/content/docs/components/Alert.md
+++ b/apps/website/src/content/docs/components/Alert.md
@@ -8,6 +8,11 @@ links:
 
 ::example{src="mui/Alert.default"}
 
+## StrataKit MUI modifications
+
+- Restyled using StrataKit's visual language.
+- The `"standard"` variant has been removed. The default variant is now `"outlined"`.
+
 ## Examples
 
 ### AlertTitle

--- a/examples/mui/Alert._permutations.tsx
+++ b/examples/mui/Alert._permutations.tsx
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import Alert from "@mui/material/Alert";
+
+export default () => {
+	return (["outlined", "filled"] as const).map((variant) => (
+		<React.Fragment key={variant}>
+			<Alert severity="success" variant={variant}>
+				This is a success Alert.
+			</Alert>
+			<Alert severity="info" variant={variant}>
+				This is an info Alert.
+			</Alert>
+			<Alert severity="warning" variant={variant}>
+				This is a warning Alert.
+			</Alert>
+			<Alert severity="error" variant={variant}>
+				This is an error Alert.
+			</Alert>
+		</React.Fragment>
+	));
+};

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+@import "./~components/MuiAlert.css";
 @import "./~components/MuiAutocomplete.css";
 @import "./~components/MuiButton.css";
 @import "./~components/MuiCard.css";
@@ -16,10 +17,6 @@
 
 .MuiAccordion-root {
 	background-color: transparent;
-}
-
-.MuiAlert-icon {
-	align-items: center; /* Fix vertical alignment of differently sized icons */
 }
 
 .MuiAppBar-root {

--- a/packages/mui/src/~components/MuiAlert.css
+++ b/packages/mui/src/~components/MuiAlert.css
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiAlert-root {
+	border: 1px solid var(--stratakit-color-border-neutral-base);
+
+	&:where(.MuiAlert-outlined) {
+		background-color: var(--stratakit-color-bg-elevation-base);
+	}
+
+	&:where(.MuiAlert-colorSuccess) {
+		border-color: var(--stratakit-color-border-positive-base);
+	}
+	&:where(.MuiAlert-colorInfo) {
+		border-color: var(--stratakit-color-border-info-base);
+	}
+	&:where(.MuiAlert-colorWarning) {
+		border-color: var(--stratakit-color-border-attention-base);
+	}
+	&:where(.MuiAlert-colorError) {
+		border-color: var(--stratakit-color-border-critical-base);
+	}
+}
+
+.MuiAlert-icon {
+	align-items: center; /* Fix vertical alignment of differently sized icons */
+
+	:where(.MuiAlert-root.MuiAlert-colorSuccess) & {
+		color: var(--stratakit-color-icon-positive-base);
+	}
+	:where(.MuiAlert-root.MuiAlert-colorInfo) & {
+		color: var(--stratakit-color-icon-info-base);
+	}
+	:where(.MuiAlert-root.MuiAlert-colorWarning) & {
+		color: var(--stratakit-color-icon-attention-base);
+	}
+	:where(.MuiAlert-root.MuiAlert-colorError) & {
+		color: var(--stratakit-color-icon-critical-base);
+	}
+}


### PR DESCRIPTION
### Changes

Updated the `background-color`, `border-color` and icon `color` of `Alert` in all permutations of `severity` and `variant`. These colors match the Strata visual language; the most prominent change is the higher contrast borders.

Updated docs too.

### Testing

Added `Alert._permutations.tsx`.

Screenshots:

| Before | After |
| --- | --- |
| <img width="420" height="582" alt="image" src="https://github.com/user-attachments/assets/aa871412-8d78-412d-a829-35bb186433a6" /> | <img width="399" height="591" alt="image" src="https://github.com/user-attachments/assets/eeef7f5e-cf31-44e2-9792-7e77ad72a1b6" /> |