### PR TITLE
update `Card` examples

### DIFF
--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -16,7 +16,7 @@ export default () => {
 		<Card className={styles.card} variant="outlined">
 			<CardMedia
 				className={styles.media}
-				component="img" // This does not work with `render` prop.
+				component="img"
 				height="140"
 				image="https://images.unsplash.com/photo-1489944440615-453fc2b6a9a9"
 				alt=""

--- a/examples/mui/Card.header.tsx
+++ b/examples/mui/Card.header.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import * as React from "react";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
@@ -10,6 +11,8 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import CardMedia from "@mui/material/CardMedia";
 import IconButton from "@mui/material/IconButton";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { Icon } from "@stratakit/mui";
@@ -23,13 +26,7 @@ export default () => {
 			<CardHeader
 				title="Stadium"
 				subheader="January 16, 2026"
-				action={
-					<Tooltip title="More actions" describeChild={false}>
-						<IconButton>
-							<Icon href={svgMore} />
-						</IconButton>
-					</Tooltip>
-				}
+				action={<ActionsMenu />}
 			/>
 			<CardMedia
 				className={styles.media}
@@ -51,3 +48,43 @@ export default () => {
 		</Card>
 	);
 };
+
+function ActionsMenu() {
+	const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+	const open = Boolean(anchorEl);
+	const handleClose = () => setAnchorEl(null);
+
+	const buttonId = React.useId();
+	const menuId = React.useId();
+
+	return (
+		<>
+			<Tooltip title="More actions" describeChild={false}>
+				<IconButton
+					id={buttonId}
+					aria-controls={open ? menuId : undefined}
+					aria-haspopup="true"
+					aria-expanded={open ? "true" : "false"}
+					onClick={(event) => setAnchorEl(event.currentTarget)}
+				>
+					<Icon href={svgMore} />
+				</IconButton>
+			</Tooltip>
+			<Menu
+				id={menuId}
+				anchorEl={anchorEl}
+				open={open}
+				onClose={handleClose}
+				slotProps={{
+					list: {
+						"aria-labelledby": buttonId,
+					},
+				}}
+			>
+				<MenuItem onClick={handleClose}>View</MenuItem>
+				<MenuItem onClick={handleClose}>Favorite</MenuItem>
+				<MenuItem onClick={handleClose}>Delete</MenuItem>
+			</Menu>
+		</>
+	);
+}

--- a/examples/mui/Menu.default.tsx
+++ b/examples/mui/Menu.default.tsx
@@ -24,7 +24,7 @@ export default () => {
 				id={buttonId}
 				aria-controls={open ? menuId : undefined}
 				aria-haspopup="true"
-				aria-expanded={open ? "true" : undefined}
+				aria-expanded={open ? "true" : "false"}
 				onClick={(event) => setAnchorEl(event.currentTarget)}
 			>
 				Open menu


### PR DESCRIPTION
### Changes

This addresses the remaining examples-related concerns from #1228.
- The "More actions" button now opens a proper menu with the right semantics. When testing this I noticed the `aria-expanded` attribute is being removed when the menu is closed; I changed this from `undefined` to `"false"`.
- ~~All examples now use `aria-labelledby` on the Card element to give an accessible name to the `article`. This points to the title/heading text.~~ [Reverted](https://github.com/iTwin/stratakit/pull/1286#discussion_r2891356935).

Also removed code comment about `render` prop.

### Testing

Verified in the a11y tree that the actions button correctly reflects its `expanded` state.

Initially I tried labelling the `article`, but I couldn't get it to be announced in NVDA in Chrome/Firefox, even though it shows up correctly in the accessibility tree. (Works in VoiceOver and JAWS though). See [comment 1](https://github.com/iTwin/stratakit/issues/1228#issuecomment-3985470339) and [comment 2](https://github.com/iTwin/stratakit/pull/1286#discussion_r2878816253). I ended up not changing the examples.

[Deploy preview](https://stratakit.bentley.com/1286/docs/components/card/)