### PR TITLE
Fix permalink in `/mui` page of test-app

### DIFF
--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -424,6 +424,7 @@ function ComponentExamples(props: ComponentExamplesProps) {
 					{name}
 				</Typography>
 				<IconButton
+					render={<a />}
 					id={`${id}-permalink`}
 					aria-labelledby={`${id}-permalink ${id}`}
 					className={styles.examplePermalink}


### PR DESCRIPTION
### Changes

This PR fixes "hash" permalink displayed in `/mui` page by rendering it as an [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a).

### Testing

[Deploy preview](https://stratakit.bentley.com/1295/mui/)

