### PR TITLE
remap `Typography` variants

### DIFF
--- a/.changeset/four-pigs-visit.md
+++ b/.changeset/four-pigs-visit.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Adjusted the `Typography` scale to better align with StrataKit's visual language.

--- a/.changeset/plenty-dolls-leave.md
+++ b/.changeset/plenty-dolls-leave.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated the default `variant` of `Typography` to `"body2"`.

--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -7,3 +7,9 @@ links:
 ---
 
 ::example{src="mui/Typography.default"}
+
+## StrataKit MUI modifications
+
+- The `font-family` has been changed to `InterVariable`. See [self-hosting fonts](/getting-started/develop/self-hosting-the-fonts).
+- The typography scale has been adjusted to better align with StrataKit's more compact visual language.
+- The default `variant` is now `"body2"` instead of `"body1"`.

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -82,6 +82,18 @@ function createTheme() {
 			button: {
 				textTransform: "none", // Disable all-caps on buttons and tabs
 			},
+			// These are only hardcoded here as fallback. The CSS will take precedence.
+			body1: { fontSize: 16 },
+			body2: { fontSize: 14 },
+			h1: { fontSize: 48 },
+			h2: { fontSize: 40 },
+			h3: { fontSize: 32 },
+			h4: { fontSize: 28 },
+			h5: { fontSize: 24 },
+			h6: { fontSize: 20 },
+			caption: { fontSize: 12 },
+			subtitle1: { fontSize: 12 },
+			subtitle2: { fontSize: 11 },
 		},
 		shadows: [
 			"none", // 0
@@ -377,7 +389,7 @@ function createTheme() {
 					describeChild: true,
 				},
 			},
-			MuiTypography: { defaultProps: { component: Role.p } },
+			MuiTypography: { defaultProps: { component: Role.p, variant: "body2" } },
 		},
 	});
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -14,6 +14,7 @@ import type {
 	TextFieldProps,
 	TextFieldVariants,
 } from "@mui/material/TextField";
+import type { TypographyProps } from "@mui/material/Typography";
 import type * as React from "react";
 
 declare module "@mui/material/OverridableComponent" {
@@ -254,5 +255,16 @@ declare module "@mui/material/Tooltip" {
 		 * Use `describeChild={false}` if you want to label the child element.
 		 */
 		describeChild?: boolean;
+	}
+}
+
+declare module "@mui/material/Typography" {
+	interface TypographyOwnProps {
+		/**
+		 * The default variant with `@stratakit/mui` is `"body2"`.
+		 *
+		 * @default "body2"
+		 */
+		variant?: TypographyProps["variant"];
 	}
 }

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -15,6 +15,7 @@
 @import "./~components/MuiInput.css";
 @import "./~components/MuiSlider.css";
 @import "./~components/MuiTabs.css";
+@import "./~components/MuiTypography.css";
 
 .MuiAccordion-root {
 	background-color: transparent;

--- a/packages/mui/src/~components/MuiTypography.css
+++ b/packages/mui/src/~components/MuiTypography.css
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiTypography-root {
+	&:where(.MuiTypography-body1) {
+		@apply --typography("body-lg");
+	}
+	&:where(.MuiTypography-body2) {
+		@apply --typography("body-md");
+	}
+
+	&:where(.MuiTypography-h1) {
+		@apply --typography("display-lg");
+	}
+	&:where(.MuiTypography-h2) {
+		@apply --typography("display-md");
+	}
+	&:where(.MuiTypography-h3) {
+		@apply --typography("display-sm");
+	}
+	&:where(.MuiTypography-h4) {
+		@apply --typography("headline-lg");
+	}
+	&:where(.MuiTypography-h5) {
+		@apply --typography("headline-md");
+	}
+	&:where(.MuiTypography-h6) {
+		@apply --typography("headline-sm");
+	}
+
+	&:where(.MuiTypography-caption) {
+		@apply --typography("body-sm");
+	}
+	&:where(.MuiTypography-subtitle1) {
+		@apply --typography("body-sm");
+	}
+	&:where(.MuiTypography-subtitle2) {
+		@apply --typography("caption-lg");
+	}
+}


### PR DESCRIPTION
### Changes

Updates to MUI's `Typography` component:

- Changed default `variant` from `"body1"` (1rem) to `"body2"` (0.875rem). Updated types to mention the new default.
- Added CSS to map the most common variants to StrataKit's existing typography styles, using the `--typography` mixin.
- Documented these modifications.

Updates to the theme:

- Added hardcoded font size mappings to the [`typography`](https://mui.com/material-ui/customization/typography/) scale. These are mostly here as fallback and are not perfect (e.g. line-height is not set).

### Testing

[Deploy preview](https://stratakit.bentley.com/1298/mui/#typography)
[Docs](https://stratakit.bentley.com/1298/docs/components/typography/)

Comparison screenshots:

| Before | After |
| --- | --- |
| <img width="300" height="806" alt="Screenshot showing MUI's default typography scale with massive headings" src="https://github.com/user-attachments/assets/b21aa99c-0172-4aac-a177-77bf14aeb692" /> | <img width="245" alt="Same typography scale with StrataKit adjustments, with significantly smaller headings and tiny subtitles" src="https://github.com/user-attachments/assets/3e2e53e9-9dee-4ebb-ad1e-294ba104009f" /> |

### Future

This PR is only a first step, with the main goal of reducing the size of MUI's absolutely humongous headings. Not everything is covered in this PR.

Some future improvements to look forward to:
- The `typography.json` file needs to be re-generated using the new Figma file.
- There will need to be new variants added to `Typography` (e.g. `"body3"`).
- Some values are currently wrong (e.g. `"subtitle1"` and `"subtitle2"`).
- Font-weights and letter-spacing are not currently handled.
- Component-level typography needs adjustments too.
- Monospace needs a proper look.