### PR TITLE
fix fonts in minimal-template

### DIFF
--- a/internal/minimal-template/index.html
+++ b/internal/minimal-template/index.html
@@ -10,7 +10,7 @@
 				font-style: normal;
 				font-weight: 100 900;
 				font-display: swap;
-				src: url("/src/assets/InterVariable.woff2") format("woff2");
+				src: url("/src/fonts/InterVariable.woff2") format("woff2");
 			}
 
 			@font-face {
@@ -18,7 +18,7 @@
 				font-style: italic;
 				font-weight: 100 900;
 				font-display: swap;
-				src: url("/src/assets/InterVariable-Italic.woff2") format("woff2");
+				src: url("/src/fonts/InterVariable-Italic.woff2") format("woff2");
 			}
 		</style>
 	</head>


### PR DESCRIPTION
### Changes

Fixes a typo from #1255. There is no `src/assets/` directory, the fonts are stored in [`src/fonts/`](https://github.com/iTwin/stratakit/tree/main/internal/minimal-template/src/fonts).

### Testing

N/A