### PR TITLE
add built-in alt text to form errors

### DIFF
--- a/.changeset/olive-snails-do.md
+++ b/.changeset/olive-snails-do.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added alt text to the error icon used in FormHelperText.

--- a/examples/mui/FormControl.error.tsx
+++ b/examples/mui/FormControl.error.tsx
@@ -10,7 +10,6 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import FormHelperText from "@mui/material/FormHelperText";
 import FormLabel from "@mui/material/FormLabel";
-import visuallyHidden from "@mui/utils/visuallyHidden";
 
 export default () => {
 	const errorId = React.useId();
@@ -29,7 +28,6 @@ export default () => {
 				/>
 			</FormGroup>
 			<FormHelperText id={errorId}>
-				<span style={visuallyHidden}>Error:</span>
 				You must accept these settings to continue.
 			</FormHelperText>
 		</FormControl>

--- a/examples/mui/RadioGroup.error.tsx
+++ b/examples/mui/RadioGroup.error.tsx
@@ -10,7 +10,6 @@ import FormHelperText from "@mui/material/FormHelperText";
 import FormLabel from "@mui/material/FormLabel";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
-import visuallyHidden from "@mui/utils/visuallyHidden";
 
 export default () => {
 	const labelId = React.useId();
@@ -28,10 +27,7 @@ export default () => {
 				<FormControlLabel value="male" control={<Radio />} label="Male" />
 				<FormControlLabel value="other" control={<Radio />} label="Other" />
 			</RadioGroup>
-			<FormHelperText id={errorId}>
-				<span style={visuallyHidden}>Error:</span>
-				You must select a gender.
-			</FormHelperText>
+			<FormHelperText id={errorId}>You must select a gender.</FormHelperText>
 		</FormControl>
 	);
 };

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -48,6 +48,8 @@
 			--_octagon-filled: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="currentColor" d="M10.086 2H5.914a1 1 0 0 0-.707.293L2.293 5.207A1 1 0 0 0 2 5.914v4.237a1 1 0 0 0 .3.715l2.908 2.848a1 1 0 0 0 .7.286h4.178a1 1 0 0 0 .707-.293l2.914-2.914a1 1 0 0 0 .293-.707V5.914a1 1 0 0 0-.293-.707l-2.914-2.914A1 1 0 0 0 10.086 2Z" /></svg>');
 			--_❗: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="black" fill-opacity=".48" d="M8.875 10.625a.875.875 0 1 0-1.75 0 .875.875 0 0 0 1.75 0ZM8 4a1.581 1.581 0 0 1 1.5 2.081l-.789 2.365c-.228.684-1.195.684-1.423 0L6.5 6.081A1.581 1.581 0 0 1 8 4Zm0 .5a1.08 1.08 0 0 0-1.025 1.423l.788 2.365a.25.25 0 0 0 .436.075l.039-.075.788-2.365a1.082 1.082 0 0 0-.89-1.415L8 4.5Zm1.375 6.125a1.375 1.375 0 1 1-2.75 0 1.375 1.375 0 0 1 2.75 0Z" /><path fill="white" d="M8.875 10.625a.875.875 0 1 1-1.75 0 .875.875 0 0 1 1.75 0ZM6.974 5.923l.789 2.366a.25.25 0 0 0 .474 0l.789-2.366a1.081 1.081 0 1 0-2.052 0Z" /></svg>');
 
+			content: "" / "⚠️"; /* Using a built-in emoji as alt text for automatic localization */
+
 			mask: var(--_octagon-filled) no-repeat center;
 			background-color: var(--stratakit-color-bg-critical-base);
 


### PR DESCRIPTION
### Changes

This addresses https://github.com/iTwin/stratakit/pull/1181#issuecomment-3843240678. `FormHelperText`, in its `error` variant, will now use the "⚠️" emoji as alt text, via CSS [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/content#adding_an_image_with_alternative_text) (see [browser support](https://caniuse.com/wf-alt-text-generated-content)). This helps achieve parity between visual and semantic representations of the error message.

The Radio and Checkbox examples were including visually-hidden "Error" text, which is no longer necessary.

#### Rationale

Ideally we shouldn't need any alt text. [`aria-errormessage`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) exists precisely for this use case, but it has poor support so we use `aria-describedby`, which does not differentiate between normal hint text and error messages.

The more traditional way of handling this would be using simple visually-hidden text (similar to how some of the examples were doing). However, this is a bit challenging to handle within the library because we would need to translate the string into dozens of languages. My hypothesis is that "⚠️", being a standard semantically meaningful unicode symbol, will be automatically translated (**Needs testing to confirm**).

### Testing

I used the [TextField.error](https://github.com/iTwin/stratakit/blob/main/examples/mui/TextField.error.tsx) example as the basis for all my testing. This example is the most common one and also covers the important scenario where the error message is automatically announced when focusing the text field (as opposed to simply reaching the text using the virtual cursor).

Testing with English:

- macOS + VoiceOver: The emoji was consistently announced as "warning sign".
- Windows + NVDA/JAWS: The emoji was announced as "warning" in Firefox, but **skipped altogether in Edge**.

Testing with French (where the expected translation should include the word "avertissement"). I changed the page's `lang` attribute as well as the language in the screen reader settings.
- macOS + VoiceOver: The emoji is **not translated in Edge**. It was just simply announcing the words "warning sign" with an accent, instead of announcing the translated word. Didn't test Safari yet.
- Windows + NVDA/JAWS: When using the virtual cursor, it is translated only in Firefox and skipped altogether in Edge. In both Firefox and Edge, it is **announced in English when focusing the text field**. This behavior seems consistent in NVDA and JAWS.