### PR TITLE
update form error examples and docs

### DIFF
--- a/apps/website/src/content/docs/components/mui/Checkbox.md
+++ b/apps/website/src/content/docs/components/mui/Checkbox.md
@@ -33,4 +33,6 @@ links:
 
 ### Error
 
+Use the `error` prop on `FormControl` to display the `FormHelperText` in an error state. Consider adding a visually hidden "Error:" prefix to the `FormHelperText` if the error message is not clear on its own.
+
 ::example{src="mui/FormControl.error"}

--- a/apps/website/src/content/docs/components/mui/Radio.md
+++ b/apps/website/src/content/docs/components/mui/Radio.md
@@ -20,4 +20,6 @@ links:
 
 ### Error
 
+Use the `error` prop on `FormControl` to display the `FormHelperText` in an error state. Consider adding a visually hidden "Error:" prefix to the `FormHelperText` if the error message is not clear on its own.
+
 ::example{src="mui/RadioGroup.error"}

--- a/apps/website/src/content/docs/components/mui/TextField.md
+++ b/apps/website/src/content/docs/components/mui/TextField.md
@@ -16,6 +16,8 @@ links:
 
 ### Error
 
+Use the `error` prop to display the `helperText` in an error state. Consider adding a visually hidden "Error:" prefix to the `helperText` if the error message is not clear on its own.
+
 ::example{src="mui/TextField.error"}
 
 ### Multiline

--- a/examples/mui/TextField.error.tsx
+++ b/examples/mui/TextField.error.tsx
@@ -4,7 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import TextField from "@mui/material/TextField";
+import { visuallyHidden } from "@mui/utils";
 
 export default () => {
-	return <TextField label="Email" helperText="Invalid email address" error />;
+	return (
+		<TextField
+			label="Email"
+			error
+			helperText={
+				<>
+					<span style={visuallyHidden}>Error:</span> Invalid email address
+				</>
+			}
+		/>
+	);
 };


### PR DESCRIPTION
### Changes

Follow-on from #1301. This addresses https://github.com/iTwin/stratakit/pull/1181#issuecomment-3843240678 by updating the examples and documentation. (Avoiding issues with handling localization within the library)

- `TextField.error` now includes the visually-hidden "Error" text, matching the existing pattern from `FormControl.error` and `RadioGroup.error`.
- TextField, Radio, and Checkbox docs updated to explicitly mention this as guidance.

### Testing

Unlike #1301, this didn't need extensive testing because it's just normal text in the accessibility tree. (Expected to be localized by consumers along with the rest of the error message)

