### PR TITLE
add `render` prop to `TableCell`

### DIFF
--- a/apps/test-app/app/tokens.tsx
+++ b/apps/test-app/app/tokens.tsx
@@ -58,8 +58,7 @@ export default function Page() {
 	return (
 		<Container
 			maxWidth="md"
-			component="main"
-			// render={<main />} // TODO: This is not working 🤬
+			render={<main />}
 			className={styles.main}
 			tabIndex={-1}
 			id={React.use(SkipLinkContext)?.id}

--- a/examples/mui/Table.default.tsx
+++ b/examples/mui/Table.default.tsx
@@ -51,7 +51,7 @@ export default () => {
 				<TableBody>
 					{rows.map((row) => (
 						<TableRow key={row.name}>
-							<TableCell component="th" scope="row">
+							<TableCell render={<th />} scope="row">
 								{row.name}
 							</TableCell>
 							<TableCell align="right">{row.calories}</TableCell>

--- a/examples/mui/Table.footer.tsx
+++ b/examples/mui/Table.footer.tsx
@@ -53,7 +53,7 @@ export default () => {
 				<TableBody>
 					{rows.map((row) => (
 						<TableRow key={row.name}>
-							<TableCell component="th" scope="row">
+							<TableCell render={<th />} scope="row">
 								{row.name}
 							</TableCell>
 							<TableCell align="right">{row.calories}</TableCell>

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -15,6 +15,7 @@ import {
 	MuiChipLabel,
 } from "./~components/MuiChip.js";
 import { MuiSnackbar } from "./~components/MuiSnackbar.js";
+import { MuiTableCell, MuiTableHead } from "./~components/MuiTable.js";
 import {
 	ArrowDownIcon,
 	CaretsUpDownIcon,
@@ -347,7 +348,7 @@ function createTheme() {
 			MuiTableBody: {
 				defaultProps: { component: withRenderProp(Role, "tbody") },
 			},
-			// MuiTableCell: { defaultProps: { component: withRenderProp(Role, "td") } }, // This dynamically renders as `th` when inside TableHeader
+			MuiTableCell: { defaultProps: { component: MuiTableCell } },
 			MuiTableContainer: {
 				defaultProps: { component: withRenderProp(Role, "div") },
 			},
@@ -355,7 +356,7 @@ function createTheme() {
 				defaultProps: { component: withRenderProp(Role, "tfoot") },
 			},
 			MuiTableHead: {
-				defaultProps: { component: withRenderProp(Role, "thead") },
+				defaultProps: { component: MuiTableHead },
 			},
 			MuiTablePagination: {
 				defaultProps: {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -236,7 +236,7 @@ declare module "@mui/material/Switch" {
 
 declare module "@mui/material/TableCell" {
 	interface TableCellProps extends Pick<CommonProps, "render"> {
-		/** @deprecated DO NOT USE */
+		/** @deprecated Use `render` prop instead. */
 		component?: MuiTableCellProps["component"];
 	}
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -10,6 +10,8 @@
 import type { RoleProps } from "@ariakit/react/role";
 import type { BadgeProps } from "@mui/material/Badge";
 import type { IconButtonProps } from "@mui/material/IconButton";
+import type { CommonProps } from "@mui/material/OverridableComponent";
+import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type {
 	TextFieldProps,
 	TextFieldVariants,
@@ -229,6 +231,13 @@ declare module "@mui/material/Switch" {
 		success: false;
 		warning: false;
 		error: false;
+	}
+}
+
+declare module "@mui/material/TableCell" {
+	interface TableCellProps extends Pick<CommonProps, "render"> {
+		/** @deprecated DO NOT USE */
+		component?: MuiTableCellProps["component"];
 	}
 }
 

--- a/packages/mui/src/~components/MuiTable.tsx
+++ b/packages/mui/src/~components/MuiTable.tsx
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { Role } from "@ariakit/react/role";
+import { forwardRef } from "@stratakit/foundations/secret-internals";
+
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+const MuiTableHeadContext = React.createContext(false);
+
+// ----------------------------------------------------------------------------
+
+const MuiTableHead = forwardRef<"thead", BaseProps<"thead">>(
+	(props, forwardedRef) => {
+		return (
+			<MuiTableHeadContext.Provider value={true}>
+				<Role render={<thead />} {...props} ref={forwardedRef} />
+			</MuiTableHeadContext.Provider>
+		);
+	},
+);
+DEV: MuiTableHead.displayName = "MuiTableHead";
+
+// ----------------------------------------------------------------------------
+
+const MuiTableCell = forwardRef<"td", BaseProps<"td">>(
+	(props, forwardedRef) => {
+		const inHeader = React.useContext(MuiTableHeadContext);
+		const Component = inHeader ? "th" : "td";
+
+		return <Role render={<Component />} {...props} ref={forwardedRef} />;
+	},
+);
+DEV: MuiTableCell.displayName = "MuiTableCell";
+
+// ----------------------------------------------------------------------------
+
+export { MuiTableHead, MuiTableCell };


### PR DESCRIPTION
### Changes

This was leftover from https://github.com/iTwin/stratakit/pull/1212#discussion_r2773941051.

**Runtime:**

- `TableCell` and `TableHead` now use custom components so that the former dynamically renders as `<td>` or `<th>` based on whether it's inside the latter.

**Types:**

- `TableCell` required redefining the `render` prop and deprecating the `component` prop, presumably because it does not inherit from `OverridableComponent`.

**Examples:**

- Changed `component` prop to `render` prop in Table examples.

### Testing

Manually verified that:

- `render` prop works can be passed to `TableCell`.
- DOM output is correct, with—and more importantly—_without_ `render` prop.