### PR TITLE
improve `Button` contrast

### DIFF
--- a/.changeset/curvy-dryers-give.md
+++ b/.changeset/curvy-dryers-give.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed color contrast for a few `Button` permutations.

--- a/packages/mui/src/~components/MuiButton.css
+++ b/packages/mui/src/~components/MuiButton.css
@@ -48,10 +48,14 @@
 
 	&:where(.MuiButton-outlinedPrimary, .MuiButton-textPrimary) {
 		--_MuiButton-icon-color: var(--stratakit-color-icon-accent-strong);
+		--variant-outlinedBorder: var(--stratakit-color-border-accent-base);
 	}
 
 	&:where(.MuiButton-outlinedError, .MuiButton-textError) {
 		--_MuiButton-icon-color: var(--stratakit-color-icon-critical-base);
+		--variant-textColor: var(--stratakit-color-text-critical-base);
+		--variant-outlinedColor: var(--stratakit-color-text-critical-base);
+		--variant-outlinedBorder: var(--stratakit-color-border-critical-base);
 	}
 
 	&:where(.Mui-disabled) {


### PR DESCRIPTION
### Changes

This updates the colors for a few `Button` permutations.

- `color="error"`: updated text and border colors for `variant="text"` and `variant="outlined"`. The text color change is the most important one, as previously it was failing 4.5:1.
- `color="primary"`: updated border color for `variant="outlined"`

### Testing

| Before | After |
| --- | --- |
| <img width="579" height="281" alt="screenshot" src="https://github.com/user-attachments/assets/8720fc1f-a567-48ac-9043-070fadd4cc2b" /> | <img width="569" height="282" alt="screenshot" src="https://github.com/user-attachments/assets/73e862aa-9a06-4e7d-ac4d-ba92471fa39c" /> |
