### PR TITLE
adjust `List` spacing and sizing

### DIFF
--- a/.changeset/deep-nails-flow.md
+++ b/.changeset/deep-nails-flow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Decreased spacing/sizing of `List` components.

--- a/apps/website/src/content/docs/components/mui/List.md
+++ b/apps/website/src/content/docs/components/mui/List.md
@@ -8,6 +8,10 @@ links:
 
 ::example{src="mui/List.default"}
 
+## StrataKit MUI modifications
+
+- Spacing and sizing has been adjusted to better align with StrataKit's more compact visual design language.
+
 ## Examples
 
 ### ListItemAvatar

--- a/examples/mui/List.avatar.tsx
+++ b/examples/mui/List.avatar.tsx
@@ -22,7 +22,7 @@ export default () => {
 				disablePadding
 				secondaryAction={
 					<IconButton label="Rename">
-						<Icon href={`${svgRename}#icon`} />
+						<Icon href={svgRename} />
 					</IconButton>
 				}
 			>
@@ -39,7 +39,7 @@ export default () => {
 				disablePadding
 				secondaryAction={
 					<IconButton label="Rename">
-						<Icon href={`${svgRename}#icon`} />
+						<Icon href={svgRename} />
 					</IconButton>
 				}
 			>

--- a/packages/foundations/src/~size.css
+++ b/packages/foundations/src/~size.css
@@ -9,4 +9,7 @@ html,
 	--stratakit-size-control-field-height-small: 1.5rem;
 	--stratakit-size-control-field-height-medium: 2rem;
 	--stratakit-size-control-field-height-large: 2.5rem;
+
+	--stratakit-size-control-listitem-height-small: 1.75rem;
+	--stratakit-size-control-listitem-height-large: 2.5rem;
 }

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -290,6 +290,13 @@ function createTheme() {
 			MuiListItemButton: {
 				defaultProps: { component: Role.button },
 			},
+			MuiListItemText: {
+				defaultProps: {
+					slotProps: {
+						primary: { variant: "inherit" },
+					},
+				},
+			},
 			MuiListSubheader: { defaultProps: { component: Role.li } },
 			MuiMenu: { defaultProps: { component: Role.div } },
 			MuiMenuItem: { defaultProps: { component: Role.li } },

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -14,6 +14,7 @@
 @import "./~components/MuiForm.css";
 @import "./~components/MuiIconButton.css";
 @import "./~components/MuiInput.css";
+@import "./~components/MuiList.css";
 @import "./~components/MuiSlider.css";
 @import "./~components/MuiSwitch.css";
 @import "./~components/MuiTabs.css";

--- a/packages/mui/src/~components/MuiList.css
+++ b/packages/mui/src/~components/MuiList.css
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiList-root {
+	&:where(.MuiList-padding) {
+		padding-block: var(--stratakit-space-x1);
+	}
+}
+
+:is(
+		.MuiListItemButton-root,
+		.MuiListSubheader-root,
+		.MuiListItem-root:where(.MuiListItem-padding)
+	) {
+	line-height: unset;
+	min-block-size: var(--stratakit-size-control-listitem-height-large);
+	align-content: center;
+
+	padding-block: var(--stratakit-space-x1);
+	padding-inline: var(--stratakit-space-x3);
+	gap: var(--stratakit-space-x2);
+
+	:where(.MuiList-root.MuiList-dense) & {
+		min-block-size: var(--stratakit-size-control-listitem-height-small);
+		@apply --typography("body-sm");
+	}
+}
+
+:is(.MuiListItemIcon-root, .MuiListItemAvatar-root) {
+	min-width: unset;
+}
+
+.MuiListItemText-root {
+	margin: 0;
+	gap: var(--stratakit-space-x1);
+}


### PR DESCRIPTION
### Changes

A few changes to the spacing/sizing of `List` and its subcomponents:
- Reduced font-size (`"body1"` → `"inherit"`)
- Reduced height (uses new `--stratakit-size-control-listitem-height-*` variables)
- Reduced margins/paddings and the humongous gaps
- Reduced icon size (in examples)
- Adjusted values for `dense` prop.

Affects `ListItem` (without `disablePadding`), `ListItemButton` and `ListSubheader`. Also affects other components that depend on `List`, such as `Drawer`.

**Note**: `Avatar` size is already 40×40, so it makes the `ListItem` grow in size when combined with padding. This should be addressed separately, perhaps in #1314.

### Testing

| Before | After |
| --- | --- |
| <img width="419" height="576" alt="screenshot of all List variants with the chonky default spacing/sizing" src="https://github.com/user-attachments/assets/1d06b182-087c-4daf-9d8c-068d562d1163" /> | <img width="470" height="519" alt="screenshot with the compact spacing/sizing adjustments" src="https://github.com/user-attachments/assets/fd41682b-d3bb-46a6-9461-8447de711292" /> |

[Deploy preview](https://stratakit.bentley.com/1315/mui)