### PR TITLE
improve styling for `DialogActions` and `Backdrop`

### DIFF
--- a/.changeset/curvy-bananas-care.md
+++ b/.changeset/curvy-bananas-care.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Adjusted styling for `DialogActions`.

--- a/.changeset/famous-cloths-draw.md
+++ b/.changeset/famous-cloths-draw.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Adjusted styling for `Backdrop`.

--- a/apps/website/src/content/docs/components/mui/Dialog.md
+++ b/apps/website/src/content/docs/components/mui/Dialog.md
@@ -7,3 +7,7 @@ links:
 ---
 
 ::example{src="mui/Dialog.default"}
+
+## StrataKit MUI modifications
+
+- Restyled using StrataKit's visual language.

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -10,6 +10,7 @@
 @import "./~components/MuiCard.css";
 @import "./~components/MuiCheckbox.css";
 @import "./~components/MuiChip.css";
+@import "./~components/MuiDialog.css";
 @import "./~components/MuiForm.css";
 @import "./~components/MuiIconButton.css";
 @import "./~components/MuiInput.css";
@@ -29,16 +30,13 @@
 	color: var(--stratakit-color-text-neutral-primary);
 }
 
+.MuiBackdrop-root {
+	background-color: oklch(from var(--stratakit-color-bg-elevation-overlay) l c h / 0.8);
+}
+
 .MuiBottomNavigationAction-root {
 	&:where(.Mui-selected) {
 		color: var(--stratakit-color-text-accent-strong);
-	}
-}
-
-.MuiDialogActions-root {
-	&:where(.MuiDialogActions-spacing) {
-		padding-block: var(--stratakit-space-x4);
-		padding-inline: var(--stratakit-space-x5);
 	}
 }
 

--- a/packages/mui/src/~components/MuiDialog.css
+++ b/packages/mui/src/~components/MuiDialog.css
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiDialogActions-root {
+	background-color: var(--stratakit-color-bg-page-base);
+	background-clip: padding-box; /* Ensure background-color doesn't bleed into transparent border */
+	border: 1px solid transparent;
+	border-block-start-color: var(--stratakit-color-border-page-base);
+	border-end-end-radius: inherit;
+	border-end-start-radius: inherit;
+
+	&:where(.MuiDialogActions-spacing) {
+		padding-block: var(--stratakit-space-x4);
+		padding-inline: var(--stratakit-space-x5);
+	}
+}

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -50,6 +50,10 @@
 	}
 }
 
+.MuiDialog-paper {
+	border: 1px solid;
+}
+
 .MuiFormControlLabel-label:where(.Mui-disabled) {
 	color: GrayText;
 }


### PR DESCRIPTION
### Changes

Styling changes based on [`Dialog.css`](https://github.com/iTwin/stratakit/blob/main/packages/structures/src/Dialog.css):

1. `DialogActions` now has a dark background-color and top border, demarcating the dialog actions which were previously meshing with the content area. This required using a transparent `border` combined with `background-clip` to prevent covering the `Dialog`'s visual border (which comes from a box-shadow; more noticeable in dark mode).

2. `Backdrop` now uses a custom backdrop color (differs in light/dark color-schemes). This required using relative color syntax to add opacity, because MUI sets an inline `opacity` for animation purposes. Note: This affects more than just `Dialog`.

### Testing

Screenshot:

<img width="620" height="354" alt="screenshot of a dialog showing the dark footer background and the dark backdrop" src="https://github.com/user-attachments/assets/39cbfbff-ce07-4e9c-9c05-2988a57932eb" />

[Deploy preview](https://stratakit.bentley.com/1316/mui#dialog)