### PR TITLE
fix `Backdrop`

### DIFF
--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -31,7 +31,9 @@
 }
 
 .MuiBackdrop-root {
-	background-color: oklch(from var(--stratakit-color-bg-elevation-overlay) l c h / 0.8);
+	&:where(:not(.MuiBackdrop-invisible)) {
+		background-color: oklch(from var(--stratakit-color-bg-elevation-overlay) l c h / 0.8);
+	}
 }
 
 .MuiBottomNavigationAction-root {


### PR DESCRIPTION
### Changes

This addresses https://github.com/iTwin/stratakit/pull/1316#discussion_r2942765597.

### Testing

Menu's backdrop is no longer visible, while Dialog's backdrop looks as intended.

<img width="174" height="191" alt="screenshot" src="https://github.com/user-attachments/assets/a3b87d13-8410-4f67-a39c-c90c87423250" />
