### PR TITLE
bump deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3115,10 +3115,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  devalue@5.6.3:
+  devalue@5.6.4:
     resolution:
       {
-        integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==,
+        integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==,
       }
 
   devlop@1.1.0:
@@ -3488,10 +3488,10 @@ packages:
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
       }
 
-  h3@1.15.5:
+  h3@1.15.8:
     resolution:
       {
-        integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==,
+        integrity: sha512-iOH6Vl8mGd9nNfu9C0IZ+GuOAfJHcyf3VriQxWaSWIB76Fg4BnFuk4cxBxjmQSSxJS664+pgjP6e7VBnUzFfcg==,
       }
 
   hasown@2.0.2:
@@ -5398,10 +5398,10 @@ packages:
         integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
       }
 
-  undici@6.23.0:
+  undici@6.24.1:
     resolution:
       {
-        integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==,
+        integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==,
       }
     engines: { node: ">=18.17" }
 
@@ -5900,12 +5900,12 @@ snapshots:
       "@octokit/plugin-rest-endpoint-methods": 17.0.0(@octokit/core@7.0.6)
       "@octokit/request": 10.0.7
       "@octokit/request-error": 7.1.0
-      undici: 6.23.0
+      undici: 6.24.1
 
   "@actions/http-client@3.0.2":
     dependencies:
       tunnel: 0.0.6
-      undici: 6.23.0
+      undici: 6.24.1
 
   "@ariakit/core@0.4.18": {}
 
@@ -7234,7 +7234,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.6.3
+      devalue: 5.6.4
       diff: 8.0.3
       dlv: 1.1.3
       dset: 3.1.4
@@ -7530,7 +7530,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.6.3: {}
+  devalue@5.6.4: {}
 
   devlop@1.1.0:
     dependencies:
@@ -7771,7 +7771,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  h3@1.15.5:
+  h3@1.15.8:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
@@ -9287,7 +9287,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@6.23.0: {}
+  undici@6.24.1: {}
 
   unified@11.0.5:
     dependencies:
@@ -9358,7 +9358,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.5
+      h3: 1.15.8
       lru-cache: 11.2.6
       node-fetch-native: 1.6.7
       ofetch: 1.5.1


### PR DESCRIPTION
### Changes

Bumps:
- `undici` (fixes CVE-2026-1528, CVE-2026-1526, CVE-2026-2229, CVE-2026-1525, CVE-2026-1527)
- `devalue` (fixes CVE-2026-30226, GHSA-mwv9-gp5h-frr4)
- `h3` (fixes CVE-2026-33128, GHSA-wr4h-v87w-p3r7)

### Testing

✅