### PR TITLE
fix `MobileStepper` icon size

### DIFF
--- a/examples/mui/MobileStepper.default.tsx
+++ b/examples/mui/MobileStepper.default.tsx
@@ -28,7 +28,7 @@ export default () => {
 					disabled={activeStep === steps - 1}
 				>
 					Next
-					<Icon href={`${svgNext}#icon-large`} size="large" />
+					<Icon href={svgNext} />
 				</Button>
 			}
 			backButton={
@@ -38,7 +38,7 @@ export default () => {
 					onClick={() => setActiveStep((prev) => prev - 1)}
 					disabled={activeStep === 0}
 				>
-					<Icon href={`${svgBack}#icon-large`} size="large" />
+					<Icon href={svgBack} />
 					Back
 				</Button>
 			}


### PR DESCRIPTION
### Changes

Updates the `MobileStepper` example to use a regular size Icon, instead of the large one.

### Testing

Before:
<img width="670" height="70" alt="screenshot" src="https://github.com/user-attachments/assets/8c1fa2fa-6e83-4bc3-9315-a7b1607587eb" />

After:
<img width="675" height="72" alt="screenshot" src="https://github.com/user-attachments/assets/5e4da173-546e-4703-8ca4-2c50e655c69b" />
