### PR TITLE
create custom `ButtonBase`

### DIFF
--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -8,6 +8,7 @@ import { Role } from "@ariakit/react/role";
 import OutlinedInput from "@mui/material/OutlinedInput";
 import { createTheme as createMuiTheme } from "@mui/material/styles";
 import { MuiBadge } from "./~components/MuiBadge.js";
+import { MuiButtonBase } from "./~components/MuiButtonBase.js";
 import { MuiCard, MuiCardActionArea } from "./~components/MuiCard.js";
 import {
 	MuiChip,
@@ -162,9 +163,6 @@ function createTheme() {
 				},
 			},
 			MuiBottomNavigation: { defaultProps: { component: Role.div } },
-			MuiBottomNavigationAction: {
-				defaultProps: { component: Role.button },
-			},
 			MuiBreadcrumbs: {
 				defaultProps: {
 					component: Role.nav,
@@ -173,13 +171,13 @@ function createTheme() {
 			},
 			MuiButtonBase: {
 				defaultProps: {
-					component: Role.button,
+					component: MuiButtonBase,
 					disableRipple: true, // https://mui.com/material-ui/getting-started/faq/#how-can-i-disable-the-ripple-effect-globally
 				},
 			},
 			MuiButton: {
 				defaultProps: {
-					component: Role.button,
+					component: MuiButtonBase,
 					color: "secondary",
 					variant: "contained",
 				},
@@ -234,7 +232,7 @@ function createTheme() {
 			MuiDrawer: { defaultProps: { component: Role.div } },
 			MuiFab: {
 				defaultProps: {
-					component: Role.button,
+					component: MuiButtonBase,
 					color: "primary",
 				},
 			},
@@ -288,7 +286,7 @@ function createTheme() {
 			MuiList: { defaultProps: { component: Role.ul } },
 			MuiListItem: { defaultProps: { component: Role.li } },
 			MuiListItemButton: {
-				defaultProps: { component: Role.button },
+				defaultProps: { component: MuiButtonBase },
 			},
 			MuiListItemText: {
 				defaultProps: {
@@ -310,7 +308,7 @@ function createTheme() {
 			},
 			MuiPaginationItem: {
 				defaultProps: {
-					component: Role.button,
+					component: MuiButtonBase,
 					slots: {
 						previous: ChevronLeftIcon,
 						next: ChevronRightIcon,
@@ -355,12 +353,10 @@ function createTheme() {
 			MuiSnackbarContent: { defaultProps: { component: Role.div } },
 			MuiStack: { defaultProps: { component: Role.div } },
 			MuiStep: { defaultProps: { component: Role.div } },
-			MuiStepButton: { defaultProps: { component: Role.button } },
 			MuiSwitch: { defaultProps: { component: Role.span } },
 			MuiStepper: { defaultProps: { component: Role.div } },
 			MuiSvgIcon: { defaultProps: { component: Role.svg } },
 			MuiSwipeableDrawer: { defaultProps: { component: Role.div } },
-			MuiTab: { defaultProps: { component: Role.button } },
 			MuiTabs: { defaultProps: { component: Role.div } },
 			MuiTable: { defaultProps: { component: withRenderProp(Role, "table") } },
 			MuiTableBody: {

--- a/packages/mui/src/~components/MuiButtonBase.tsx
+++ b/packages/mui/src/~components/MuiButtonBase.tsx
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { Role } from "@ariakit/react/role";
+import {
+	forwardRef,
+	useMergedRefs,
+} from "@stratakit/foundations/secret-internals";
+
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+interface MuiButtonBaseProps extends BaseProps<"button"> {}
+
+const MuiButtonBase = forwardRef<"button", MuiButtonBaseProps>(
+	(props, forwardedRef) => {
+		const { "aria-disabled": ariaDisabled, ...rest } = props;
+
+		// MUI's ButtonBase treats this wrapper as a non-button, so it always sets `aria-disabled`.
+		// We need to infer the `disabled` prop from `aria-disabled` for native `<button>` elements.
+		const isDisabled = ariaDisabled === true || ariaDisabled === "true";
+
+		const [tagName, setTagName] = React.useState<string | undefined>(undefined);
+		const determineTagName = React.useCallback(
+			(element: HTMLElement | null) => {
+				if (!element) return;
+				setTagName(element.tagName);
+			},
+			[],
+		);
+		const isNativeButton = !props.render || tagName === "BUTTON";
+
+		const type = (() => {
+			if (!isNativeButton || props.type) return props.type;
+			if (props.formAction) return "submit"; // https://github.com/mui/material-ui/pull/47185
+			return "button";
+		})();
+
+		// Remove redundant `role="button"` for native `<button>`.
+		const role =
+			isNativeButton && props.role === "button" ? undefined : props.role;
+
+		return (
+			<Role.button
+				{...rest}
+				type={type}
+				role={role}
+				ref={useMergedRefs(determineTagName, forwardedRef)}
+				disabled={isNativeButton ? isDisabled : undefined}
+				aria-disabled={isNativeButton ? undefined : ariaDisabled}
+			/>
+		);
+	},
+);
+DEV: MuiButtonBase.displayName = "MuiButtonBase";
+
+// ----------------------------------------------------------------------------
+
+export { MuiButtonBase };

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -11,6 +11,7 @@ import {
 	useEventHandlers,
 	useMergedRefs,
 } from "@stratakit/foundations/secret-internals";
+import { MuiButtonBase } from "./MuiButtonBase.js";
 
 // ----------------------------------------------------------------------------
 
@@ -72,7 +73,7 @@ const MuiCardActionArea = forwardRef<"button", BaseProps<"button">>(
 		const context = React.useContext(MuiCardContext);
 
 		return (
-			<Role.button
+			<MuiButtonBase
 				{...rest}
 				ref={useMergedRefs(context?.setActionAreaElement, forwardedRef)}
 			/>

--- a/packages/mui/src/~components/MuiChip.tsx
+++ b/packages/mui/src/~components/MuiChip.tsx
@@ -9,6 +9,7 @@ import { VisuallyHidden } from "@ariakit/react/visually-hidden";
 import IconButton from "@mui/material/IconButton";
 import { useTheme } from "@mui/material/styles";
 import { DismissIcon } from "../Icon.js";
+import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type Chip from "@mui/material/Chip";
 
@@ -74,7 +75,7 @@ const MuiChipLabel = React.forwardRef<
 		};
 	}, [id, setLabelId]);
 
-	const Component = isClickable ? Role.button : Role.span;
+	const Component = isClickable ? MuiButtonBase : Role.span;
 	return (
 		<Component
 			id={id}

--- a/packages/mui/src/~components/MuiIconButton.tsx
+++ b/packages/mui/src/~components/MuiIconButton.tsx
@@ -3,9 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { Role } from "@ariakit/react/role";
 import Tooltip from "@mui/material/Tooltip";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { IconButtonOwnProps } from "@mui/material/IconButton";
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
@@ -23,12 +23,12 @@ const MuiIconButton = forwardRef<"button", MuiIconButtonProps>(
 		if (label) {
 			return (
 				<Tooltip title={label} describeChild={false}>
-					<Role.button {...rest} ref={forwardedRef} />
+					<MuiButtonBase {...rest} ref={forwardedRef} />
 				</Tooltip>
 			);
 		}
 
-		return <Role.button {...rest} ref={forwardedRef} />;
+		return <MuiButtonBase {...rest} ref={forwardedRef} />;
 	},
 );
 DEV: MuiIconButton.displayName = "MuiIconButton";


### PR DESCRIPTION
### Changes

After #1212, all instances of buttons were exhibiting slightly wrong behavior because MUI naïvely assumes that if a `component` prop is passed, then it must be a "non-native" button (e.g. a `<div>`).

This PR creates a custom `MuiButtonBase` which performs a runtime check against the DOM element's [`tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName) and sets the correct props accordingly. This component replaces the use of `Role.button` in various places:
- `ButtonBase`
- `Button`
- `IconButton`
- `Fab`
- `ListItemButton`
- `PaginationItem`
- `CardActionArea`
- `Chip`

All of the above were deemed necessary, except for `Chip`, which was changed only for consistency.

A few others don't need the `component` prop at all, as they automatically inherit from `ButtonBase`. This includes: `BottomNavigationAction`, `StepButton`, `Tab`.

#### Deferred

Links need special handling and are out of scope for this PR. I will handle [`href`](https://mui.com/material-ui/api/button/#button-prop-href), [`LinkComponent`](https://mui.com/material-ui/api/button-base/#button-base-prop-LinkComponent), and `render={<a href="…">}` separately in #1332.

In the future, we should also consider making disabled buttons focusable (i.e. using `aria-disabled` with `tabindex="0"` and manually preventing clicks), perhaps using Ariakit's `Button` helper.

### Testing

Verified that:
- A native button is rendered as `<button type="button">` (no `role`).
- When disabled, a native button is rendered as `<button type="button" disabled>` (no `aria-disabled`).
- A non-native `<div>` button is still rendered as `<div role="button" tabindex="0">` (no `type`).
- When disabled, a non-native button is rendered as `<div role="button" aria-disabled="true" tabindex="-1">`.
  - **Note:** `onClick` is still called for disabled non-native buttons. This behavior is consistent with stock MUI.
- `render` prop works.