### PR TITLE
add `rootNode` prop to `Root`

### DIFF
--- a/.changeset/honest-zebras-help.md
+++ b/.changeset/honest-zebras-help.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added `rootNode` prop to the `Root` component.

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -26,7 +26,9 @@ const key = `${packageName}@${__VERSION__}`;
 
 // ----------------------------------------------------------------------------
 
-interface RootProps extends BaseProps<"div"> {
+interface RootProps
+	extends BaseProps<"div">,
+		Pick<React.ComponentProps<typeof StrataKitRoot>, "rootNode"> {
 	children?: React.ReactNode;
 	/**
 	 * The color scheme to use for all components on the page.
@@ -67,18 +69,19 @@ DEV: Root.displayName = "Root";
 
 interface RootInnerProps
 	extends React.ComponentPropsWithoutRef<"div">,
-		Pick<RootProps, "colorScheme"> {}
+		Pick<RootProps, "colorScheme" | "rootNode"> {}
 
 /** @private */
 const RootInner = React.forwardRef<HTMLDivElement, RootInnerProps>(
 	(props, forwardedRef) => {
-		const { children, colorScheme, ...rest } = props;
+		const { children, colorScheme, rootNode, ...rest } = props;
 
 		return (
 			<StrataKitRoot
 				{...rest}
 				className={cx("🥝MuiRoot", props.className)}
 				colorScheme={colorScheme}
+				rootNode={rootNode}
 				synchronizeColorScheme
 				ref={forwardedRef}
 			>


### PR DESCRIPTION
### Changes

This exposes the `rootNode` prop from the `Root` component of `@stratakit/mui`. This prop is necessary for proper portaling behavior in popout windows.

The actual implementation of this prop is in `@stratakit/foundations`. #958

### Testing

I only quickly verified that types are working.