### PR TITLE
Improve Sizes docs of `Button` and `IconButton`

### DIFF
--- a/apps/website/src/content/docs/components/mui/Button.md
+++ b/apps/website/src/content/docs/components/mui/Button.md
@@ -71,6 +71,10 @@ An [**Icon**](/components/icon) can be displayed before or after the **Button’
 
 ### Sizes
 
+- **Small:** Use in compact interfaces where space is limited.
+- **Medium:** Default size, suitable for most use cases.
+- **Large:** Use in spacious layouts where a more prominent button is needed.
+
 ::example{src="mui/Button.sizes"}
 
 ## ✅ Do

--- a/apps/website/src/content/docs/components/mui/IconButton.md
+++ b/apps/website/src/content/docs/components/mui/IconButton.md
@@ -37,6 +37,10 @@ Make sure to provide an accessible description in the form of a visually hidden 
 
 ### Sizes
 
+- **Small:** Use in compact interfaces where space is limited.
+- **Medium:** Default size, suitable for most use cases.
+- **Large:** Use in spacious layouts where a more prominent button is needed.
+
 ::example{src="mui/IconButton.sizes"}
 
 ## ✅ Do


### PR DESCRIPTION
### Changes

This PR improves `### Sizes` section of `Button` and `IconButton` docs. https://github.com/iTwin/stratakit/pull/1309#discussion_r2966703184

### Testing

- [Button docs](https://stratakit.bentley.com/1343/docs/components/button/)
- [IconButton docs](https://stratakit.bentley.com/1343/docs/components/iconbutton/)