### PR TITLE
reduce `Paper` specificity

### DIFF
--- a/.changeset/metal-ducks-press.md
+++ b/.changeset/metal-ducks-press.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `Accordion` background-color.

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -3,6 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+@import "./~components/MuiPaper.css";
+
 @import "./~components/MuiAlert.css";
 @import "./~components/MuiAutocomplete.css";
 @import "./~components/MuiBadge.css";
@@ -58,47 +60,6 @@
 .MuiMenuItem-root {
 	&:where(.Mui-focusVisible) {
 		outline-offset: -2px;
-	}
-}
-
-.MuiPaper-root {
-	--Paper-overlay: unset !important; /* Remove background-image overlay that MUI adds in dark mode */
-
-	&:where(.MuiPaper-elevation1) {
-		--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-page-base);
-	}
-
-	&:where(
-			.MuiPaper-elevation2,
-			.MuiPaper-elevation3,
-			.MuiPaper-elevation4,
-			.MuiPaper-elevation5,
-			.MuiPaper-elevation6,
-			.MuiPaper-elevation7
-		) {
-		--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-elevation-base);
-	}
-
-	&:where(
-			.MuiPaper-elevation8,
-			.MuiPaper-elevation9,
-			.MuiPaper-elevation10,
-			.MuiPaper-elevation11,
-			.MuiPaper-elevation12,
-			.MuiPaper-elevation13,
-			.MuiPaper-elevation14,
-			.MuiPaper-elevation15,
-			.MuiPaper-elevation16,
-			.MuiPaper-elevation17,
-			.MuiPaper-elevation18,
-			.MuiPaper-elevation19,
-			.MuiPaper-elevation20,
-			.MuiPaper-elevation21,
-			.MuiPaper-elevation22,
-			.MuiPaper-elevation23,
-			.MuiPaper-elevation24
-		) {
-		--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-elevation-level-1);
 	}
 }
 

--- a/packages/mui/src/~components/MuiPaper.css
+++ b/packages/mui/src/~components/MuiPaper.css
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+:where(.MuiPaper-root) {
+	--Paper-overlay: unset !important; /* Remove background-image overlay that MUI adds in dark mode */
+
+	&:where(.MuiPaper-elevation1) {
+		--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-page-base);
+	}
+
+	&:where(
+			.MuiPaper-elevation2,
+			.MuiPaper-elevation3,
+			.MuiPaper-elevation4,
+			.MuiPaper-elevation5,
+			.MuiPaper-elevation6,
+			.MuiPaper-elevation7
+		) {
+		--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-elevation-base);
+	}
+
+	&:where(
+			.MuiPaper-elevation8,
+			.MuiPaper-elevation9,
+			.MuiPaper-elevation10,
+			.MuiPaper-elevation11,
+			.MuiPaper-elevation12,
+			.MuiPaper-elevation13,
+			.MuiPaper-elevation14,
+			.MuiPaper-elevation15,
+			.MuiPaper-elevation16,
+			.MuiPaper-elevation17,
+			.MuiPaper-elevation18,
+			.MuiPaper-elevation19,
+			.MuiPaper-elevation20,
+			.MuiPaper-elevation21,
+			.MuiPaper-elevation22,
+			.MuiPaper-elevation23,
+			.MuiPaper-elevation24
+		) {
+		--stratakit-mui-palette-background-paper: var(--stratakit-color-bg-elevation-level-1);
+	}
+}


### PR DESCRIPTION
### Context

`Paper` is a low-level helper component, used as the base for several components, such as `Accordion` and `Card`. Its styles should have the lowest priority so that components that build upon it can have more specific overrides.

In the currently released version, the following declaration is having no effect because it is being overridden by the Paper styles further down:

https://github.com/iTwin/stratakit/blob/a84b020ce80a5c8607617aefb5a7addbd7e81d5a/packages/mui/src/~components.css#L24-L26

### Changes

Moved `MuiPaper` styles to the top and wrapped in `:where()` to nullify specificity, allowing other styles to take priority.

Alternative considered: increase specificity of other components, e.g. `.MuiAccordion-root:is(.MuiPaper-root)`.

### Testing

Verified that Accordion styles are taking precedence. No visual change in test-app, but it will have an effect on a different background-color.