### PR TITLE
fix circular import

### DIFF
--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { Text } from "@stratakit/bricks";
 import { Icon } from "@stratakit/foundations";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
+import Text from "./Text.js";
 
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 


### PR DESCRIPTION
### Changes

Fixes a circular import that was causing this error:

```terminal
[WARN] [vite] Export "default" of module "../../packages/bricks/dist/Badge.js" was reexported through module "../../packages/bricks/dist/index.js" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order
```

### Testing

No longer seeing any warnings when building.