### PR TITLE
update selected state styles

### DIFF
--- a/.changeset/curvy-donkeys-film.md
+++ b/.changeset/curvy-donkeys-film.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated styling for selected states across various components: `Autocomplete`, `ListItemButton`, `Pagination`, `Select`, `TableRow`, `ToggleButton`.

--- a/apps/website/src/content/docs/components/mui/Pagination.md
+++ b/apps/website/src/content/docs/components/mui/Pagination.md
@@ -11,3 +11,4 @@ links:
 ## StrataKit MUI modifications
 
 - The `shape` prop now defaults to `"rounded"` instead of `"circular"`.
+- Lightly styled using StrataKit's visual language.

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -22,6 +22,7 @@
 @import "./~components/MuiSlider.css";
 @import "./~components/MuiStepper.css";
 @import "./~components/MuiSwitch.css";
+@import "./~components/MuiTable.css";
 @import "./~components/MuiTabs.css";
 @import "./~components/MuiToggleButton.css";
 
@@ -42,12 +43,6 @@
 	}
 }
 
-.MuiBottomNavigationAction-root {
-	&:where(.Mui-selected) {
-		color: var(--stratakit-color-text-accent-strong);
-	}
-}
-
 .MuiLink-root {
 	font-weight: 500;
 	text-decoration-color: currentColor;
@@ -60,8 +55,22 @@
 }
 
 .MuiMenuItem-root {
+	&:where(.Mui-selected) {
+		border-block: 1px solid var(--stratakit-color-border-accent-strong);
+		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+		color: var(--stratakit-color-text-accent-strong);
+	}
+
 	&:where(.Mui-focusVisible) {
 		outline-offset: -2px;
+	}
+}
+
+.MuiPaginationItem-root {
+	&:where(.Mui-selected) {
+		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+		border: 1px solid var(--stratakit-color-border-accent-strong);
+		color: var(--stratakit-color-text-accent-strong);
 	}
 }
 

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -43,3 +43,19 @@
 	@apply --typography("body-md");
 	min-block-size: var(--stratakit-size-control-listitem-height-small);
 }
+
+.MuiAutocomplete-option {
+	@apply --typography("body-md");
+	background-color: transparent;
+
+	&:where([aria-selected="true"]:not([aria-disabled="true"])) {
+		border-block: 1px solid var(--stratakit-color-border-accent-strong);
+		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+		color: var(--stratakit-color-text-accent-strong);
+	}
+
+	&:where(.Mui-focusVisible) {
+		outline: var(--🥝focus-outline);
+		outline-offset: -2px;
+	}
+}

--- a/packages/mui/src/~components/MuiList.css
+++ b/packages/mui/src/~components/MuiList.css
@@ -18,6 +18,9 @@
 	min-block-size: var(--stratakit-size-control-listitem-height-large);
 	align-content: center;
 
+	border-block: 1px solid transparent;
+	margin-block-end: -1px; /* prevent double border */
+
 	padding-block: var(--stratakit-space-x1);
 	padding-inline: var(--stratakit-space-x3);
 	gap: var(--stratakit-space-x2);
@@ -32,6 +35,13 @@
 			var(--stratakit-size-control-field-height-medium) +
 			var(--stratakit-space-x3)
 		);
+	}
+
+	&:where(.Mui-selected) {
+		border-block: 1px solid var(--stratakit-color-border-accent-strong);
+		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+		color: var(--stratakit-color-text-accent-strong);
+		--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
 	}
 }
 

--- a/packages/mui/src/~components/MuiTable.css
+++ b/packages/mui/src/~components/MuiTable.css
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiTableRow-root {
+	&:where(.Mui-selected) {
+		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+	}
+}
+
+.MuiTableCell-root {
+	&:where(.MuiTableCell-paddingCheckbox) {
+		text-align: center;
+	}
+
+	:where(.MuiTableRow-root.Mui-selected) & {
+		border-color: var(--stratakit-color-border-accent-strong);
+		position: relative;
+
+		&::before {
+			content: "";
+			position: absolute;
+			inset: 0;
+			pointer-events: none;
+			border-block-start: 1px solid var(--stratakit-color-border-accent-strong);
+		}
+	}
+}

--- a/packages/mui/src/~components/MuiToggleButton.css
+++ b/packages/mui/src/~components/MuiToggleButton.css
@@ -25,4 +25,11 @@
 		--_MuiToggleButton-height: var(--stratakit-size-control-field-height-large);
 		--_MuiToggleButton-padding: var(--stratakit-space-x3);
 	}
+
+	&:where(.Mui-selected) {
+		border-color: var(--stratakit-color-border-accent-strong);
+		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+		color: var(--stratakit-color-text-accent-strong);
+		--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
+	}
 }

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -3,6 +3,15 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+.MuiAutocomplete-option {
+	&:where([aria-selected="true"]:not([aria-disabled="true"])) {
+		background-color: SelectedItem;
+		border-color: SelectedItemText;
+		color: SelectedItemText;
+		forced-color-adjust: none; /* removing the backplate */
+	}
+}
+
 .MuiAvatar-root {
 	border: 1px solid;
 }
@@ -70,6 +79,15 @@
 	&::before,
 	&::after {
 		background-color: MarkText;
+	}
+}
+
+.MuiPaginationItem-root {
+	&:where(.Mui-selected) {
+		background-color: SelectedItem;
+		border-color: SelectedItemText;
+		color: SelectedItemText;
+		forced-color-adjust: none; /* removing the backplate */
 	}
 }
 
@@ -144,5 +162,12 @@
 		+ .MuiSwitch-track {
 			--_MuiSwitch-track-border-color: GrayText;
 		}
+	}
+}
+
+.MuiToggleButton-root {
+	&:where(.Mui-selected) {
+		background-color: SelectedItem;
+		color: SelectedItemText;
 	}
 }

--- a/packages/mui/src/~tokens.css
+++ b/packages/mui/src/~tokens.css
@@ -26,6 +26,7 @@
 	--stratakit-mui-palette-secondary-contrastText: var(--stratakit-color-text-neutral-emphasis);
 
 	--stratakit-mui-palette-action-active: var(--stratakit-color-icon-neutral-primary);
+	--stratakit-mui-palette-action-selected: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 	--stratakit-mui-palette-action-disabled: var(--stratakit-color-icon-neutral-disabled);
 	--stratakit-mui-palette-action-disabledBackground: var(
 		--stratakit-color-bg-glow-on-surface-disabled


### PR DESCRIPTION
### Changes

Updates to selected state styling across the board, using the following tokens:
- Background: `--stratakit-color-bg-glow-on-surface-accent-pressed`
- Border: `--stratakit-color-border-accent-strong`
- Text: `--stratakit-color-text-accent-strong`
- Icon: `--stratakit-color-icon-accent-strong`

This almost entirely addresses the [Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html) a11y issue in MUI components, where only a faint background change is used to convey selected states. It also makes it consistent with the Strata design language.

The MUI token `--stratakit-mui-palette-action-selected` now maps to `--stratakit-color-bg-glow-on-surface-accent-pressed` instead of the default neutral overlay. This is used inconsistently across MUI components and is mainly a fallback.

Component-level adjustments listed below. Some basic forced colors styles included for each.

#### 1. `Autocomplete`

- The options hug the edges, so only top and bottom border added for now. Also updated font-size.
- **Future:** I believe we should style it consistently with `Select` options.

#### ~~2. `BottomNavigation`~~

(Moved to separate PR: #1373)

#### 3. `ListItemButton`

- Similar to Autocomplete options, only top and bottom borders added.
- **Future**: I believe we should style the list to _not_ hug the edges (similar to NavigationRail).

#### 4. `Pagination`

- This now looks similar the legacy IconButton active state. Resolves the third point of #1233.
- Works nicely together with the border-radius change from #1365.

#### 5. `Select`

This is being handled properly in #1253 but I've changed it here too for consistency with Autocomplete.

#### 6. `TableRow`

- This now matches the legacy Table component, which adds top and bottom borders. Text color is not changed.
- Proper use of this requires a checkbox, for which I've fixed the center alignment.

#### 7. `ToggleButton`

This is also similar to Pagination (and legacy IconButton). The border-radius for items near (vs far from) the edges is automatically handled by MUI.

#### Notes

Combined disabled+active states not currently supported.

### Testing

| Component | Screenshot |
| --- | --- |
| `Autocomplete` | <img width="313" height="103" alt="image" src="https://github.com/user-attachments/assets/cf05197e-9168-40f5-8ec4-5bc7e79b9434" /> |
| `ListItemButton` | <img width="248" height="150" alt="image" src="https://github.com/user-attachments/assets/24ab5587-3f53-413f-aa96-8faa6337939e" /> |
| `Pagination` | <img width="345" height="59" alt="image" src="https://github.com/user-attachments/assets/873315ca-4333-4927-9785-1811b08da342" /> |
| `Select` | <img width="255" height="112" alt="image" src="https://github.com/user-attachments/assets/7e8b4295-315d-478c-9eba-461a79e34f34" /> |
| `TableRow` | <img width="303" height="172" alt="image" src="https://github.com/user-attachments/assets/a4bb3f9e-1bed-42ff-8f7a-a0bd8c574afa" /> |
| `ToggleButton` | <img width="183" height="57" alt="image" src="https://github.com/user-attachments/assets/bb421534-a4d2-4f07-80f4-88f0a31c6926" /><br /><img width="187" height="64" alt="image" src="https://github.com/user-attachments/assets/0a2d7f88-fd09-4392-b29b-1d89e01285b2" /> |