### PR TITLE
Adjust positioning and spacing of `Select` dropdown icon

### DIFF
--- a/.changeset/frank-gifts-serve.md
+++ b/.changeset/frank-gifts-serve.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Adjusted positioning and spacing of `Select` and `NativeSelect`'s dropdown icon.

--- a/examples/mui/NativeSelect.default.module.css
+++ b/examples/mui/NativeSelect.default.module.css
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
-.formControl {
-	min-inline-size: 250px;
-}

--- a/examples/mui/NativeSelect.default.tsx
+++ b/examples/mui/NativeSelect.default.tsx
@@ -8,12 +8,10 @@ import FormControl from "@mui/material/FormControl";
 import InputLabel from "@mui/material/InputLabel";
 import NativeSelect from "@mui/material/NativeSelect";
 
-import styles from "./NativeSelect.default.module.css";
-
 export default () => {
 	const inputId = React.useId();
 	return (
-		<FormControl className={styles.formControl}>
+		<FormControl>
 			<InputLabel variant="standard" htmlFor={inputId}>
 				Choose a design system:
 			</InputLabel>

--- a/examples/mui/Select.default.module.css
+++ b/examples/mui/Select.default.module.css
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
-.formControl {
-	min-inline-size: 250px;
-}

--- a/examples/mui/Select.default.tsx
+++ b/examples/mui/Select.default.tsx
@@ -9,13 +9,11 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 
-import styles from "./Select.default.module.css";
-
 export default () => {
 	const labelId = React.useId();
 	const label = "Choose a design system:";
 	return (
-		<FormControl className={styles.formControl}>
+		<FormControl>
 			<InputLabel id={labelId}>{label}</InputLabel>
 			<Select labelId={labelId} label={label} defaultValue={2}>
 				<MenuItem value={1}>iTwinUI</MenuItem>

--- a/examples/mui/Select.icon.module.css
+++ b/examples/mui/Select.icon.module.css
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
-.formControl {
-	min-inline-size: 250px;
-}

--- a/examples/mui/Select.icon.module.css
+++ b/examples/mui/Select.icon.module.css
@@ -6,13 +6,3 @@
 .formControl {
 	min-inline-size: 250px;
 }
-
-.input {
-	display: flex;
-	align-items: center;
-	gap: var(--stratakit-space-x2);
-
-	> .icon {
-		min-inline-size: initial;
-	}
-}

--- a/examples/mui/Select.icon.tsx
+++ b/examples/mui/Select.icon.tsx
@@ -15,13 +15,12 @@ import { Icon } from "@stratakit/mui";
 import svgCircle from "@stratakit/icons/circle.svg";
 import svgRectangle from "@stratakit/icons/rectangle.svg";
 import svgStar from "@stratakit/icons/star.svg";
-import styles from "./Select.icon.module.css";
 
 export default () => {
 	const labelId = React.useId();
 	const label = "Choose a shape:";
 	return (
-		<FormControl className={styles.formControl}>
+		<FormControl>
 			<InputLabel id={labelId}>{label}</InputLabel>
 			<Select labelId={labelId} label={label} defaultValue={2}>
 				<MenuItem value={1}>

--- a/examples/mui/Select.icon.tsx
+++ b/examples/mui/Select.icon.tsx
@@ -23,30 +23,21 @@ export default () => {
 	return (
 		<FormControl className={styles.formControl}>
 			<InputLabel id={labelId}>{label}</InputLabel>
-			<Select
-				labelId={labelId}
-				label={label}
-				defaultValue={2}
-				slotProps={{
-					input: {
-						className: styles.input,
-					},
-				}}
-			>
+			<Select labelId={labelId} label={label} defaultValue={2}>
 				<MenuItem value={1}>
-					<ListItemIcon className={styles.icon}>
+					<ListItemIcon>
 						<Icon href={svgRectangle} />
 					</ListItemIcon>
 					<ListItemText>Rectangle</ListItemText>
 				</MenuItem>
 				<MenuItem value={2}>
-					<ListItemIcon className={styles.icon}>
+					<ListItemIcon>
 						<Icon href={svgCircle} />
 					</ListItemIcon>
 					<ListItemText>Circle</ListItemText>
 				</MenuItem>
 				<MenuItem value={3}>
-					<ListItemIcon className={styles.icon}>
+					<ListItemIcon>
 						<Icon href={svgStar} />
 					</ListItemIcon>
 					<ListItemText>Star</ListItemText>

--- a/examples/mui/Select.multiple.module.css
+++ b/examples/mui/Select.multiple.module.css
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
-.formControl {
-	min-inline-size: 250px;
-}

--- a/examples/mui/Select.multiple.tsx
+++ b/examples/mui/Select.multiple.tsx
@@ -9,13 +9,11 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 
-import styles from "./Select.multiple.module.css";
-
 export default () => {
 	const labelId = React.useId();
 	const label = "Choose design systems:";
 	return (
-		<FormControl className={styles.formControl}>
+		<FormControl>
 			<InputLabel id={labelId}>{label}</InputLabel>
 			<Select labelId={labelId} label={label} defaultValue={[2]} multiple>
 				<MenuItem value={1}>iTwinUI</MenuItem>

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -21,6 +21,7 @@
 @import "./~components/MuiInput.css";
 @import "./~components/MuiList.css";
 @import "./~components/MuiMenu.css";
+@import "./~components/MuiSelect.css";
 @import "./~components/MuiSlider.css";
 @import "./~components/MuiStepper.css";
 @import "./~components/MuiSwitch.css";
@@ -63,10 +64,4 @@
 		border: 1px solid var(--stratakit-color-border-accent-strong);
 		color: var(--stratakit-color-text-accent-strong);
 	}
-}
-
-.MuiSelect-select {
-	display: flex;
-	align-items: center;
-	gap: var(--stratakit-space-x2);
 }

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -64,3 +64,9 @@
 		color: var(--stratakit-color-text-accent-strong);
 	}
 }
+
+.MuiSelect-select {
+	display: flex;
+	align-items: center;
+	gap: var(--stratakit-space-x2);
+}

--- a/packages/mui/src/~components/MuiInput.css
+++ b/packages/mui/src/~components/MuiInput.css
@@ -9,6 +9,9 @@
 	--✨border--error: var(--stratakit-color-border-critical-base);
 	--✨border--disabled: var(--stratakit-color-border-glow-on-surface-disabled);
 
+	--✨padding-inline--small: var(--stratakit-space-x2);
+	--✨padding-inline--medium: var(--stratakit-space-x3);
+
 	padding: 0;
 	border: 1px solid var(--_MuiInput-border-color);
 	border-radius: 4px;
@@ -17,6 +20,7 @@
 	@apply --typography("body-md");
 	--_MuiInput-block-size: var(--stratakit-size-control-field-height-medium);
 	--_MuiInput-border-color: var(--✨border--default);
+	--_MuiInput-padding-inline: var(--✨padding-inline--medium);
 
 	@media (any-hover: hover) {
 		&:where(:not(.Mui-disabled)):hover {
@@ -31,6 +35,7 @@
 	&:where(.MuiInputBase-sizeSmall) {
 		@apply --typography("body-sm");
 		--_MuiInput-block-size: var(--stratakit-size-control-field-height-small);
+		--_MuiInput-padding-inline: var(--✨padding-inline--small);
 	}
 
 	&:where(:focus-within) {
@@ -56,19 +61,11 @@
 }
 
 .MuiInputBase-input {
-	--✨padding-inline--small: var(--stratakit-space-x2);
-	--✨padding-inline--medium: var(--stratakit-space-x3);
-
 	height: unset;
 	min-block-size: calc(var(--_MuiInput-block-size) - 2px); /* Accommodate for border width */
 	padding-block: 0;
 	padding-inline: var(--_MuiInput-padding-inline);
 	align-content: center;
-	--_MuiInput-padding-inline: var(--✨padding-inline--medium);
-
-	:where(.MuiInputBase-root.MuiInputBase-sizeSmall) & {
-		--_MuiInput-padding-inline: var(--✨padding-inline--small);
-	}
 
 	&:where(input, textarea) {
 		&::placeholder {

--- a/packages/mui/src/~components/MuiSelect.css
+++ b/packages/mui/src/~components/MuiSelect.css
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+:is(.MuiSelect-select, .MuiNativeSelect-select):is(.MuiInputBase-input) {
+	--✨gap: var(--stratakit-space-x2);
+	--✨icon-size: 1rem;
+
+	display: flex;
+	align-items: center;
+	gap: var(--✨gap);
+
+	/* reserve space for the absolute positioned icon */
+	padding-inline-end: calc(
+		(var(--_MuiInput-padding-inline) + var(--✨gap) - 1px) +
+		var(--✨icon-size)
+	);
+}
+
+:is(.MuiSelect-icon, .MuiNativeSelect-icon) {
+	inset-block-start: 50%;
+	translate: 0 -50%;
+	inset-inline-end: calc(var(--_MuiInput-padding-inline) - 1px);
+}


### PR DESCRIPTION
### Changes

- Moved input and icon styling out of `Select.icon.module.css` as requested in https://github.com/iTwin/stratakit/pull/1253#discussion_r3030884224.
- Adjusted positioning and spacing of icon used in `Select` and `NativeSelect`.

**Deploy previews:**
- [`NativeSelect`](https://stratakit.bentley.com/1396/mui/#nativeselect)
- [`Select`](https://stratakit.bentley.com/1396/mui/#select)
- [`Table` paginator select](https://stratakit.bentley.com/1396/mui/#table)

| Component | Before | After |
| -- | -- | -- |
| `Select` | <img width="468" height="215" alt="Screenshot 2026-04-09 at 3 09 26 PM" src="https://github.com/user-attachments/assets/fd5ff4bc-8eba-4a26-b5e1-96ae3115cb3e" /> | <img width="582" height="215" alt="Screenshot 2026-04-09 at 3 09 06 PM" src="https://github.com/user-attachments/assets/5cba9130-b9b4-4d0c-8267-f607fb86eb3c" /> |
| `NativeSelect` in paginator | <img width="339" height="94" alt="Screenshot 2026-04-09 at 3 10 47 PM" src="https://github.com/user-attachments/assets/c539f0ac-566d-4b4a-99aa-c259d90115b7" /> | <img width="391" height="94" alt="Screenshot 2026-04-09 at 3 10 19 PM" src="https://github.com/user-attachments/assets/b5d26889-eef3-4c85-a195-028481457d7f" /> |



### Testing

- Tested `Select`, `NativeSelect`, and paginator select.
- When testing `Select`, delete the label so the select doesn't stretch.