### PR TITLE
upgrade to MUI v9

### DIFF
--- a/.changeset/chubby-planes-count.md
+++ b/.changeset/chubby-planes-count.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Updated `Stepper` and `Step` to use `<ul>` and `<li>` elements respectively. Explicit `role`s do not need to be set anymore.

--- a/.changeset/long-squids-study.md
+++ b/.changeset/long-squids-study.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Updated `ButtonBase` and derived components to use the new [`nativeButton`](https://mui.com/material-ui/api/button-base/#button-base-prop-nativeButton) prop. When rendering buttons as non-`<button>` elements (e.g. `<a>`), make sure to also set `nativeButton={false}`.

--- a/.changeset/silent-oranges-relax.md
+++ b/.changeset/silent-oranges-relax.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Updated peer dependency range of `@mui/material` to `^9.0.0`.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
         This helps us reproduce the issue.
       placeholder: |
         - @stratakit/mui 0.2.1
-        - @mui/material 7.3.8
+        - @mui/material 9.0.0
         - react 19.2.0
         - Browsers: Chrome 147, Safari 26.2
     validations:

--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -139,7 +139,7 @@ export const meta: MetaFunction = () => {
  */
 const components: Record<string, React.ReactNode> = {
 	Accordion: (
-		<Stack spacing={1} alignSelf="stretch">
+		<Stack spacing={1} sx={{ alignSelf: "stretch" }}>
 			<div>
 				<AccordionDefault />
 			</div>
@@ -160,14 +160,14 @@ const components: Record<string, React.ReactNode> = {
 		</Stack>
 	),
 	Alert: (
-		<Stack spacing={1} alignSelf="stretch">
+		<Stack spacing={1} sx={{ alignSelf: "stretch" }}>
 			<AlertDefault />
 			<AlertTitle />
 			{!isProduction && <AlertPermutations_ />}
 		</Stack>
 	),
 	AppBar: (
-		<Stack spacing={1} alignSelf="stretch">
+		<Stack spacing={1} sx={{ alignSelf: "stretch" }}>
 			<AppBarDefault />
 		</Stack>
 	),
@@ -195,7 +195,7 @@ const components: Record<string, React.ReactNode> = {
 		</>
 	),
 	BottomNavigation: (
-		<Stack spacing={1} alignSelf="stretch">
+		<Stack spacing={1} sx={{ alignSelf: "stretch" }}>
 			<BottomNavigationDefault />
 		</Stack>
 	),
@@ -228,7 +228,7 @@ const components: Record<string, React.ReactNode> = {
 		</>
 	),
 	Chip: (
-		<Stack spacing={1} direction="row" useFlexGap flexWrap="wrap">
+		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
 			<ChipDefault />
 			<ChipOutlined />
 			<ChipClickable />
@@ -250,7 +250,7 @@ const components: Record<string, React.ReactNode> = {
 	Dialog: <DialogDefault />,
 	Divider: (
 		<>
-			<Stack alignSelf="stretch">
+			<Stack sx={{ alignSelf: "stretch" }}>
 				<DividerDefault />
 			</Stack>
 			<DividerVertical />
@@ -271,7 +271,7 @@ const components: Record<string, React.ReactNode> = {
 		</>
 	),
 	LinearProgress: (
-		<Stack spacing={1} alignSelf="stretch">
+		<Stack spacing={1} sx={{ alignSelf: "stretch" }}>
 			<LinearProgressDefault />
 			{!isProduction && <LinearProgressColors_ />}
 		</Stack>
@@ -287,7 +287,7 @@ const components: Record<string, React.ReactNode> = {
 		</>
 	),
 	List: (
-		<Stack spacing={1} alignSelf="stretch">
+		<Stack spacing={1} sx={{ alignSelf: "stretch" }}>
 			<ListDefault />
 			<ListAvatar />
 			<ListSubheader />
@@ -301,7 +301,7 @@ const components: Record<string, React.ReactNode> = {
 	),
 	...(isProduction ? {} : { MenuList: <MenuListDefault_ /> }),
 	MobileStepper: (
-		<Stack spacing={1} alignSelf="stretch">
+		<Stack spacing={1} sx={{ alignSelf: "stretch" }}>
 			<MobileStepperDefault />
 		</Stack>
 	),
@@ -324,7 +324,7 @@ const components: Record<string, React.ReactNode> = {
 		</>
 	),
 	Skeleton: (
-		<Stack spacing={2} alignSelf="stretch">
+		<Stack spacing={2} sx={{ alignSelf: "stretch" }}>
 			<SkeletonDefault />
 			<SkeletonVariants />
 		</Stack>
@@ -340,7 +340,7 @@ const components: Record<string, React.ReactNode> = {
 	Snackbar: <SnackbarDefault />,
 	SpeedDial: <SpeedDialDefault />,
 	Stepper: (
-		<Stack spacing={4} alignSelf="stretch">
+		<Stack spacing={4} sx={{ alignSelf: "stretch" }}>
 			<StepperDefault />
 			<StepperOptional />
 			<StepperClickable />
@@ -493,7 +493,11 @@ function ComponentExamples(props: ComponentExamplesProps) {
 				</IconButton>
 			</hgroup>
 
-			<Stack spacing={2} alignItems="start" className={styles.exampleContent}>
+			<Stack
+				spacing={2}
+				sx={{ alignItems: "start" }}
+				className={styles.exampleContent}
+			>
 				{props.children}
 			</Stack>
 		</div>

--- a/apps/website/src/content/docs/components/mui/Stepper.md
+++ b/apps/website/src/content/docs/components/mui/Stepper.md
@@ -13,6 +13,7 @@ links:
 - Lightly styled using StrataKit's visual language.
 - The `StepIcon` has been fully replaced with new icons and a custom CSS implementation.
 - Reduced the hit target size of `StepButton`.
+- The `connector` prop is used to add `aria-hidden="true"` to the `StepConnector`.
 - Includes `forced-colors` support.
 
 ## Examples

--- a/examples/mui/AppBar.default.tsx
+++ b/examples/mui/AppBar.default.tsx
@@ -19,7 +19,7 @@ export default () => {
 				<IconButton size="large" edge="start" aria-label="menu">
 					<Icon href={`${svgMenu}#icon-large`} size="large" />
 				</IconButton>
-				<Typography variant="h6" render={<div />} flexGrow={1}>
+				<Typography variant="h6" render={<div />} sx={{ flexGrow: 1 }}>
 					News
 				</Typography>
 				<Button variant="text">Login</Button>

--- a/examples/mui/Button.sizes.tsx
+++ b/examples/mui/Button.sizes.tsx
@@ -8,7 +8,7 @@ import Stack from "@mui/material/Stack";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" alignItems="center">
+		<Stack spacing={1} direction="row" sx={{ alignItems: "center" }}>
 			<Button size="small">Small</Button>
 			<Button size="medium">Medium</Button>
 			<Button size="large">Large</Button>

--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -26,7 +26,9 @@ export default () => {
 			/>
 			<CardContent>
 				<Typography gutterBottom variant="h6" render={<h2 />}>
-					<CardActionArea render={<a href="#" />}>Stadium</CardActionArea>
+					<CardActionArea render={<a href="#" />} nativeButton={false}>
+						Stadium
+					</CardActionArea>
 				</Typography>
 				<Typography variant="body2" color="text.secondary">
 					Stadium is a place for outdoor sports, concerts, or other events and

--- a/examples/mui/Chip.sizes.tsx
+++ b/examples/mui/Chip.sizes.tsx
@@ -8,7 +8,7 @@ import Stack from "@mui/material/Stack";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" alignItems="center">
+		<Stack spacing={1} direction="row" sx={{ alignItems: "center" }}>
 			<Chip size="small" label="Small" />
 			<Chip label="Medium" />
 		</Stack>

--- a/examples/mui/IconButton.sizes.tsx
+++ b/examples/mui/IconButton.sizes.tsx
@@ -11,7 +11,7 @@ import svgPlaceholder from "@stratakit/icons/placeholder.svg";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" alignItems="center">
+		<Stack spacing={1} direction="row" sx={{ alignItems: "center" }}>
 			<IconButton size="small" label="Small">
 				<Icon href={svgPlaceholder} />
 			</IconButton>

--- a/examples/mui/NativeSelect.default.tsx
+++ b/examples/mui/NativeSelect.default.tsx
@@ -19,9 +19,11 @@ export default () => {
 			</InputLabel>
 			<NativeSelect
 				defaultValue={2}
-				inputProps={{
-					name: "design-system",
-					id: inputId,
+				slotProps={{
+					input: {
+						name: "design-system",
+						id: inputId,
+					},
 				}}
 			>
 				<option value={1}>iTwinUI</option>

--- a/examples/mui/Stepper.clickable.tsx
+++ b/examples/mui/Stepper.clickable.tsx
@@ -10,17 +10,17 @@ import visuallyHidden from "@mui/utils/visuallyHidden";
 
 export default () => {
 	return (
-		<Stepper activeStep={1} role="list">
-			<Step role="listitem">
+		<Stepper activeStep={1}>
+			<Step>
 				<StepButton>
 					Select campaign settings
 					<span style={visuallyHidden}> (completed)</span>
 				</StepButton>
 			</Step>
-			<Step role="listitem" aria-current="true">
+			<Step>
 				<StepButton>Create an ad group</StepButton>
 			</Step>
-			<Step role="listitem">
+			<Step>
 				<StepButton>Create an ad</StepButton>
 			</Step>
 		</Stepper>

--- a/examples/mui/Stepper.default.tsx
+++ b/examples/mui/Stepper.default.tsx
@@ -10,17 +10,17 @@ import visuallyHidden from "@mui/utils/visuallyHidden";
 
 export default () => {
 	return (
-		<Stepper activeStep={1} role="list">
-			<Step role="listitem">
+		<Stepper activeStep={1}>
+			<Step>
 				<StepLabel>
 					Select campaign settings
 					<span style={visuallyHidden}> (completed)</span>
 				</StepLabel>
 			</Step>
-			<Step role="listitem" aria-current="true">
+			<Step>
 				<StepLabel>Create an ad group</StepLabel>
 			</Step>
-			<Step role="listitem">
+			<Step>
 				<StepLabel>Create an ad</StepLabel>
 			</Step>
 		</Stepper>

--- a/examples/mui/Stepper.optional.tsx
+++ b/examples/mui/Stepper.optional.tsx
@@ -11,11 +11,11 @@ import visuallyHidden from "@mui/utils/visuallyHidden";
 
 export default () => {
 	return (
-		<Stepper activeStep={2} role="list">
-			<Step role="listitem">
+		<Stepper activeStep={2}>
+			<Step>
 				<StepLabel>Select campaign settings</StepLabel>
 			</Step>
-			<Step role="listitem" completed={false}>
+			<Step completed={false}>
 				<StepLabel
 					optional={
 						<Typography variant="caption" aria-hidden="true">
@@ -27,7 +27,7 @@ export default () => {
 					<span style={visuallyHidden}>, optional</span>
 				</StepLabel>
 			</Step>
-			<Step role="listitem" aria-current="true">
+			<Step>
 				<StepLabel>Create an ad</StepLabel>
 			</Step>
 		</Stepper>

--- a/examples/mui/TextField.sizes.tsx
+++ b/examples/mui/TextField.sizes.tsx
@@ -8,7 +8,7 @@ import TextField from "@mui/material/TextField";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" alignItems="center">
+		<Stack spacing={1} direction="row" sx={{ alignItems: "center" }}>
 			<TextField size="small" label="Small" />
 			<TextField size="medium" label="Medium" />
 		</Stack>

--- a/examples/mui/Tooltip.direction.tsx
+++ b/examples/mui/Tooltip.direction.tsx
@@ -9,7 +9,7 @@ import Tooltip from "@mui/material/Tooltip";
 
 export default () => {
 	return (
-		<Stack spacing={4} alignSelf="center">
+		<Stack spacing={4} sx={{ alignSelf: "center" }}>
 			<Tooltip placement="bottom" title="I am below the button">
 				<Button disabled>Bottom</Button>
 			</Tooltip>

--- a/internal/minimal-template/package.json
+++ b/internal/minimal-template/package.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.1",
-		"@mui/material": "7",
+		"@mui/material": "^9.0.0",
 		"@stratakit/icons": "latest",
 		"@stratakit/mui": "latest",
 		"react": "^19.2.4",

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -67,7 +67,7 @@
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {
-		"@mui/material": "^7.3.6",
+		"@mui/material": "^9.0.0",
 		"react": ">=18.0.0",
 		"react-dom": ">=18.0.0"
 	},

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -171,7 +171,7 @@ function createTheme() {
 			MuiAvatar: {
 				defaultProps: {
 					component: Role.div,
-					imgProps: { draggable: false },
+					slotProps: { img: { draggable: false } },
 				},
 				styleOverrides: {
 					root: {
@@ -226,7 +226,12 @@ function createTheme() {
 			MuiCardHeader: {
 				defaultProps: {
 					component: Role.div,
-					slotProps: { title: { component: Role.h2 } },
+					slotProps: {
+						title: {
+							// biome-ignore lint/suspicious/noExplicitAny: MUI's CardHeader.title.component is hardcoded to "span"
+							component: Role.h2 as any,
+						},
+					},
 				},
 			},
 			MuiCardMedia: { defaultProps: { component: MuiCardMedia } },
@@ -266,7 +271,6 @@ function createTheme() {
 			MuiFormHelperText: { defaultProps: { component: Role.p } },
 			MuiFormLabel: { defaultProps: { component: Role.label as never } },
 			MuiGrid: { defaultProps: { component: Role.div } },
-			MuiGridLegacy: { defaultProps: { component: Role.div } },
 			MuiIcon: { defaultProps: { component: Role.span } },
 			MuiIconButton: {
 				defaultProps: { component: MuiIconButton, color: "secondary" },

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -6,6 +6,7 @@
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import OutlinedInput from "@mui/material/OutlinedInput";
+import StepConnector from "@mui/material/StepConnector";
 import { createTheme as createMuiTheme } from "@mui/material/styles";
 import { MuiBadge } from "./~components/MuiBadge.js";
 import { MuiBottomNavigationAction } from "./~components/MuiBottomNavigation.js";
@@ -384,9 +385,14 @@ function createTheme() {
 			},
 			MuiSnackbarContent: { defaultProps: { component: Role.div } },
 			MuiStack: { defaultProps: { component: Role.div } },
-			MuiStep: { defaultProps: { component: Role.div } },
+			MuiStep: { defaultProps: { component: Role.li } },
 			MuiSwitch: { defaultProps: { component: Role.span } },
-			MuiStepper: { defaultProps: { component: Role.div } },
+			MuiStepper: {
+				defaultProps: {
+					component: Role.ol,
+					connector: <StepConnector aria-hidden="true" />, // hiding the connector to prevent invalid markup
+				},
+			},
 			MuiStepLabel: {
 				defaultProps: {
 					slotProps: {

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -132,6 +132,7 @@ function createTheme() {
 			MuiAccordionSummary: {
 				defaultProps: {
 					component: Role.div,
+					nativeButton: false,
 					expandIcon: <ChevronDownIcon />,
 				},
 			},
@@ -317,7 +318,10 @@ function createTheme() {
 			MuiList: { defaultProps: { component: Role.ul } },
 			MuiListItem: { defaultProps: { component: Role.li } },
 			MuiListItemButton: {
-				defaultProps: { component: MuiButtonBase },
+				defaultProps: {
+					component: MuiButtonBase,
+					nativeButton: true,
+				},
 			},
 			MuiListItemText: {
 				defaultProps: {

--- a/packages/mui/src/~components/MuiButton.css
+++ b/packages/mui/src/~components/MuiButton.css
@@ -66,22 +66,24 @@
 		&:where(.Mui-disabled) {
 			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
 		}
+
+		&:where(.MuiButton-colorPrimary, .MuiButton-colorError) {
+			--_MuiButton-icon-color: var(--stratakit-color-icon-neutral-emphasis);
+		}
 	}
 
-	&:where(.MuiButton-containedPrimary, .MuiButton-containedError) {
-		--_MuiButton-icon-color: var(--stratakit-color-icon-neutral-emphasis);
-	}
+	&:where(.MuiButton-outlined, .MuiButton-text) {
+		&:where(.MuiButton-colorPrimary) {
+			--_MuiButton-icon-color: var(--stratakit-color-icon-accent-strong);
+			--variant-outlinedBorder: var(--stratakit-color-border-accent-base);
+		}
 
-	&:where(.MuiButton-outlinedPrimary, .MuiButton-textPrimary) {
-		--_MuiButton-icon-color: var(--stratakit-color-icon-accent-strong);
-		--variant-outlinedBorder: var(--stratakit-color-border-accent-base);
-	}
-
-	&:where(.MuiButton-outlinedError, .MuiButton-textError) {
-		--_MuiButton-icon-color: var(--stratakit-color-icon-critical-base);
-		--variant-textColor: var(--stratakit-color-text-critical-base);
-		--variant-outlinedColor: var(--stratakit-color-text-critical-base);
-		--variant-outlinedBorder: var(--stratakit-color-border-critical-base);
+		&:where(.MuiButton-colorError) {
+			--_MuiButton-icon-color: var(--stratakit-color-icon-critical-base);
+			--variant-textColor: var(--stratakit-color-text-critical-base);
+			--variant-outlinedColor: var(--stratakit-color-text-critical-base);
+			--variant-outlinedBorder: var(--stratakit-color-border-critical-base);
+		}
 	}
 
 	&:where(.Mui-disabled) {

--- a/packages/mui/src/~components/MuiButtonBase.tsx
+++ b/packages/mui/src/~components/MuiButtonBase.tsx
@@ -21,11 +21,10 @@ interface MuiButtonBaseProps
 
 const MuiButtonBase = forwardRef<"button", MuiButtonBaseProps>(
 	(props, forwardedRef) => {
-		const { href, "aria-disabled": ariaDisabled, ...rest } = props;
+		const { href, "aria-disabled": ariaDisabled, disabled, ...rest } = props;
 
-		// MUI's ButtonBase treats this wrapper as a non-button, so it always sets `aria-disabled`.
-		// We need to infer the `disabled` prop from `aria-disabled` for native `<button>` elements.
-		const isDisabled = ariaDisabled === true || ariaDisabled === "true";
+		const isDisabled =
+			disabled || ariaDisabled === true || ariaDisabled === "true";
 
 		const [tagName, setTagName] = React.useState<string | undefined>(undefined);
 		const determineTagName = React.useCallback(

--- a/packages/mui/src/~components/MuiChip.css
+++ b/packages/mui/src/~components/MuiChip.css
@@ -16,7 +16,7 @@
 		--_MuiChip-padding-inline: var(--stratakit-space-x3);
 	}
 
-	&:where(.MuiChip-filledDefault.MuiChip-colorDefault) {
+	&:where(.MuiChip-filled.MuiChip-colorDefault) {
 		background-color: var(--stratakit-color-bg-neutral-base);
 		border: 1px solid var(--stratakit-color-border-neutral-base);
 	}
@@ -33,11 +33,11 @@
 .MuiChip-label {
 	padding-inline: var(--_MuiChip-padding-inline);
 
-	&:where(.MuiChip-labelSmall) {
+	:where(.MuiChip-root.MuiChip-sizeSmall) & {
 		@apply --typography("body-sm");
 	}
 
-	&:where(.MuiChip-labelMedium) {
+	:where(.MuiChip-root.MuiChip-sizeMedium) & {
 		@apply --typography("body-md");
 	}
 
@@ -51,11 +51,11 @@
 	border-radius: inherit;
 	margin-inline-start: calc(var(--stratakit-space-x2) * -1);
 
-	&:where(.MuiChip-deleteIconSmall) {
+	:where(.MuiChip-root.MuiChip-sizeSmall) & {
 		margin-inline-end: -1px; /* Accounts for `border-width` */
 	}
 
-	&:where(.MuiChip-deleteIconMedium) {
+	:where(.MuiChip-root.MuiChip-sizeMedium) & {
 		margin-inline-end: calc(var(--stratakit-space-x1) - 1px);
 	}
 
@@ -70,11 +70,11 @@
 .MuiChip-avatar {
 	margin-inline-start: calc(var(--stratakit-space-x1) - 1px);
 
-	&:where(.MuiChip-avatarSmall) {
+	:where(.MuiChip-root.MuiChip-sizeSmall) & {
 		margin-inline-end: calc(var(--stratakit-space-x1) * -1);
 	}
 
-	&:where(.MuiChip-avatarMedium) {
+	:where(.MuiChip-root.MuiChip-sizeMedium) & {
 		margin-inline-end: calc(var(--stratakit-space-x2) * -1);
 	}
 }

--- a/packages/mui/src/~components/MuiInput.css
+++ b/packages/mui/src/~components/MuiInput.css
@@ -78,16 +78,16 @@
 		}
 	}
 
-	&:where(.MuiInputBase-inputMultiline) {
+	:where(.MuiInputBase-root.MuiInputBase-multiline) > & {
 		padding-block: 8.25px;
 		align-content: baseline;
 	}
 
-	&:where(.MuiInputBase-inputAdornedStart) {
+	:where(.MuiInputBase-root.MuiInputBase-adornedStart) > & {
 		padding-inline-start: 0;
 	}
 
-	&:where(.MuiInputBase-inputAdornedEnd) {
+	:where(.MuiInputBase-root.MuiInputBase-adornedEnd) > & {
 		padding-inline-end: 0;
 	}
 

--- a/packages/mui/src/~components/MuiList.css
+++ b/packages/mui/src/~components/MuiList.css
@@ -54,6 +54,6 @@
 	gap: var(--stratakit-space-x1);
 }
 
-.MuiListItemSecondaryAction-root {
+.MuiListItem-secondaryAction {
 	inset-inline-end: var(--stratakit-space-x3);
 }

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -105,19 +105,19 @@
 }
 
 .MuiDrawer-paper {
-	&:where(.MuiDrawer-paperAnchorTop) {
+	:where(.MuiDrawer-anchorTop) > & {
 		border-block-end: 1px solid;
 	}
 
-	&:where(.MuiDrawer-paperAnchorRight) {
+	:where(.MuiDrawer-anchorRight) > & {
 		border-inline-start: 1px solid;
 	}
 
-	&:where(.MuiDrawer-paperAnchorBottom) {
+	:where(.MuiDrawer-anchorBottom) > & {
 		border-block-start: 1px solid;
 	}
 
-	&:where(.MuiDrawer-paperAnchorLeft) {
+	:where(.MuiDrawer-anchorLeft) > & {
 		border-inline-end: 1px solid;
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     "@mui/material":
-      specifier: ^7.3.8
-      version: 7.3.8
+      specifier: ^9.0.0
+      version: 9.0.0
     "@mui/utils":
-      specifier: ^7.3.8
-      version: 7.3.8
+      specifier: ^9.0.0
+      version: 9.0.0
     "@playwright/test":
       specifier: ~1.58.2
       version: 1.58.2
@@ -93,10 +93,10 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       "@mui/material":
         specifier: "catalog:"
-        version: 7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       "@mui/utils":
         specifier: "catalog:"
-        version: 7.3.8(@types/react@19.2.14)(react@19.2.4)
+        version: 9.0.0(@types/react@19.2.14)(react@19.2.4)
       "@react-router/node":
         specifier: ^7.13.1
         version: 7.13.1(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
@@ -190,7 +190,7 @@ importers:
         version: 0.37.6(astro@5.18.1(@types/node@22.19.13)(lightningcss@1.30.1)(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3))
       "@mui/material":
         specifier: "catalog:"
-        version: 7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       "@stratakit/bricks":
         specifier: workspace:*
         version: link:../../packages/bricks
@@ -266,10 +266,10 @@ importers:
     dependencies:
       "@mui/material":
         specifier: "catalog:"
-        version: 7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       "@mui/utils":
         specifier: "catalog:"
-        version: 7.3.8(@types/react@19.2.14)(react@19.2.4)
+        version: 9.0.0(@types/react@19.2.14)(react@19.2.4)
       "@stratakit/bricks":
         specifier: workspace:*
         version: link:../packages/bricks
@@ -402,8 +402,8 @@ importers:
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       "@mui/material":
-        specifier: ^7.3.6
-        version: 7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^9.0.0
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       "@stratakit/foundations":
         specifier: ^0.4.7
         version: link:../foundations
@@ -771,10 +771,10 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
 
-  "@babel/runtime@7.28.6":
+  "@babel/runtime@7.29.2":
     resolution:
       {
-        integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==,
+        integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -1777,22 +1777,22 @@ packages:
         integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==,
       }
 
-  "@mui/core-downloads-tracker@7.3.8":
+  "@mui/core-downloads-tracker@9.0.0":
     resolution:
       {
-        integrity: sha512-s9UHZo7QJVly7gNArEZkbbsimHqJZhElgBpXIJdehZ4OWXt+CCr0SBDgUCDJnQrqpd1dWK2dLq5rmO4mCBmI3w==,
+        integrity: sha512-uwQNGkhv0lf7ufxw6QXev77BW6pWbW+7uxYjU5+rfp4lBkFtMEgJCsarTM3Tn+i0lGx6+Ol2u88JdGXr0GDskA==,
       }
 
-  "@mui/material@7.3.8":
+  "@mui/material@9.0.0":
     resolution:
       {
-        integrity: sha512-QKd1RhDXE1hf2sQDNayA9ic9jGkEgvZOf0tTkJxlBPG8ns8aS4rS8WwYURw2x5y3739p0HauUXX9WbH7UufFLw==,
+        integrity: sha512-+VP/oQCDhDR87NQQgXnNBG8dwy6GNuQLnenS1pZvkbn2dKFSxRSRMybTpH9xUxXP+316mlYDy5CSbYtusnCWtw==,
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
       "@emotion/react": ^11.5.0
       "@emotion/styled": ^11.3.0
-      "@mui/material-pigment-css": ^7.3.8
+      "@mui/material-pigment-css": ^9.0.0
       "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1806,10 +1806,10 @@ packages:
       "@types/react":
         optional: true
 
-  "@mui/private-theming@7.3.8":
+  "@mui/private-theming@9.0.0":
     resolution:
       {
-        integrity: sha512-du5dlPZ9XL3xW2apHoGDXBI+QLtyVJGrXNCfcNYfP/ojkz1RQ0rRV6VG9Rkm1DqEFRG8mjjTL7zmE1Bvn1eR4A==,
+        integrity: sha512-JtuZoaiCqwD6vjgYu6Xp3T7DZkrxJlgtDz5yESzhI34fEX5hHMh2VJUbuL9UOg8xrfIFMrq6dcYoH/7Zi4G0RA==,
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
@@ -1819,10 +1819,10 @@ packages:
       "@types/react":
         optional: true
 
-  "@mui/styled-engine@7.3.8":
+  "@mui/styled-engine@9.0.0":
     resolution:
       {
-        integrity: sha512-JHAeXQzS0tJ+Fq3C6J4TVDsW+yKhO4uuxuiLaopNStJeQYBIUCXpKYyUCcgXym4AmhbznQnv9RlHywSH6b0FOg==,
+        integrity: sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==,
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
@@ -1835,10 +1835,10 @@ packages:
       "@emotion/styled":
         optional: true
 
-  "@mui/system@7.3.8":
+  "@mui/system@9.0.0":
     resolution:
       {
-        integrity: sha512-hoFRj4Zw2Km8DPWZp/nKG+ao5Jw5LSk2m/e4EGc6M3RRwXKEkMSG4TgtfVJg7dS2homRwtdXSMW+iRO0ZJ4+IA==,
+        integrity: sha512-YnC5Zg6j04IxiLc/boAKs0464jfZlLFVa7mf5E8lF0XOtZVUvG6R6gJK50lgUYdaaLdyLfxF6xR7LaPuEpeT/g==,
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
@@ -1854,10 +1854,10 @@ packages:
       "@types/react":
         optional: true
 
-  "@mui/types@7.4.11":
+  "@mui/types@9.0.0":
     resolution:
       {
-        integrity: sha512-fZ2xO9D08IKOxO2oUBi1nnVKH6oJUD+64cnv4YAaFoC0E5+i1+S5AHbNqqvZlYYsbPEQ6qEVwuBqY3jl5W4G+Q==,
+        integrity: sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==,
       }
     peerDependencies:
       "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1865,10 +1865,10 @@ packages:
       "@types/react":
         optional: true
 
-  "@mui/utils@7.3.8":
+  "@mui/utils@9.0.0":
     resolution:
       {
-        integrity: sha512-kZRcE2620CBGr+XI8YMmwPj6WIPwSF7uMJjvSfqd8zXVvlz0MCJbzRRUGNf8NgflCLthdji2DdS643TeyJ3+nA==,
+        integrity: sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==,
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
@@ -4753,10 +4753,10 @@ packages:
         integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
       }
 
-  react-is@19.2.3:
+  react-is@19.2.4:
     resolution:
       {
-        integrity: sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==,
+        integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==,
       }
 
   react-refresh@0.14.2:
@@ -6115,7 +6115,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/runtime@7.28.6": {}
+  "@babel/runtime@7.29.2": {}
 
   "@babel/template@7.28.6":
     dependencies:
@@ -6189,7 +6189,7 @@ snapshots:
   "@emotion/babel-plugin@11.13.5":
     dependencies:
       "@babel/helper-module-imports": 7.28.6
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
       "@emotion/hash": 0.9.2
       "@emotion/memoize": 0.9.0
       "@emotion/serialize": 1.3.3
@@ -6220,7 +6220,7 @@ snapshots:
 
   "@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4)":
     dependencies:
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
       "@emotion/babel-plugin": 11.13.5
       "@emotion/cache": 11.14.0
       "@emotion/serialize": 1.3.3
@@ -6246,7 +6246,7 @@ snapshots:
 
   "@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)":
     dependencies:
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
       "@emotion/babel-plugin": 11.13.5
       "@emotion/is-prop-valid": 1.4.0
       "@emotion/react": 11.14.0(@types/react@19.2.14)(react@19.2.4)
@@ -6608,15 +6608,15 @@ snapshots:
 
   "@mjackson/node-fetch-server@0.2.0": {}
 
-  "@mui/core-downloads-tracker@7.3.8": {}
+  "@mui/core-downloads-tracker@9.0.0": {}
 
-  "@mui/material@7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)":
+  "@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)":
     dependencies:
-      "@babel/runtime": 7.28.6
-      "@mui/core-downloads-tracker": 7.3.8
-      "@mui/system": 7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      "@mui/types": 7.4.11(@types/react@19.2.14)
-      "@mui/utils": 7.3.8(@types/react@19.2.14)(react@19.2.4)
+      "@babel/runtime": 7.29.2
+      "@mui/core-downloads-tracker": 9.0.0
+      "@mui/system": 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+      "@mui/types": 9.0.0(@types/react@19.2.14)
+      "@mui/utils": 9.0.0(@types/react@19.2.14)(react@19.2.4)
       "@popperjs/core": 2.11.8
       "@types/react-transition-group": 4.4.12(@types/react@19.2.14)
       clsx: 2.1.1
@@ -6624,25 +6624,25 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-is: 19.2.3
+      react-is: 19.2.4
       react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       "@emotion/react": 11.14.0(@types/react@19.2.14)(react@19.2.4)
       "@emotion/styled": 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       "@types/react": 19.2.14
 
-  "@mui/private-theming@7.3.8(@types/react@19.2.14)(react@19.2.4)":
+  "@mui/private-theming@9.0.0(@types/react@19.2.14)(react@19.2.4)":
     dependencies:
-      "@babel/runtime": 7.28.6
-      "@mui/utils": 7.3.8(@types/react@19.2.14)(react@19.2.4)
+      "@babel/runtime": 7.29.2
+      "@mui/utils": 9.0.0(@types/react@19.2.14)(react@19.2.4)
       prop-types: 15.8.1
       react: 19.2.4
     optionalDependencies:
       "@types/react": 19.2.14
 
-  "@mui/styled-engine@7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)":
+  "@mui/styled-engine@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)":
     dependencies:
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
       "@emotion/cache": 11.14.0
       "@emotion/serialize": 1.3.3
       "@emotion/sheet": 1.4.0
@@ -6653,13 +6653,13 @@ snapshots:
       "@emotion/react": 11.14.0(@types/react@19.2.14)(react@19.2.4)
       "@emotion/styled": 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
 
-  "@mui/system@7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)":
+  "@mui/system@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)":
     dependencies:
-      "@babel/runtime": 7.28.6
-      "@mui/private-theming": 7.3.8(@types/react@19.2.14)(react@19.2.4)
-      "@mui/styled-engine": 7.3.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
-      "@mui/types": 7.4.11(@types/react@19.2.14)
-      "@mui/utils": 7.3.8(@types/react@19.2.14)(react@19.2.4)
+      "@babel/runtime": 7.29.2
+      "@mui/private-theming": 9.0.0(@types/react@19.2.14)(react@19.2.4)
+      "@mui/styled-engine": 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      "@mui/types": 9.0.0(@types/react@19.2.14)
+      "@mui/utils": 9.0.0(@types/react@19.2.14)(react@19.2.4)
       clsx: 2.1.1
       csstype: 3.2.3
       prop-types: 15.8.1
@@ -6669,21 +6669,21 @@ snapshots:
       "@emotion/styled": 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       "@types/react": 19.2.14
 
-  "@mui/types@7.4.11(@types/react@19.2.14)":
+  "@mui/types@9.0.0(@types/react@19.2.14)":
     dependencies:
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
     optionalDependencies:
       "@types/react": 19.2.14
 
-  "@mui/utils@7.3.8(@types/react@19.2.14)(react@19.2.4)":
+  "@mui/utils@9.0.0(@types/react@19.2.14)(react@19.2.4)":
     dependencies:
-      "@babel/runtime": 7.28.6
-      "@mui/types": 7.4.11(@types/react@19.2.14)
+      "@babel/runtime": 7.29.2
+      "@mui/types": 9.0.0(@types/react@19.2.14)
       "@types/prop-types": 15.7.15
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.2.4
-      react-is: 19.2.3
+      react-is: 19.2.4
     optionalDependencies:
       "@types/react": 19.2.14
 
@@ -7182,7 +7182,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
@@ -7395,7 +7395,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
       csstype: 3.2.3
 
   dom-serializer@2.0.0:
@@ -7841,7 +7841,7 @@ snapshots:
 
   i18next@23.16.8:
     dependencies:
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
 
   immer@11.1.4: {}
 
@@ -8707,7 +8707,7 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-is@19.2.3: {}
+  react-is@19.2.4: {}
 
   react-refresh@0.14.2: {}
 
@@ -8726,7 +8726,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      "@babel/runtime": 7.28.6
+      "@babel/runtime": 7.29.2
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,8 +5,8 @@ packages:
   - examples
 
 catalog:
-  "@mui/material": ^7.3.8
-  "@mui/utils": ^7.3.8
+  "@mui/material": ^9.0.0
+  "@mui/utils": ^9.0.0
   "@playwright/test": ~1.58.2
   "@types/node": ^22.19.13
   "@types/react": ^19.2.14
@@ -22,6 +22,7 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - "@stratakit/*"
   - "@itwin/*"
+  - "@mui/*"
   - react
   - react-dom
 


### PR DESCRIPTION
### Changes

Package-level changes ([`b4e80b3`](https://github.com/iTwin/stratakit/pull/1400/commits/b4e80b332caca5f87a1187678adb0abdbaab47b8)):

- Updated installed versions of `@mui` packages to v9 (required changing `minimumReleaseAgeExclude`).
- Updated peer dependency range in `@stratakit/mui`. https://github.com/iTwin/stratakit/labels/breaking%20change

Adapting to v9 breaking changes (based on [migration guide](https://mui.com/material-ui/migration/upgrade-to-v9) and [announcement blog post](https://mui.com/blog/introducing-material-ui-v9/)):

- [`716cb8b`](https://github.com/iTwin/stratakit/pull/1400/commits/716cb8b5bd3ca6e05693fdce8b8c6a0ad0ce49f1): system styling props → `sx` prop
- [`032c08f`](https://github.com/iTwin/stratakit/pull/1400/commits/032c08f808e821d390cb0a6981e41e1f9318ea0d): `slotProps` and other breaking API changes:
  - `Avatar.imgProps` → `Avatar.slotProps.img`
  - `Select.inputProps` → `Select.slotProps.input`
  - Removed `GridLegacy`
  - Also needed to add `as any` to `CardHeader.slotProps.title`. (likely a bug in MUI)
- [`5e048ec`](https://github.com/iTwin/stratakit/pull/1400/commits/5e048ec507be7d2f4a4e743937b22f57b0f0ca06): CSS changes (replacing removed/deprecated classes with new ones). The main affected components are: `Button`, `Chip` and `Input`. 
- [`f249df2`](https://github.com/iTwin/stratakit/pull/1400/commits/f249df271a7363010b9dc8e428296d1732fc4976): `ButtonBase` now requires `nativeButton` to be set in a few places (`false` if rendering as a `<div>`, `true` if `<button>`).
  - MUI now automatically handles `disabled` vs `aria-disabled` depending on the rendered DOM element, so we can directly read `props.disabled` in the `MuiButtonBase` wrapper.
  - **Note:** This is also expected to be done by consumers if using the `render` prop to change the rendered element.
- [`ccf8a18`](https://github.com/iTwin/stratakit/pull/1400/commits/ccf8a18f77cf37bd843ac86d0454ccf2cfba61ab): `Stepper` and `Step` now default to `<ul>` and `<li>` so no longer need `role="list"` and `role="listitem"` set from the outside. When `StepButton` is used, `role="tab"` and other attributes will be set automatically (with correct keyboard interactions).
  - This required setting the `connector` prop to fix invalid markup. See [comment](https://github.com/iTwin/stratakit/pull/1400#discussion_r3053795329).

### Testing

See [Deploy preview](https://stratakit.bentley.com/1400/mui/).

Originally I only scrolled through the `/mui` page quickly. Later on, I spent more time inspecting and interacting with various components (using mouse, keyboard, and with forced-colors).

Everything seemed ok after latest changes, but additional testing from reviewers is always appreciated.

- [x] Re-tested [#1331](https://github.com/iTwin/stratakit/pull/1331) and [#1332](https://github.com/iTwin/stratakit/pull/1332). Left comments [1](https://github.com/iTwin/stratakit/pull/1331#pullrequestreview-4077952768) and [2](https://github.com/iTwin/stratakit/pull/1332#issuecomment-4209289664).
- [x] `Stepper` markup updated. Required setting `aria-hidden` on `<StepConnector>`.
- [x] There were some a11y test failures in website examples. Addressed and re-tested so there are no more violations.