### PR TITLE
`Autocomplete` menu uses `Menu` class names

### DIFF
--- a/.changeset/sweet-spoons-buy.md
+++ b/.changeset/sweet-spoons-buy.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-`Autocomplete` menu and options inherits the same visual styling as `Menu`.
+`Autocomplete` listbox and options now match the visual styling of `Menu` and `MenuItem`. The `renderOption` prop is used to add a class.

--- a/.changeset/sweet-spoons-buy.md
+++ b/.changeset/sweet-spoons-buy.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-`Autocomplete` inherits the same visual styling as `Menu`.
+`Autocomplete` menu and options inherits the same visual styling as `Menu`.

--- a/.changeset/sweet-spoons-buy.md
+++ b/.changeset/sweet-spoons-buy.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+`Autocomplete` inherits the same visual styling as `Menu`.

--- a/apps/website/src/content/docs/components/mui/Autocomplete.md
+++ b/apps/website/src/content/docs/components/mui/Autocomplete.md
@@ -10,9 +10,9 @@ links:
 
 ## StrataKit MUI modifications
 
-- Spacing and sizing has been adjusted to better align with StrataKit's more compact visual design language.
+- Restyled using StrataKit's visual language.
 - The "clear" indicator is now keyboard focusable and remains visible to improve accessibility.
-- The dropdown menu adopts the same visual styling as [`Menu`](menu) by reusing its class names.
+- Autocomplete menu matches the visual styling of [`Menu`](menu), with individual Autocomplete options using the `MuiMenuItem-root` class via `renderOption`.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Autocomplete.md
+++ b/apps/website/src/content/docs/components/mui/Autocomplete.md
@@ -12,6 +12,7 @@ links:
 
 - Spacing and sizing has been adjusted to better align with StrataKit's more compact visual design language.
 - The "clear" indicator is now keyboard focusable and remains visible to improve accessibility.
+- The dropdown menu adopts the same visual styling as [`Menu`](menu) by reusing its class names.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Autocomplete.md
+++ b/apps/website/src/content/docs/components/mui/Autocomplete.md
@@ -12,7 +12,7 @@ links:
 
 - Restyled using StrataKit's visual language.
 - The "clear" indicator is now keyboard focusable and remains visible to improve accessibility.
-- Autocomplete menu matches the visual styling of [`Menu`](menu), with individual Autocomplete options using the `MuiMenuItem-root` class via `renderOption`.
+- The listbox now matches the visual styling of [`Menu`](/components/menu), with individual options using the `MuiMenuItem-root` class via a theme-level [`renderOption`](https://mui.com/material-ui/api/autocomplete/#autocomplete-prop-renderOption) prop.
 
 ## Examples
 

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import OutlinedInput from "@mui/material/OutlinedInput";
 import { createTheme as createMuiTheme } from "@mui/material/styles";
+import cx from "classnames";
 import { MuiBadge } from "./~components/MuiBadge.js";
 import { MuiBottomNavigationAction } from "./~components/MuiBottomNavigation.js";
 import { MuiButtonBase } from "./~components/MuiButtonBase.js";
@@ -154,12 +155,13 @@ function createTheme() {
 					ListboxProps: {
 						className: "MuiMenu-list",
 					},
-					renderOption: (props, option) => (
+					renderOption: ({ key, ...props }, option, _, ownerState) => (
 						<li
+							key={key}
 							{...props}
-							className={`${props.className || ""} MuiMenuItem-root`.trim()}
+							className={cx("MuiMenuItem-root", props.className)}
 						>
-							{option}
+							{ownerState.getOptionLabel(option)}
 						</li>
 					),
 					slotProps: {

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -151,6 +151,17 @@ function createTheme() {
 				defaultProps: {
 					popupIcon: <ChevronDownIcon />,
 					clearIcon: <DismissIcon />,
+					ListboxProps: {
+						className: "MuiMenu-list",
+					},
+					renderOption: (props, option) => (
+						<li
+							{...props}
+							className={`${props.className || ""} MuiMenuItem-root`.trim()}
+						>
+							{option}
+						</li>
+					),
 					slotProps: {
 						paper: {
 							elevation: 8, // match Menu elevation

--- a/packages/mui/src/createTheme.tsx
+++ b/packages/mui/src/createTheme.tsx
@@ -152,9 +152,6 @@ function createTheme() {
 				defaultProps: {
 					popupIcon: <ChevronDownIcon />,
 					clearIcon: <DismissIcon />,
-					ListboxProps: {
-						className: "MuiMenu-list",
-					},
 					renderOption: ({ key, ...props }, option, _, ownerState) => (
 						<li
 							key={key}

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -39,23 +39,6 @@
 	}
 }
 
-.MuiAutocomplete-option {
-	@apply --typography("body-md");
-	min-block-size: var(--stratakit-size-control-listitem-height-small);
-}
-
-.MuiAutocomplete-option {
-	@apply --typography("body-md");
-	background-color: transparent;
-
-	&:where([aria-selected="true"]:not([aria-disabled="true"])) {
-		border-block: 1px solid var(--stratakit-color-border-accent-strong);
-		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
-		color: var(--stratakit-color-text-accent-strong);
-	}
-
-	&:where(.Mui-focusVisible) {
-		outline: var(--🥝focus-outline);
-		outline-offset: -2px;
-	}
+.MuiAutocomplete-listbox {
+	padding: var(--stratakit-space-x1);
 }

--- a/packages/mui/src/~components/MuiMenu.css
+++ b/packages/mui/src/~components/MuiMenu.css
@@ -88,7 +88,7 @@
 		outline-offset: calc(var(--🥝focus-outline-offset) * -1);
 	}
 
-	&:where(.Mui-selected) {
+	&:where(.Mui-selected, [aria-selected="true"]) {
 		--🥝Icon-color: var(--✨color-icon--selected);
 		--_MuiMenuItem-background-color: var(--✨color-bg--selected);
 		--_MuiMenuItem-color: var(--✨color-text--selected);


### PR DESCRIPTION
### Changes

- Apply `Menu` class names to `Autocomplete` within `createTheme.tsx`. https://github.com/iTwin/stratakit/labels/AI
- Add `[aria-selected="true"]` to `MuiMenu.css` as `.Mui-selected` didn't work for `Autocomplete`.
- Updated documentation.

[**Deploy preview**](https://stratakit.bentley.com/1403/mui/#autocomplete) 👀

### Testing

- Visual confirmation in light, dark, & `forced-colors`.