### PR TITLE
add `render` prop to `Dialog` types

### DIFF
--- a/.changeset/hungry-symbols-chew.md
+++ b/.changeset/hungry-symbols-chew.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `Dialog` types to add missing `render` prop.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -155,6 +155,13 @@ declare module "@mui/material/Chip" {
 	}
 }
 
+declare module "@mui/material/Dialog" {
+	interface DialogProps extends Pick<CommonProps, "render"> {
+		/** @deprecated Use `render` prop instead. */
+		component?: React.ElementType;
+	}
+}
+
 declare module "@mui/material/Fab" {
 	interface FabPropsColorOverrides {
 		info: false;


### PR DESCRIPTION
### Changes

`Dialog` supports the `render` prop at runtime (after #1212) but its types were not reflecting it (as called out in https://github.com/iTwin/stratakit/pull/1399#discussion_r3050800578). This is likely because `DialogProps` doesn't extend from `OverridableComponent`.

This PR adds the `render` prop under `DialogProps`. It extends from the already declared `CommonProps`, which ensures that JSDocs are automatically propagated. Additionally, the `component` prop is marked as deprecated.

### Testing

Confirmed that `<Dialog render={…} />` is typed correctly and works at runtime. Also confirmed that `component` appears as deprecated.