### PR TITLE
Better insets for `Autocomplete`

### DIFF
--- a/.changeset/hungry-cobras-kneel.md
+++ b/.changeset/hungry-cobras-kneel.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Corrected left alignment for the first chip in each row of multiselect `Autocomplete`.

--- a/.changeset/hungry-cobras-kneel.md
+++ b/.changeset/hungry-cobras-kneel.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-Corrected left alignment for the first chip in each row of multiselect `Autocomplete`.
+Corrected left alignment for the first chip in each row of multiselect `Autocomplete` and spacing around the expand and clear buttons.

--- a/examples/mui/Autocomplete.default.module.css
+++ b/examples/mui/Autocomplete.default.module.css
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
-.autocomplete {
-	min-inline-size: 300px;
-}

--- a/examples/mui/Autocomplete.default.tsx
+++ b/examples/mui/Autocomplete.default.tsx
@@ -6,12 +6,9 @@
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 
-import styles from "./Autocomplete.default.module.css";
-
 export default () => {
 	return (
 		<Autocomplete
-			className={styles.autocomplete}
 			options={[
 				"Badge",
 				"Button",

--- a/examples/mui/Autocomplete.multiple.module.css
+++ b/examples/mui/Autocomplete.multiple.module.css
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
-.autocomplete {
-	min-inline-size: 300px;
-}

--- a/examples/mui/Autocomplete.multiple.tsx
+++ b/examples/mui/Autocomplete.multiple.tsx
@@ -6,12 +6,9 @@
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 
-import styles from "./Autocomplete.multiple.module.css";
-
 export default () => {
 	return (
 		<Autocomplete
-			className={styles.autocomplete}
 			options={[
 				"Badge",
 				"Button",

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -8,7 +8,7 @@
 	/* Account for 1px border on input. */
 	--_MuiAutocomplete-button-inset: calc(-1px + var(--stratakit-space-x1));
 
-	padding-inline-start: var(--stratakit-space-x2);
+	padding-inline-start: var(--_MuiInput-padding-inline);
 	padding-inline-end: calc(
 		(var(--✨button-width) * 2) +
 		(var(--_MuiAutocomplete-button-inset) * 2)

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -22,7 +22,7 @@
 
 .MuiAutocomplete-tag:is(.MuiChip-root) {
 	margin-block: var(--stratakit-space-x05);
-	margin-inline: 0;
+	margin-inline: 0; /* Now relying on `column-gap` */
 }
 
 .MuiAutocomplete-clearIndicator {

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -17,7 +17,7 @@
 }
 
 .MuiAutocomplete-input:is(.MuiInputBase-input) {
-	padding-inline: 0;
+	padding-inline: 0; /* Padding moved to the parent */
 }
 
 .MuiAutocomplete-tag:is(.MuiChip-root) {

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -5,10 +5,8 @@
 
 .MuiAutocomplete-inputRoot:is(.MuiInputBase-root) {
 	--✨button-width: var(--stratakit-size-control-field-height-small);
-	--_MuiAutocomplete-button-inset: calc(
-		-1px +
-		var(--stratakit-space-x1)
-	); /* Account for 1px border on input. */
+	/* Account for 1px border on input. */
+	--_MuiAutocomplete-button-inset: calc(-1px + var(--stratakit-space-x1));
 
 	padding-inline-start: var(--stratakit-space-x2);
 	padding-inline-end: calc(

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -4,27 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 .MuiAutocomplete-inputRoot:is(.MuiInputBase-root) {
-	--_MuiAutocomplete-icon-button-width: var(--stratakit-size-control-field-height-medium);
+	--✨button-width: var(--stratakit-size-control-field-height-small);
+	--_MuiAutocomplete-button-inset: calc(
+		-1px +
+		var(--stratakit-space-x1)
+	); /* Account for 1px border on input. */
 
-	padding-inline-end: calc(var(--_MuiAutocomplete-icon-button-width) * 2 - 1px);
+	padding-inline-start: var(--stratakit-space-x2);
+	padding-inline-end: calc(
+		(var(--✨button-width) * 2) +
+		(var(--_MuiAutocomplete-button-inset) * 2)
+	);
+	column-gap: var(--stratakit-space-x1);
+}
 
-	&:where(.MuiInputBase-sizeSmall) {
-		--_MuiAutocomplete-icon-button-width: var(--stratakit-size-control-field-height-small);
-	}
+.MuiAutocomplete-input:is(.MuiInputBase-input) {
+	padding-inline: 0;
 }
 
 .MuiAutocomplete-tag:is(.MuiChip-root) {
 	margin-block: var(--stratakit-space-x05);
-	margin-inline-start: var(--stratakit-space-x1);
-	margin-inline-end: 0;
-
-	&:where(:nth-child(1 of &)) {
-		margin-inline-start: var(--stratakit-space-x2);
-	}
-
-	&:where(:nth-last-child(1 of &)) {
-		margin-inline-end: var(--stratakit-space-x2);
-	}
+	margin-inline: 0;
 }
 
 .MuiAutocomplete-clearIndicator {
@@ -32,7 +32,7 @@
 }
 
 .MuiAutocomplete-endAdornment {
-	inset-inline-end: calc(-1px + var(--stratakit-space-x1)); /* Account for 1px border on input. */
+	inset-inline-end: var(--_MuiAutocomplete-button-inset);
 
 	> * {
 		margin-inline-end: 0; /* MUI applies `-2px` */


### PR DESCRIPTION
### Changes

- Corrected left alignment for the first chip in each row of multiselect `Autocomplete`.
- Fixes indentation reserved for clear and open button.
- Removes inline styles from demos.

[**Deploy preview** ](https://stratakit.bentley.com/1411/mui/#autocomplete) 👀

| Before | After |
| -- | -- |
| <img width="1120" height="351" alt="Screenshot 2026-04-09 at 5 05 15 PM" src="https://github.com/user-attachments/assets/46231d06-0657-4709-b7d9-97a0a9224ea9" /> | <img width="1120" height="351" alt="Screenshot 2026-04-09 at 5 02 11 PM" src="https://github.com/user-attachments/assets/77fca95b-2799-4fa2-b7ff-e37583ee3594" /> |

_Red outline shows the bounds of the `input`._

### Testing

I did it.