### PR TITLE
add background to `TextField`

### DIFF
--- a/.changeset/three-rivers-love.md
+++ b/.changeset/three-rivers-love.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added `background-color` to `TextField`, `Autocomplete` and `Select`.

--- a/packages/mui/src/~components/MuiInput.css
+++ b/packages/mui/src/~components/MuiInput.css
@@ -15,6 +15,7 @@
 	padding: 0;
 	border: 1px solid var(--_MuiInput-border-color);
 	border-radius: 4px;
+	background-color: var(--stratakit-color-bg-control-textbox);
 	transition: border-color 150ms ease-out;
 
 	@apply --typography("body-md");


### PR DESCRIPTION
### Changes

This has been pending for a while. The background-color is a subtle but necessary addition to make the `TextField` feel like its own entity (previously it was blending into the page/surface background).

Also affects `Autocomplete` and `Select` (not sure about the latter, though I suppose we intend to style it heavily anyway).

### Testing

More noticeable in light theme.

| Before | After |
| --- | --- |
| <img width="385" height="216" alt="screenshot" src="https://github.com/user-attachments/assets/2a9bada6-e5e6-4b62-94fd-e931844e9cbc" /> | <img width="392" height="216" alt="screenshot" src="https://github.com/user-attachments/assets/ce2f43a1-d5c6-49c4-85a5-3a0b732b975f" /> |

[Deploy preview](https://stratakit.bentley.com/1412/mui)