### PR TITLE
Add `Accordion.header-actions` example

### DIFF
--- a/apps/test-app/app/mui.tsx
+++ b/apps/test-app/app/mui.tsx
@@ -16,6 +16,7 @@ import AccordionActions from "examples/mui/Accordion.actions.tsx";
 import AccordionDecoration from "examples/mui/Accordion.decoration.tsx";
 import AccordionDefault from "examples/mui/Accordion.default.tsx";
 import AccordionExpanded from "examples/mui/Accordion.expanded.tsx";
+import AccordionHeaderActions from "examples/mui/Accordion.header-actions.tsx";
 import AccordionMarkerLeft from "examples/mui/Accordion.marker-left.tsx";
 import AccordionMultiple from "examples/mui/Accordion.multiple.tsx";
 import AccordionVariants from "examples/mui/Accordion.variants.tsx";
@@ -157,6 +158,9 @@ const components: Record<string, React.ReactNode> = {
 			</div>
 			<AccordionMultiple />
 			<AccordionVariants />
+			<div>
+				<AccordionHeaderActions />
+			</div>
 		</Stack>
 	),
 	Alert: (

--- a/apps/website/src/content/docs/components/mui/Accordion.md
+++ b/apps/website/src/content/docs/components/mui/Accordion.md
@@ -78,15 +78,22 @@ It’s important you use an [appropriate heading level](https://www.a11yproject.
 
 ### Decorations
 
-Decorate the `AccordionSummary` with an [**Icon**](/components/icon).
+Decorate the [`AccordionSummary`](https://mui.com/material-ui/api/accordion-summary/) with an [**Icon**](/components/icon).
 
 ::example{src="mui/Accordion.decoration"}
 
 ### AccordionActions
 
-Use the `AccordionActions` component to display actions related to the content of the **Accordion**.
+Use the [`AccordionActions`](https://mui.com/material-ui/api/accordion-actions/) component to display actions related to the content of the **Accordion**.
 
 ::example{src="mui/Accordion.actions"}
+
+### Header actions
+
+Interactive elements should not be placed inside the [`AccordionSummary`](https://mui.com/material-ui/api/accordion-summary/) component to avoid nested interactive elements.
+To display actions inside the **Accordion** header, create a wrapper element for the summary and place the interactive elements there.
+
+::example{src="mui/Accordion.header-actions" min-width="450px"}
 
 ## ✅ Do
 
@@ -98,4 +105,4 @@ Use the `AccordionActions` component to display actions related to the content o
 - Don’t nest **Accordions** inside one another.
 - Don’t use different heading levels for **Accordion** items in the same set. Since **Accordions** cannot be nested, they are at the same level in the document hierarchy.
 - Don’t close an **Accordion** when another **Accordion** is opened. Exclusive **Accordions** create [accessibility and usability issues](https://yatil.net/blog/exclusive-accordions).
-- Don't place interactive elements inside an `AccordionSummary`.
+- Don't place interactive elements inside the [`AccordionSummary`](https://mui.com/material-ui/api/accordion-summary/).

--- a/examples/mui/Accordion.header-actions.module.css
+++ b/examples/mui/Accordion.header-actions.module.css
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.summaryWrapper {
+	display: flex;
+	align-items: center;
+	padding-inline: var(--stratakit-space-x4);
+	position: relative;
+}
+
+.summary {
+	gap: var(--stratakit-space-x3);
+	padding: 0;
+	position: static;
+
+	&::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+	}
+}
+
+.expander {
+	order: -1;
+}

--- a/examples/mui/Accordion.header-actions.tsx
+++ b/examples/mui/Accordion.header-actions.tsx
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IconButton } from "@mui/material";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Typography from "@mui/material/Typography";
+import { Icon } from "@stratakit/mui";
+
+import svgAdd from "@stratakit/icons/add.svg";
+import styles from "./Accordion.header-actions.module.css";
+
+export default () => {
+	return (
+		<Accordion
+			slotProps={{
+				heading: {
+					component: "div",
+				},
+			}}
+		>
+			<AccordionSummary
+				className={styles.summary}
+				slotProps={{
+					root: {
+						component: SummaryRoot,
+					},
+					expandIconWrapper: {
+						className: styles.expander,
+					},
+				}}
+			>
+				<Typography render={<span />}>Role management</Typography>
+			</AccordionSummary>
+			<AccordionDetails>
+				<ul>
+					<li>Read projects</li>
+					<li>Create projects</li>
+					<li>Delete projects</li>
+				</ul>
+			</AccordionDetails>
+		</Accordion>
+	);
+};
+
+function SummaryRoot(props: React.ComponentProps<"div">) {
+	return (
+		<div className={styles.summaryWrapper}>
+			<div {...props} />
+			<IconButton label="Add role" edge="end">
+				<Icon href={svgAdd} />
+			</IconButton>
+		</div>
+	);
+}


### PR DESCRIPTION
### Changes

This PR adds `Accordion.header-actions` example based on https://github.com/iTwin/stratakit/pull/1380#discussion_r3027577495

### Testing

- [test-app](https://stratakit.bentley.com/1413/mui/#accordion)
- [Docs](https://stratakit.bentley.com/1413/docs/components/accordion/)