### PR TITLE
warn when `Typography` is used without the `render` prop

### DIFF
--- a/.changeset/twenty-queens-grow.md
+++ b/.changeset/twenty-queens-grow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+`Typography` will now log a warning during development if a heading variant is used without explicitly setting the `render` prop. This change is to help developers ensure correct heading structure.

--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -13,3 +13,4 @@ links:
 - The `font-family` has been changed to `InterVariable`. See [self-hosting fonts](/getting-started/develop/self-hosting-the-fonts).
 - The typography scale has been adjusted to better align with StrataKit's more compact visual language.
 - The default `variant` is now `"body2"` instead of `"body1"`.
+- A warning will be logged during development if a heading variant is used without explicitly setting the `render` prop.

--- a/apps/website/src/content/docs/getting-started/migration-from-legacy-stratakit.mdx
+++ b/apps/website/src/content/docs/getting-started/migration-from-legacy-stratakit.mdx
@@ -307,6 +307,7 @@ Read additional [StrataKit MUI component documentation](/components/overview/) f
 
 - Replace the `Text` component from `@stratakit/bricks` with the `Typography` component from `@mui/material`. See [Typography examples](/components/typography/) for reference.
 - Update value of [`variant`](/reference/bricks/Text#Text.variant) prop.
+- If using a heading variant, make sure to set the `render` prop to the most appropriate element based on your application structure.
 
   | Before          | After                                                                          |
   | --------------- | ------------------------------------------------------------------------------ |

--- a/examples/mui/Typography._variants.tsx
+++ b/examples/mui/Typography._variants.tsx
@@ -28,7 +28,7 @@ const variants = [
 export default () => {
 	return variants.map((variant) => {
 		return (
-			<Typography key={variant} variant={variant}>
+			<Typography key={variant} variant={variant} render={<div />}>
 				{variant.charAt(0).toUpperCase()}
 				{variant.slice(1)}
 			</Typography>

--- a/packages/mui/src/~components/MuiTypography.tsx
+++ b/packages/mui/src/~components/MuiTypography.tsx
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Role } from "@ariakit/react/role";
+import { forwardRef } from "@stratakit/foundations/secret-internals";
+
+import type { TypographyOwnProps } from "@mui/material/Typography";
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+const variantMapping = {
+	h1: "h1",
+	h2: "h2",
+	h3: "h3",
+	h4: "h4",
+	h5: "h5",
+	h6: "h6",
+	subtitle1: "h6",
+	subtitle2: "h6",
+	body1: "p",
+	body2: "p",
+	inherit: "p",
+	button: "span",
+	caption: "span",
+	overline: "span",
+} satisfies TypographyOwnProps["variantMapping"];
+
+const variants = Object.keys(variantMapping) as TypographyOwnProps["variant"][];
+
+/** These variants are currently rendered as headings by default. */
+const headings = ["h1", "h2", "h3", "h4", "h5", "h6", "subtitle1", "subtitle2"];
+
+// ----------------------------------------------------------------------------
+
+const MuiTypography = forwardRef<"p", BaseProps<"p">>((props, forwardedRef) => {
+	const classList = props.className?.split(" ").filter(Boolean);
+
+	// Derive the variant from the className passed to the DOM element.
+	const variant = (() => {
+		const variant = variants.find((name) =>
+			classList?.includes(`MuiTypography-${name}`),
+		);
+		return variant || "body2";
+	})();
+
+	DEV: if (!props.render && headings.includes(variant)) {
+		console.warn(
+			"MuiTypography: Please explicitly set the `render` prop to ensure correct heading structure.",
+		);
+	}
+
+	const render = (() => {
+		const Element = variantMapping[variant] || "p";
+		return <Element />;
+	})();
+
+	return <Role render={render} {...props} ref={forwardedRef} />;
+});
+DEV: MuiTypography.displayName = "MuiTypography";
+
+// ----------------------------------------------------------------------------
+
+export { MuiTypography };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -27,6 +27,7 @@ import { MuiIconButton } from "./~components/MuiIconButton.js";
 import { MuiSnackbar } from "./~components/MuiSnackbar.js";
 import { MuiStepIcon } from "./~components/MuiStepper.js";
 import { MuiTableCell, MuiTableHead } from "./~components/MuiTable.js";
+import { MuiTypography } from "./~components/MuiTypography.js";
 import {
 	ArrowDownIcon,
 	CaretsUpDownIcon,
@@ -44,7 +45,6 @@ import {
 
 import type { RoleProps } from "@ariakit/react/role";
 import type { ColorSystemOptions } from "@mui/material/styles";
-import type { TypographyOwnProps } from "@mui/material/Typography";
 
 /** Creates a StrataKit theme for MUI. Should be used with MUI's `ThemeProvider`. */
 function createTheme() {
@@ -470,22 +470,7 @@ function createTheme() {
 			MuiTypography: {
 				defaultProps: {
 					variant: "body2",
-					variantMapping: {
-						h1: Role.h1,
-						h2: Role.h2,
-						h3: Role.h3,
-						h4: Role.h4,
-						h5: Role.h5,
-						h6: Role.h6,
-						subtitle1: Role.h6,
-						subtitle2: Role.h6,
-						body1: Role.p,
-						body2: Role.p,
-						inherit: Role.p,
-						button: Role.span,
-						caption: Role.span,
-						overline: Role.span,
-					} as unknown as TypographyOwnProps["variantMapping"],
+					component: MuiTypography,
 				},
 			},
 		},


### PR DESCRIPTION
### Context

_Follow-up to #1334._

The `Typography` component currently includes default semantics for heading `variant`s. These default heading levels are very likely to be incorrect within the context of an application. (Sometimes there is a need for a _large_ `<h2>` or `<div>`; other times, there is a need for a small `<h1>` or `<h2>`.)

I've done a review all instances of `Typography` that use a heading `variant` in our codebase, and found that we override the `render`ed element in all cases, except for the `Typography._variants` example.

Granted, our typography-to-visual mappings (even after #1298) are too large for use in dense application interfaces. But even making them smaller wouldn't be foolproof because it's all very contextual. The best solution is to completely separate the semantics from visuals (as was the case in legacy StrataKit).

### Changes

1. Replaced `defaultProps.variantMapping` with a single `component` wrapper that renders those same elements, but additionally logs a dev-only warning when one of the heading variants is used without the `render` prop.
2. Updated the migration guide to add a point about needing to use the `render` prop.
3. Added `render={<div />}` to the `Typography._variants` example, as the point of this demo is to demonstrate visuals, not semantics.

### Testing

Confirmed that a warning is logged locally during development when `variant` is used without `render`.

Confirmed that no warning is logged anywhere in the test-app after updating the `Typography._variants` example.

### Future work

- Write documentation (a guide. https://github.com/iTwin/stratakit/issues/1242#issuecomment-3885276954) that teaches consumers how to determine the correct heading level.
- Remove the default heading semantics (breaking change), while keeping the warning.
- Add custom StrataKit typography variants (noted in #1298).
- Consider a Heading utility (previously mentioned in https://github.com/iTwin/stratakit/pull/1340#discussion_r2988995739 and probably elsewhere too).