### PR TITLE
`AvatarGroup` ordering

### DIFF
--- a/.changeset/fiery-weeks-open.md
+++ b/.changeset/fiery-weeks-open.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+`AvatarGroup` DOM order now matches the visual display order.

--- a/apps/website/src/content/docs/components/mui/AvatarGroup.md
+++ b/apps/website/src/content/docs/components/mui/AvatarGroup.md
@@ -7,3 +7,8 @@ links:
 ---
 
 ::example{src="mui/AvatarGroup.default"}
+
+## StrataKit MUI modifications
+
+- DOM order now matches the visual display order.
+- The visual stacking of the `Avatar`s is inverted.

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -9,6 +9,7 @@
 @import "./~components/MuiAlert.css";
 @import "./~components/MuiAutocomplete.css";
 @import "./~components/MuiAvatar.css";
+@import "./~components/MuiAvatarGroup.css";
 @import "./~components/MuiBadge.css";
 @import "./~components/MuiBottomNavigation.css";
 @import "./~components/MuiButton.css";

--- a/packages/mui/src/~components/MuiAvatarGroup.css
+++ b/packages/mui/src/~components/MuiAvatarGroup.css
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiAvatarGroup-root {
+	flex-direction: row;
+}
+
+.MuiAvatarGroup-avatar {
+	margin-inline: 0;
+
+	&:where(:not(:nth-child(1 of &))) {
+		margin-inline-start: var(--AvatarGroup-spacing);
+	}
+}

--- a/packages/mui/src/~components/MuiAvatarGroup.tsx
+++ b/packages/mui/src/~components/MuiAvatarGroup.tsx
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { Role } from "@ariakit/react/role";
+import { forwardRef } from "@stratakit/foundations/secret-internals";
+
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+interface MuiAvatarGroupProps extends BaseProps<"div"> {}
+
+const MuiAvatarGroup = forwardRef<"div", MuiAvatarGroupProps>(
+	(props, forwardedRef) => {
+		const { children, ...rest } = props;
+
+		// Reverse children to match source order in HTML output
+		const reversedChildren = React.Children.toArray(children).reverse();
+
+		return (
+			<Role.div {...rest} ref={forwardedRef}>
+				{reversedChildren}
+			</Role.div>
+		);
+	},
+);
+
+export { MuiAvatarGroup };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -9,6 +9,7 @@ import OutlinedInput from "@mui/material/OutlinedInput";
 import StepConnector from "@mui/material/StepConnector";
 import { createTheme as createMuiTheme } from "@mui/material/styles";
 import cx from "classnames";
+import { MuiAvatarGroup } from "./~components/MuiAvatarGroup.js";
 import { MuiBadge } from "./~components/MuiBadge.js";
 import { MuiBottomNavigationAction } from "./~components/MuiBottomNavigation.js";
 import { MuiButtonBase } from "./~components/MuiButtonBase.js";
@@ -179,7 +180,7 @@ function createTheme() {
 					},
 				},
 			},
-			MuiAvatarGroup: { defaultProps: { component: Role.div } },
+			MuiAvatarGroup: { defaultProps: { component: MuiAvatarGroup } },
 			MuiBackdrop: { defaultProps: { component: Role.div } },
 			MuiBadge: {
 				defaultProps: {


### PR DESCRIPTION
### Changes

- `AvatarGroup` DOM order now matches visual order.
- `AvatarGroup` visual stacking inverted (first `Avatar` is now at the bottom of the stack instead of the top).

[**Deploy preview**](https://stratakit.bentley.com/1417/mui/#avatargroup) 👀

| Before | After |
| -- | -- |
| <img width="501" height="187" alt="Screenshot 2026-04-13 at 1 10 24 PM" src="https://github.com/user-attachments/assets/c23115c5-51c3-4c9d-974d-2575e7659121" /> | <img width="501" height="187" alt="Screenshot 2026-04-13 at 1 10 29 PM" src="https://github.com/user-attachments/assets/7a70ea3a-1771-42e2-84b8-8e46103135a6" /> |

### Testing

- Confirmed DOM order matches what is shown on screen.