### PR TITLE
fix `Typography` docs

### DIFF
--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -18,7 +18,7 @@ links:
 
 ### Heading
 
-Heading `variant` of the **Typography** will render a respective [`<h1>` to `<h6>` heading element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements). You can use the `render` prop to override the default semantics. This is useful when you want to maintain a consistent visual hierarchy without misappropriating semantic elements.
+Heading `variant`s of the **Typography** will render the respective [`<h1>` to `<h6>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) heading elements. You should use the `render` prop to override the rendered element and maintain proper [heading structure](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/) in your application. When the `render` prop is not set, StrataKit will log a warning during development.
 
 ::example{src="mui/Typography.heading"}
 
@@ -26,10 +26,10 @@ Heading `variant` of the **Typography** will render a respective [`<h1>` to `<h6
 
 You may want a statement to _stand out_. This statement might regard a special offer, or perhaps a warning. Standalone statements are _not_ headings, since they do not introduce a new section of content.
 
-In these cases, combine a larger `variant` with the `render` prop:
+In these cases, combine a larger `variant` with the `render` prop to set a generic `<span>` or `<div>` element:
 
 ```jsx
-<Typography variant="h5" render={<span />}>
+<Typography variant="h6" render={<span />}>
 	This change cannot be undone.
 </Typography>
 ```
@@ -38,15 +38,16 @@ In these cases, combine a larger `variant` with the `render` prop:
 
 ### Variants
 
-Use **Typography's** `variant` prop to affect both the styling and the [HTML semantics](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#semantics_in_html).
+All of the stock MUI **Typography** `variant`s are available, with sizing adjusted to fit StrataKit's more compact visual language.
 
 ::example{src="mui/Typography.variants" min-height="600px"}
 
 ## ✅ Do
 
-- Use the `variant` prop of the **Typography** component to affect the styling and the semantics.
-- Use the `render` prop to override the semantics when necessary.
+- Use the `variant` prop of the **Typography** component to affect the visual presentation of the text.
+- Use the `render` prop to set the most semantically appropriate element. This is especially important for heading variants.
 
 ## 🚫 Don't
 
 - Don't use **Typography** to disrupt or flatten the visual hierarchy.
+- Don't render a heading element when you simply want to grab attention.

--- a/examples/mui/Typography.heading.tsx
+++ b/examples/mui/Typography.heading.tsx
@@ -6,5 +6,9 @@
 import Typography from "@mui/material/Typography";
 
 export default () => {
-	return <Typography variant="h4">Heading text</Typography>;
+	return (
+		<Typography variant="h4" render={<h2 />}>
+			Heading text
+		</Typography>
+	);
 };

--- a/examples/mui/Typography.variants.tsx
+++ b/examples/mui/Typography.variants.tsx
@@ -13,16 +13,32 @@ export default () => {
 			<Typography variant="body2">Body2</Typography>
 			<Typography variant="button">Button</Typography>
 			<Typography variant="caption">Caption</Typography>
-			<Typography variant="h1">H1</Typography>
-			<Typography variant="h2">H2</Typography>
-			<Typography variant="h3">H3</Typography>
-			<Typography variant="h4">H4</Typography>
-			<Typography variant="h5">H5</Typography>
-			<Typography variant="h6">H6</Typography>
+			<Typography variant="h1" render={<div />}>
+				H1
+			</Typography>
+			<Typography variant="h2" render={<div />}>
+				H2
+			</Typography>
+			<Typography variant="h3" render={<div />}>
+				H3
+			</Typography>
+			<Typography variant="h4" render={<div />}>
+				H4
+			</Typography>
+			<Typography variant="h5" render={<div />}>
+				H5
+			</Typography>
+			<Typography variant="h6" render={<div />}>
+				H6
+			</Typography>
 			<Typography variant="inherit">inherit</Typography>
 			<Typography variant="overline">overline</Typography>
-			<Typography variant="subtitle1">subtitle1</Typography>
-			<Typography variant="subtitle2">subtitle2</Typography>
+			<Typography variant="subtitle1" render={<div />}>
+				subtitle1
+			</Typography>
+			<Typography variant="subtitle2" render={<div />}>
+				subtitle2
+			</Typography>
 		</Stack>
 	);
 };


### PR DESCRIPTION
### Changes

_Follow-up to #1416. Merges into #1340._

- Strengthened the recommendation around `render` prop (e.g. "can" → "should")
- Added a link that explains heading structure: https://www.a11yproject.com/posts/how-to-accessible-heading-structure.
- Added a note about the development warning from #1416.
- Updated examples to use the `render` prop. 

### Testing

N/A