### PR TITLE
decrease `DialogContentText` font-size

### DIFF
--- a/.changeset/curvy-berries-rush.md
+++ b/.changeset/curvy-berries-rush.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Decreased the font-size of `DialogContentText`.

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -262,7 +262,12 @@ function createTheme() {
 			},
 			MuiContainer: { defaultProps: { component: Role.div } },
 			MuiDialog: { defaultProps: { component: Role.div } },
-			MuiDialogContentText: { defaultProps: { component: Role.p } },
+			MuiDialogContentText: {
+				defaultProps: {
+					component: Role.p,
+					variant: "inherit",
+				},
+			},
 			MuiDialogTitle: { defaultProps: { component: Role.h2 } },
 			MuiDivider: { defaultProps: { component: MuiDivider } },
 			MuiDrawer: { defaultProps: { component: Role.div } },


### PR DESCRIPTION
### Changes

`DialogContentText` extends `Typography` but does not use its defaults (which was changed in #1298), so it was still using `"body1"`. This PR changes it to `"inherit"` so it uses the surrounding font size.

### Testing

| Before | After |
| --- | --- |
| <img width="572" height="185" alt="screenshot" src="https://github.com/user-attachments/assets/189ae338-f845-409e-9ab6-dae6696b3239" /> | <img width="513" height="183" alt="screenshot" src="https://github.com/user-attachments/assets/36c8b1b9-d3ed-47f0-9580-05ef94755765" /> |

[Deploy preview](https://stratakit.bentley.com/1428/mui/#dialog)