### PR TITLE
Move `CardHeader` beneath `CardMedia`

### DIFF
--- a/.changeset/green-times-wonder.md
+++ b/.changeset/green-times-wonder.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Adjust spacing between `CardHeader` and `CardContent` / `CardActions`.

--- a/examples/mui/Card.header.tsx
+++ b/examples/mui/Card.header.tsx
@@ -22,11 +22,6 @@ import styles from "./Card.header.module.css";
 export default () => {
 	return (
 		<Card className={styles.card} variant="outlined">
-			<CardHeader
-				title="Stadium"
-				subheader="January 16, 2026"
-				action={<ActionsMenu />}
-			/>
 			<CardMedia
 				className={styles.media}
 				render={
@@ -36,6 +31,11 @@ export default () => {
 						alt=""
 					/>
 				}
+			/>
+			<CardHeader
+				title="Stadium"
+				subheader="January 16, 2026"
+				action={<ActionsMenu />}
 			/>
 			<CardContent>
 				<Typography variant="body2" color="text.secondary">

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -27,6 +27,12 @@
 	}
 }
 
+.MuiCardHeader-root {
+	&:where(:has(+ .MuiCardContent-root, + .MuiCardActions-root)) {
+		padding-block-end: 0;
+	}
+}
+
 .MuiCardHeader-title {
 	@apply --typography("headline-sm");
 	font-weight: 500;

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -31,6 +31,10 @@
 	&:where(:has(+ .MuiCardContent-root, + .MuiCardActions-root)) {
 		padding-block-end: 0;
 	}
+
+	&:where(:has(+ .MuiCardContent-root)) {
+		margin-block-end: calc(var(--stratakit-space-x2) * -1);
+	}
 }
 
 .MuiCardHeader-title {

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -31,10 +31,6 @@
 	&:where(:has(+ .MuiCardContent-root, + .MuiCardActions-root)) {
 		padding-block-end: 0;
 	}
-
-	&:where(:has(+ .MuiCardContent-root)) {
-		margin-block-end: calc(var(--stratakit-space-x2) * -1);
-	}
 }
 
 .MuiCardHeader-title {
@@ -57,6 +53,10 @@
 .MuiCardContent-root {
 	&:where(:has(+ .MuiCardActions-root)) {
 		padding-block-end: 0;
+	}
+
+	:where(.MuiCardHeader-root) + & {
+		padding-block-start: var(--stratakit-space-x2);
 	}
 }
 


### PR DESCRIPTION
### Changes

- Moved `CardHeader` beneath `CardMedia`.
- When `CardHeader` precedes `CardContent` or `CardActions`, remove bottom padding.

### Testing

- Tested `CardHeader` before `CardContent` & `CardActions`.