### PR TITLE
Fix visual appearance of `Switch` thumb

### DIFF
--- a/.changeset/chilly-clouds-sort.md
+++ b/.changeset/chilly-clouds-sort.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fix visual appearance of `Switch` thumb.

--- a/packages/mui/src/~components/MuiSwitch.css
+++ b/packages/mui/src/~components/MuiSwitch.css
@@ -107,6 +107,7 @@
 	aspect-ratio: inherit; /* Inherited from `.MuiSwitch-switchBase` */
 	background-color: var(--_MuiSwitch-thumb-background-color);
 	box-shadow: var(--_MuiSwitch-thumb-box-shadow);
+	border: none;
 	border-radius: var(--_MuiSwitch-thumb-border-radius);
 	block-size: 100%;
 	inline-size: 100%;

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -199,10 +199,6 @@
 	}
 }
 
-.MuiSlider-thumb:where(.Mui-disabled) {
-	border-color: GrayText;
-}
-
 .MuiSlider-mark {
 	background-color: CanvasText;
 


### PR DESCRIPTION
### Changes

- Remove `border` from `Switch` thumb to fix the inset visual border.

| Before | After |
| -- | -- |
| <img width="270" height="400" alt="Screenshot 2026-04-20 at 3 25 46 PM" src="https://github.com/user-attachments/assets/7e3f916c-1619-419d-be55-b8b2ae6abfe2" /> | <img width="270" height="400" alt="Screenshot 2026-04-20 at 3 25 33 PM" src="https://github.com/user-attachments/assets/a944a597-8b7f-49a6-b4ec-6ae9ed444e68" /> |


### Testing

- Tested light, dark, `forced-colors`.