### PR TITLE
update `Typography` subtitle variants

### DIFF
--- a/.changeset/eighty-mirrors-allow.md
+++ b/.changeset/eighty-mirrors-allow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `Typography` styles for `"subtitle1"` and `"subtitle2"` variants.

--- a/internal/typography.mixins.css
+++ b/internal/typography.mixins.css
@@ -17,6 +17,9 @@
 			style(--variant: "body-lg"): var(--stratakit-font-size-16);
 			style(--variant: "body-md"): var(--stratakit-font-size-14);
 			style(--variant: "body-sm"): var(--stratakit-font-size-12);
+			style(--variant: "subtitle-lg"): var(--stratakit-font-size-16);
+			style(--variant: "subtitle-md"): var(--stratakit-font-size-14);
+			style(--variant: "subtitle-sm"): var(--stratakit-font-size-12);
 			style(--variant: "caption-lg"): var(--stratakit-font-size-11);
 			style(--variant: "caption-md"): var(--stratakit-font-size-10);
 			style(--variant: "caption-sm"): var(--stratakit-font-size-8);
@@ -33,6 +36,9 @@
 			style(--variant: "body-lg"): 1.5;
 			style(--variant: "body-md"): 1.4286;
 			style(--variant: "body-sm"): 1.3333;
+			style(--variant: "subtitle-lg"): 1.5;
+			style(--variant: "subtitle-md"): 1.4286;
+			style(--variant: "subtitle-sm"): 1.3333;
 			style(--variant: "caption-lg"): 1.4545;
 			style(--variant: "caption-md"): 1.2;
 			style(--variant: "caption-sm"): 1.5;

--- a/packages/mui/src/~components/MuiTypography.css
+++ b/packages/mui/src/~components/MuiTypography.css
@@ -34,9 +34,9 @@
 		@apply --typography("body-sm");
 	}
 	&:where(.MuiTypography-subtitle1) {
-		@apply --typography("body-sm");
+		@apply --typography("subtitle-lg");
 	}
 	&:where(.MuiTypography-subtitle2) {
-		@apply --typography("caption-lg");
+		@apply --typography("subtitle-md");
 	}
 }


### PR DESCRIPTION
### Changes

_Follow-up to #1298 and #1427_

- (Internal) Defined `subtitle-{lg/md/sm}` variants for the `--typography` mixin. (The values are the same as `body-*`, based on the Figma file)
- Changed the mappings for `"subtitle1"` and `"subtitle1"` variants of the `Typography` component to use the new `subtitle-*` variants.

### Testing

| Before | After |
| --- | --- |
| <img width="103" height="60" alt="screenshot" src="https://github.com/user-attachments/assets/d759c884-68f9-4f28-8ab5-bd1683b6b49b" /> | <img width="115" height="70" alt="screenshot" src="https://github.com/user-attachments/assets/b5af145e-052e-41a8-9c12-23f88ff21250" /> |