### PR TITLE
add custom variants to `Typography`

### DIFF
--- a/.changeset/dark-parrots-send.md
+++ b/.changeset/dark-parrots-send.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added several new variants to the `Typography` component: `display-*`, `heading-*`, `subheading-*`, `body-*`, `caption-*` and `mono-sm`. These variants match the ones that were originally available in the `Text` component from `@stratakit/bricks`.

--- a/.changeset/real-coats-melt.md
+++ b/.changeset/real-coats-melt.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated the default `variant` of `Typography` to `"inherit"`.

--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -13,7 +13,7 @@ links:
 - The `font-family` has been changed to `InterVariable`. See [self-hosting fonts](/getting-started/develop/#self-hosting-the-fonts).
 - The typography scale has been adjusted to better align with StrataKit's more compact visual language.
 - Several new [`variant`s](#variants) have been added.
-- The default `variant` is now `"body-md"` instead of `"body1"`.
+- The default `variant` is now `"inherit"` instead of `"body1"`.
 - A warning will be logged during development if a heading variant is used without explicitly setting the `render` prop.
 - The `"secondary"` color value has been removed. A `"textTertiary"` color value has been added.
 

--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -12,7 +12,8 @@ links:
 
 - The `font-family` has been changed to `InterVariable`. See [self-hosting fonts](/getting-started/develop/#self-hosting-the-fonts).
 - The typography scale has been adjusted to better align with StrataKit's more compact visual language.
-- The default `variant` is now `"body2"` instead of `"body1"`.
+- Several new [`variant`s](#variants) have been added.
+- The default `variant` is now `"body-md"` instead of `"body1"`.
 - A warning will be logged during development if a heading variant is used without explicitly setting the `render` prop.
 - The `"secondary"` color value has been removed. A `"textTertiary"` color value has been added.
 
@@ -40,7 +41,14 @@ In these cases, combine a larger `variant` with the `render` prop to set a gener
 
 ### Variants
 
-All of the stock MUI **Typography** `variant`s are available, with sizing adjusted to fit StrataKit's more compact visual language.
+All of the stock MUI **Typography** `variant`s are available, with sizing adjusted to fit StrataKit's more compact visual language. Additionally, the following custom `variant`s are available:
+
+- `"display-lg"` / `"display-md"` / `"display-sm"`
+- `"headline-lg"` / `"headline-md"` / `"headline-sm"`
+- `"body-lg"` / `"body-md"` / `"body-sm"`
+- `"subtitle-lg"` / `"subtitle-md"` / `"subtitle-sm"`
+- `"caption-lg"` / `"caption-md"` / `"caption-sm"`
+- `"mono-sm"`
 
 ::example{src="mui/Typography.variants" min-height="600px"}
 

--- a/apps/website/src/content/docs/getting-started/migration-from-legacy-stratakit.mdx
+++ b/apps/website/src/content/docs/getting-started/migration-from-legacy-stratakit.mdx
@@ -317,24 +317,7 @@ Read additional [StrataKit MUI component documentation](/components/overview/) f
 ### Text
 
 - Replace the `Text` component from `@stratakit/bricks` with the `Typography` component from `@mui/material`. See [Typography examples](/components/typography/) for reference.
-- Update value of [`variant`](/reference/bricks/Text#Text.variant) prop.
 - If using a heading variant, make sure to set the `render` prop to the most appropriate element based on your application structure.
-
-  | Before          | After                                                                          |
-  | --------------- | ------------------------------------------------------------------------------ |
-  | `"display-lg"`  | `"h1"`                                                                         |
-  | `"display-md"`  | `"h2"`                                                                         |
-  | `"display-sm"`  | `"h3"`                                                                         |
-  | `"headline-lg"` | `"h4"`                                                                         |
-  | `"headline-md"` | `"h5"`                                                                         |
-  | `"headline-sm"` | `"h6"`                                                                         |
-  | `"body-lg"`     | `"body1"`                                                                      |
-  | `"body-md"`     | `"body2"`                                                                      |
-  | `"body-sm"`     | `"body2"`                                                                      |
-  | `"caption-lg"`  | `"caption"`                                                                    |
-  | `"caption-md"`  | `"caption"`                                                                    |
-  | `"caption-sm"`  | `"caption"`                                                                    |
-  | `"mono-sm"`     | `"body2"` (with `font-family: var(--stratakit-font-family-mono)` CSS property) |
 
 ### TextBox
 

--- a/examples/mui/Typography.heading.tsx
+++ b/examples/mui/Typography.heading.tsx
@@ -7,7 +7,7 @@ import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
-		<Typography variant="h4" render={<h2 />}>
+		<Typography variant="headline-md" render={<h2 />}>
 			Heading text
 		</Typography>
 	);

--- a/examples/mui/Typography.variants.tsx
+++ b/examples/mui/Typography.variants.tsx
@@ -9,6 +9,23 @@ import Typography from "@mui/material/Typography";
 export default () => {
 	return (
 		<Stack spacing={1}>
+			<Typography variant="display-lg">display-lg</Typography>
+			<Typography variant="display-md">display-md</Typography>
+			<Typography variant="display-sm">display-sm</Typography>
+			<Typography variant="headline-lg">headline-lg</Typography>
+			<Typography variant="headline-md">headline-md</Typography>
+			<Typography variant="headline-sm">headline-sm</Typography>
+			<Typography variant="body-lg">body-lg</Typography>
+			<Typography variant="body-md">body-md</Typography>
+			<Typography variant="body-sm">body-sm</Typography>
+			<Typography variant="subtitle-lg">subtitle-lg</Typography>
+			<Typography variant="subtitle-md">subtitle-md</Typography>
+			<Typography variant="subtitle-sm">subtitle-sm</Typography>
+			<Typography variant="caption-lg">caption-lg</Typography>
+			<Typography variant="caption-md">caption-md</Typography>
+			<Typography variant="caption-sm">caption-sm</Typography>
+			<Typography variant="mono-sm">mono-sm</Typography>
+
 			<Typography variant="body1">Body1</Typography>
 			<Typography variant="body2">Body2</Typography>
 			<Typography variant="button">Button</Typography>

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -487,9 +487,9 @@ declare module "@mui/material/Typography" {
 
 	interface TypographyOwnProps {
 		/**
-		 * The default variant with `@stratakit/mui` is `"body-md"`.
+		 * The default variant with `@stratakit/mui` is `"inherit"`.
 		 *
-		 * @default "body-md"
+		 * @default "inherit"
 		 */
 		variant?: TypographyProps["variant"];
 	}

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -466,11 +466,30 @@ declare module "@mui/material/Typography" {
 		textTertiary: true;
 	}
 
+	interface TypographyPropsVariantOverrides {
+		"display-lg": true;
+		"display-md": true;
+		"display-sm": true;
+		"headline-lg": true;
+		"headline-md": true;
+		"headline-sm": true;
+		"body-lg": true;
+		"body-md": true;
+		"body-sm": true;
+		"subtitle-lg": true;
+		"subtitle-md": true;
+		"subtitle-sm": true;
+		"caption-lg": true;
+		"caption-md": true;
+		"caption-sm": true;
+		"mono-sm": true;
+	}
+
 	interface TypographyOwnProps {
 		/**
-		 * The default variant with `@stratakit/mui` is `"body2"`.
+		 * The default variant with `@stratakit/mui` is `"body-md"`.
 		 *
-		 * @default "body2"
+		 * @default "body-md"
 		 */
 		variant?: TypographyProps["variant"];
 	}

--- a/packages/mui/src/~components/MuiTypography.css
+++ b/packages/mui/src/~components/MuiTypography.css
@@ -39,4 +39,58 @@
 	&:where(.MuiTypography-subtitle2) {
 		@apply --typography("subtitle-md");
 	}
+
+	&:where(.MuiTypography-display-lg) {
+		@apply --typography("display-lg");
+	}
+	&:where(.MuiTypography-display-md) {
+		@apply --typography("display-md");
+	}
+	&:where(.MuiTypography-display-sm) {
+		@apply --typography("display-sm");
+	}
+
+	&:where(.MuiTypography-headline-lg) {
+		@apply --typography("headline-lg");
+	}
+	&:where(.MuiTypography-headline-md) {
+		@apply --typography("headline-md");
+	}
+	&:where(.MuiTypography-headline-sm) {
+		@apply --typography("headline-sm");
+	}
+
+	&:where(.MuiTypography-body-lg) {
+		@apply --typography("body-lg");
+	}
+	&:where(.MuiTypography-body-md) {
+		@apply --typography("body-md");
+	}
+	&:where(.MuiTypography-body-sm) {
+		@apply --typography("body-sm");
+	}
+
+	&:where(.MuiTypography-subtitle-lg) {
+		@apply --typography("subtitle-lg");
+	}
+	&:where(.MuiTypography-subtitle-md) {
+		@apply --typography("subtitle-md");
+	}
+	&:where(.MuiTypography-subtitle-sm) {
+		@apply --typography("subtitle-sm");
+	}
+
+	&:where(.MuiTypography-caption-lg) {
+		@apply --typography("caption-lg");
+	}
+	&:where(.MuiTypography-caption-md) {
+		@apply --typography("caption-md");
+	}
+	&:where(.MuiTypography-caption-sm) {
+		@apply --typography("caption-sm");
+	}
+
+	&:where(.MuiTypography-mono-sm) {
+		@apply --typography("mono-sm");
+	}
 }

--- a/packages/mui/src/~components/MuiTypography.tsx
+++ b/packages/mui/src/~components/MuiTypography.tsx
@@ -28,7 +28,9 @@ const variantMapping = {
 	overline: "span",
 } satisfies TypographyOwnProps["variantMapping"];
 
-const variants = Object.keys(variantMapping) as TypographyOwnProps["variant"][];
+const muiVariants = Object.keys(
+	variantMapping,
+) as (keyof typeof variantMapping)[];
 
 /** These variants are currently rendered as headings by default. */
 const headings = ["h1", "h2", "h3", "h4", "h5", "h6", "subtitle1", "subtitle2"];
@@ -39,21 +41,22 @@ const MuiTypography = forwardRef<"p", BaseProps<"p">>((props, forwardedRef) => {
 	const classList = props.className?.split(" ").filter(Boolean);
 
 	// Derive the variant from the className passed to the DOM element.
-	const variant = (() => {
-		const variant = variants.find((name) =>
+	const muiVariant = (() => {
+		const variant = muiVariants.find((name) =>
 			classList?.includes(`MuiTypography-${name}`),
 		);
 		return variant || "body2";
 	})();
 
-	DEV: if (!props.render && headings.includes(variant)) {
+	DEV: if (!props.render && headings.includes(muiVariant)) {
 		console.warn(
 			"MuiTypography: Please explicitly set the `render` prop to ensure correct heading structure.",
 		);
 	}
 
 	const render = (() => {
-		const Element = variantMapping[variant] || "p";
+		const Element =
+			muiVariant in variantMapping ? variantMapping[muiVariant] : "p";
 		return <Element />;
 	})();
 

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -547,7 +547,7 @@ function createTheme(args: CreateThemeArgs) {
 			},
 			MuiTypography: {
 				defaultProps: {
-					variant: "body-md",
+					variant: "inherit",
 					component: MuiTypography,
 				},
 				variants: [

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -547,7 +547,7 @@ function createTheme(args: CreateThemeArgs) {
 			},
 			MuiTypography: {
 				defaultProps: {
-					variant: "body2",
+					variant: "body-md",
 					component: MuiTypography,
 				},
 				variants: [


### PR DESCRIPTION
### Changes

_Follow-up to #1298, #1427, #1432 and #1516._

Added several new values to the `variant` prop of `Typography` component:

- `"display-lg"` / `"display-md"` / `"display-sm"`
- `"headline-lg"` / `"headline-md"` / `"headline-sm"`
- `"body-lg"` / `"body-md"` / `"body-sm"`
- `"subtitle-lg"` / `"subtitle-md"` / `"subtitle-sm"`
- `"caption-lg"` / `"caption-md"` / `"caption-sm"`
- `"mono-sm"`

Changed the default variant to `"inherit"`. See https://github.com/iTwin/stratakit/pull/1433#discussion_r3390335113.

Added docs, and removed the migration table since the original values from `Text` are supported.

### Testing

[Deploy preview](https://stratakit.bentley.com/1433/mui/#typography) | [Docs preview](https://stratakit.bentley.com/1433/docs/components/typography/#variants)

<img width="382" height="545" alt="screenshot" src="https://github.com/user-attachments/assets/4e0055a7-6ad7-42f7-99ec-7ab8124c25be" />


Confirmed that IDE autocomplete works as intended.

Also confirmed that the default value change leads to desirable (or unchanged) results when `Typography` is used without an explicitly set `variant` prop.