### PR TITLE
Use MUI in `ErrorRegion` examples

### DIFF
--- a/examples/structures/ErrorRegion.default.tsx
+++ b/examples/structures/ErrorRegion.default.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Anchor } from "@stratakit/bricks";
+import Link from "@mui/material/Link";
 import { unstable_ErrorRegion as ErrorRegion } from "@stratakit/structures";
 
 export default () => {
@@ -15,7 +15,7 @@ export default () => {
 				<ErrorRegion.Item
 					key={errorItem}
 					message={<>Failed to create hierarchy for Item {errorItem}</>}
-					actions={<Anchor render={<button type="button" />}>Retry</Anchor>}
+					actions={<Link render={<button />}>Retry</Link>}
 				/>
 			))}
 		/>

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -234,7 +234,7 @@ DEV: ErrorRegionRoot.displayName = "ErrorRegion.Root";
 
 interface ErrorRegionItemProps extends Omit<BaseProps, "children"> {
 	/**
-	 * The error message. Consumers might consider using `Anchor` component to link to the associated element in the UI.
+	 * The error message. Consumers might consider using [`Link`](https://stratakit.bentley.com/docs/components/link/) component to link to the associated element in the UI.
 	 */
 	message?: React.ReactNode;
 	/**
@@ -242,7 +242,7 @@ interface ErrorRegionItemProps extends Omit<BaseProps, "children"> {
 	 */
 	messageId?: string;
 	/**
-	 * The actions available for this item. Must be a list of anchors, each rendered as a button using `<Anchor render={<button />} />`.
+	 * The actions available for this item. Must be a list of links, each rendered as a button using `<Link render={<button />} />`.
 	 */
 	actions?: React.ReactNode;
 }
@@ -255,9 +255,9 @@ interface ErrorRegionItemProps extends Omit<BaseProps, "children"> {
  * Example:
  * ```tsx
  * <ErrorRegion.Item
- *   message={<>Something went wrong with <Anchor href="item-10001">Item 10001</Anchor>.</>}
+ *   message={<>Something went wrong with <Link href="item-10001">Item 10001</Link>.</>}
  *   messageId="item-10001-error"
- *   actions={<Button>Retry</Button>}
+ *   actions={<Link render={<button />}>Retry</Link>}
  * />
  *
  * <Tree.Item


### PR DESCRIPTION
### Changes

This PR:
- Refactors `ErrorRegion` examples to use MUI components
- Updates jsdoc of `ErrorRegion` component

### Testing

- [Docs](https://stratakit.bentley.com/1434/docs/components/errorregion/)
