### PR TITLE
Add list semantics to `AvatarGroup`

### DIFF
--- a/.changeset/thin-years-sink.md
+++ b/.changeset/thin-years-sink.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added list semantics to `AvatarGroup` and nested `Avatar`s.

--- a/apps/website/src/content/docs/components/mui/AvatarGroup.md
+++ b/apps/website/src/content/docs/components/mui/AvatarGroup.md
@@ -12,3 +12,4 @@ links:
 
 - DOM order now matches the visual display order.
 - The visual stacking of the `Avatar`s is inverted.
+- Added list semantics to `AvatarGroup` and nested `Avatar`s. This required adding a wrapping element on each `Avatar`.

--- a/apps/website/src/content/docs/components/mui/AvatarGroup.md
+++ b/apps/website/src/content/docs/components/mui/AvatarGroup.md
@@ -12,4 +12,4 @@ links:
 
 - DOM order now matches the visual display order.
 - The visual stacking of the `Avatar`s is inverted.
-- Added list semantics to `AvatarGroup` and nested `Avatar`s. This required adding a wrapping element on each `Avatar`.
+- Added list semantics to `AvatarGroup`. Each child `Avatar` is wrapped in a list item element.

--- a/packages/mui/src/~components/MuiAvatarGroup.css
+++ b/packages/mui/src/~components/MuiAvatarGroup.css
@@ -9,7 +9,9 @@
 
 .MuiAvatarGroup-avatar {
 	margin-inline: 0;
+}
 
+.🥝MuiAvatarGroupItem {
 	&:where(:not(:nth-child(1 of &))) {
 		margin-inline-start: var(--AvatarGroup-spacing);
 	}

--- a/packages/mui/src/~components/MuiAvatarGroup.tsx
+++ b/packages/mui/src/~components/MuiAvatarGroup.tsx
@@ -15,20 +15,19 @@ interface MuiAvatarGroupProps extends BaseProps<"div"> {}
 
 const MuiAvatarGroup = forwardRef<"div", MuiAvatarGroupProps>(
 	(props, forwardedRef) => {
-		const { children, ...rest } = props;
+		const { children: childrenProp, ...rest } = props;
 
-		// Reverse children to match source order in HTML output
-		const reversedChildren = React.Children.toArray(children).reverse();
+		const children = React.Children.map(childrenProp, (child) => {
+			return (
+				<div className="🥝MuiAvatarGroupItem" role="listitem">
+					{child}
+				</div>
+			);
+		})?.reverse(); // Reverse children to match source order in HTML output
 
 		return (
-			<Role.div {...rest} ref={forwardedRef}>
-				{React.Children.map(reversedChildren, (child) => {
-					return (
-						<span className="🥝MuiAvatarGroupItem" role="listitem">
-							{child}
-						</span>
-					);
-				})}
+			<Role.div role="list" {...rest} ref={forwardedRef}>
+				{children}
 			</Role.div>
 		);
 	},

--- a/packages/mui/src/~components/MuiAvatarGroup.tsx
+++ b/packages/mui/src/~components/MuiAvatarGroup.tsx
@@ -22,7 +22,18 @@ const MuiAvatarGroup = forwardRef<"div", MuiAvatarGroupProps>(
 
 		return (
 			<Role.div {...rest} ref={forwardedRef}>
-				{reversedChildren}
+				{reversedChildren.map((child, index) => {
+					const key =
+						React.isValidElement(child) && child.key
+							? child.key
+							: `avatar-item-${index}`;
+
+					return (
+						<span className="🥝MuiAvatarGroupItem" key={key} role="listitem">
+							{child}
+						</span>
+					);
+				})}
 			</Role.div>
 		);
 	},

--- a/packages/mui/src/~components/MuiAvatarGroup.tsx
+++ b/packages/mui/src/~components/MuiAvatarGroup.tsx
@@ -22,14 +22,9 @@ const MuiAvatarGroup = forwardRef<"div", MuiAvatarGroupProps>(
 
 		return (
 			<Role.div {...rest} ref={forwardedRef}>
-				{reversedChildren.map((child, index) => {
-					const key =
-						React.isValidElement(child) && child.key
-							? child.key
-							: `avatar-item-${index}`;
-
+				{React.Children.map(reversedChildren, (child) => {
 					return (
-						<span className="🥝MuiAvatarGroupItem" key={key} role="listitem">
+						<span className="🥝MuiAvatarGroupItem" role="listitem">
 							{child}
 						</span>
 					);

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -188,6 +188,7 @@ function createTheme() {
 			MuiAvatarGroup: {
 				defaultProps: {
 					component: MuiAvatarGroup,
+					role: "list",
 					slotProps: {
 						surplus: {
 							["data-_sk-surplus" as keyof React.HTMLAttributes<HTMLDivElement>]: ``,

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -188,7 +188,6 @@ function createTheme() {
 			MuiAvatarGroup: {
 				defaultProps: {
 					component: MuiAvatarGroup,
-					role: "list",
 					slotProps: {
 						surplus: {
 							["data-_sk-surplus" as keyof React.HTMLAttributes<HTMLDivElement>]: ``,


### PR DESCRIPTION
### Changes

- Add `role="list"` to `AvatarGroup`.
- Add `<span class="🥝MuiAvatarGroupItem" role="listitem">` wrapping each `Avatar` within `AvatarGroup`.
- Fix `AvatarGroup` stacking CSS after introducing wrapper.
- Call out change in `AvatarGroup` docs.

[**Deploy preview**](https://stratakit.bentley.com/1437/mui/#avatargroup) 👀

### Testing

- Visuals are the same.
- macOS Voiceover: <img width="856" height="158" alt="Screen Recording 2026-04-21 at 12 05 35 PM" src="https://github.com/user-attachments/assets/81fc6c2d-87c4-40a5-bdbf-5109322dab0f" />
