### PR TITLE
enable `hover` for `TableRow`

### DIFF
--- a/.changeset/full-yaks-live.md
+++ b/.changeset/full-yaks-live.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Enabled `hover` prop for `TableRow` when inside `TableBody`.

--- a/apps/website/src/content/docs/components/mui/Table.md
+++ b/apps/website/src/content/docs/components/mui/Table.md
@@ -11,6 +11,7 @@ links:
 ## StrataKit MUI modifications
 
 - Removed `role="rowgroup"` semantics from `TableBody`, as it is not necessary and can cause issues with some assistive technologies.
+- Enabled `TableRow`'s [`hover`](https://mui.com/material-ui/api/table-row/#table-row-prop-hover) prop by default, except when used inside `TableHead`.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -318,6 +318,13 @@ declare module "@mui/material/TableCell" {
 	}
 }
 
+declare module "@mui/material/TableRow" {
+	interface TableRowOwnProps {
+		/** The default with `@stratakit/mui` is `true`, except when used inside `TableHead`. */
+		hover?: boolean;
+	}
+}
+
 declare module "@mui/material/TextField" {
 	interface TextFieldPropsColorOverrides {
 		secondary: false;

--- a/packages/mui/src/~components/MuiTable.tsx
+++ b/packages/mui/src/~components/MuiTable.tsx
@@ -5,8 +5,10 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
+import { ThemeProvider } from "@mui/material/styles";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 
+import type { Theme } from "@mui/material/styles";
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
 // ----------------------------------------------------------------------------
@@ -28,6 +30,32 @@ DEV: MuiTableHead.displayName = "MuiTableHead";
 
 // ----------------------------------------------------------------------------
 
+const MuiTableBody = forwardRef<"tbody", BaseProps<"tbody">>(
+	(props, forwardedRef) => {
+		return (
+			<ThemeProvider
+				theme={(outerTheme: Theme) => ({
+					...outerTheme,
+					components: {
+						...outerTheme.components,
+						MuiTableRow: {
+							defaultProps: {
+								...outerTheme.components?.MuiTableRow?.defaultProps,
+								hover: true, // Only enable `hover` for rows inside TableBody.
+							},
+						},
+					},
+				})}
+			>
+				<Role render={<tbody />} {...props} ref={forwardedRef} />
+			</ThemeProvider>
+		);
+	},
+);
+DEV: MuiTableBody.displayName = "MuiTableBody";
+
+// ----------------------------------------------------------------------------
+
 const MuiTableCell = forwardRef<"td", BaseProps<"td">>(
 	(props, forwardedRef) => {
 		const inHeader = React.useContext(MuiTableHeadContext);
@@ -40,4 +68,4 @@ DEV: MuiTableCell.displayName = "MuiTableCell";
 
 // ----------------------------------------------------------------------------
 
-export { MuiTableCell, MuiTableHead };
+export { MuiTableBody, MuiTableCell, MuiTableHead };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -29,7 +29,11 @@ import { MuiIconButton } from "./~components/MuiIconButton.js";
 import { MuiInputLabel } from "./~components/MuiInputLabel.js";
 import { MuiSnackbar } from "./~components/MuiSnackbar.js";
 import { MuiStepIcon } from "./~components/MuiStepper.js";
-import { MuiTableCell, MuiTableHead } from "./~components/MuiTable.js";
+import {
+	MuiTableBody,
+	MuiTableCell,
+	MuiTableHead,
+} from "./~components/MuiTable.js";
 import { MuiToggleButton } from "./~components/MuiToggleButton.js";
 import { MuiTypography } from "./~components/MuiTypography.js";
 import {
@@ -443,7 +447,7 @@ function createTheme() {
 			MuiTable: { defaultProps: { component: withRenderProp(Role, "table") } },
 			MuiTableBody: {
 				defaultProps: {
-					component: withRenderProp(Role, "tbody"),
+					component: MuiTableBody,
 					role: undefined, // Removing role="rowgroup". See https://github.com/iTwin/stratakit/pull/1361
 				},
 			},


### PR DESCRIPTION
### Changes

Uses a nested `ThemeProvider` to enable the [`hover`](https://mui.com/material-ui/api/table-row/#table-row-prop-hover) prop only for `TableRow`s used inside `TableBody`.

This is similar to the [legacy Table](https://stratakit.bentley.com/tests/table) and helps with scannability, especially in long rows where the user might lose their place going between columns.

### Testing

Confirmed that a background change happens when hovering a row, except when hovering the column headers.

[Deploy preview](https://stratakit.bentley.com/1444/mui#table)