### PR TITLE
docs: fix typos

### DIFF
--- a/apps/website/src/content/docs/components/mui/Autocomplete.md
+++ b/apps/website/src/content/docs/components/mui/Autocomplete.md
@@ -13,7 +13,7 @@ links:
 - Restyled using StrataKit's visual language.
 - The "clear" indicator is now keyboard focusable and remains visible to improve accessibility.
 - The listbox now matches the visual styling of [`Menu`](/components/menu), with individual options using the `MuiMenuItem-root` class via a theme-level [`renderOption`](https://mui.com/material-ui/api/autocomplete/#autocomplete-prop-renderOption) prop.
-- Added [role="group"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role) to the root element.
+- Added [`role="group"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role) to the root element.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Divider.md
+++ b/apps/website/src/content/docs/components/mui/Divider.md
@@ -28,7 +28,7 @@ In the following example, [from the HTML5 specification](https://html.spec.whatw
 
 ### Presentational dividers
 
-You may wish to make a **Divider** _presentational_ by removing its semantics, i.e. by passing [`role="separator"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/separator_role) and rendering it as a `<div>` element.
+You may wish to make a **Divider** _presentational_ by removing its semantics, i.e. by passing [`role="presentation"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role) and rendering it as a `<div>` element.
 
 For example, your navigation may be subdivided into multiple lists which are already separated semantically. You can use a _presentational_ **Divider** to visually mark where one list ends and the next begins.
 

--- a/apps/website/src/content/docs/components/mui/Skeleton.md
+++ b/apps/website/src/content/docs/components/mui/Skeleton.md
@@ -39,7 +39,7 @@ Accurately representing the shape and structure of a loading interface is a case
 - Use multiple **Skeletons** with the “text” variant to represent a multi-line text paragraph.
 - Include a _single_ visually hidden message per loading state.
 
-## ❌ Don’t
+## 🚫 Don’t
 
 - Don’t use **Skeleton** where the size and shape of the content and functionality being loaded is not known.
 - Don’t use **Skeleton** to indicate the progress of any process except loading. For indicating the progress of calculations and other processes within a loaded interface, use [**Progress**](/components/progress).


### PR DESCRIPTION
### Changes

Fixes a couple typos I noticed when looking through the docs.

The `role="separator"` mistake was relatively serious — it's the complete opposite of `role="presentation"`.

### Testing

N/A