### PR TITLE
Replace typographic symbols

### DIFF
--- a/apps/website/src/content/docs/components/mui/Accordion.md
+++ b/apps/website/src/content/docs/components/mui/Accordion.md
@@ -34,7 +34,7 @@ Make sure the **Accordion** is suitable for your use case. There may be other, m
 
 ### Expanded
 
-Disclose any **Accordion’s** content by default using the `defaultExpanded` prop. Alternatively, use `expanded` and `onChange` props to control the expanded state.
+Disclose any **Accordion's** content by default using the `defaultExpanded` prop. Alternatively, use `expanded` and `onChange` props to control the expanded state.
 
 ::example{src="mui/Accordion.expanded"}
 
@@ -66,7 +66,7 @@ Multiple adjacent **Accordions** make a set. To make this set programmatically d
 
 :::caution[Heading levels]
 
-It’s important you use an [appropriate heading level](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/) for each **Accordion**. Since **Accordions** can only represent one level of data (see [**Use cases**](#use-cases)), each **Accordion** in a set must take the _same_ heading level.
+It's important you use an [appropriate heading level](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/) for each **Accordion**. Since **Accordions** can only represent one level of data (see [**Use cases**](#use-cases)), each **Accordion** in a set must take the _same_ heading level.
 
 - Title of page (`h1` heading)
   - **Accordion** 1 (`h2` heading)
@@ -91,11 +91,11 @@ Use the `AccordionActions` component to display actions related to the content o
 ## ✅ Do
 
 - Use **Accordion** to tidy away long sections of content, to be later disclosed.
-- Adopt the correct heading level for the **Accordion’s** position in the document structure. The heading component can be [changed in the `slotProps`](https://mui.com/material-ui/react-accordion/#changing-heading-level).
+- Adopt the correct heading level for the **Accordion's** position in the document structure. The heading component can be [changed in the `slotProps`](https://mui.com/material-ui/react-accordion/#changing-heading-level).
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t nest **Accordions** inside one another.
-- Don’t use different heading levels for **Accordion** items in the same set. Since **Accordions** cannot be nested, they are at the same level in the document hierarchy.
-- Don’t close an **Accordion** when another **Accordion** is opened. Exclusive **Accordions** create [accessibility and usability issues](https://yatil.net/blog/exclusive-accordions).
+- Don't nest **Accordions** inside one another.
+- Don't use different heading levels for **Accordion** items in the same set. Since **Accordions** cannot be nested, they are at the same level in the document hierarchy.
+- Don't close an **Accordion** when another **Accordion** is opened. Exclusive **Accordions** create [accessibility and usability issues](https://yatil.net/blog/exclusive-accordions).
 - Don't place interactive elements inside an `AccordionSummary`.

--- a/apps/website/src/content/docs/components/mui/Avatar.md
+++ b/apps/website/src/content/docs/components/mui/Avatar.md
@@ -19,9 +19,9 @@ links:
 
 ### Initials
 
-If an image isn’t available, display an individual’s initials as a single character in an [`<abbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/abbr) element with an `aria-hidden="true"`.
+If an image isn't available, display an individual's initials as a single character in an [`<abbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/abbr) element with an `aria-hidden="true"`.
 
-If an accessible name is not provided by other means, apply [`role="img"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/img_role) to the **Avatar** and set [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) to the individual’s full name so assistive technologies announce the name instead of the initials.
+If an accessible name is not provided by other means, apply [`role="img"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/img_role) to the **Avatar** and set [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) to the individual's full name so assistive technologies announce the name instead of the initials.
 
 ::example{src="mui/Avatar.initials"}
 
@@ -44,7 +44,7 @@ In some cases, the **Avatar** may be considered presentational, since text ident
 - If an accessible name is not provided by other means, supply a name using `alt` for [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img) **Avatars** and `aria-label` for [`role="img"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/img_role) **Avatars**.
 - Display a single character [initial](#initials) if an image is not available.
 
-## 🚫 Don’t
+## 🚫 Don't
 
 - Don‘t resort to displaying initials if an image is available.
-- Don’t omit an accessible label if there is no other label in place.
+- Don't omit an accessible label if there is no other label in place.

--- a/apps/website/src/content/docs/components/mui/Backdrop.md
+++ b/apps/website/src/content/docs/components/mui/Backdrop.md
@@ -1,6 +1,6 @@
 ---
 title: Backdrop
-description: Backdrops guide the user’s attention to a specific area of the screen.
+description: Backdrops guide the user's attention to a specific area of the screen.
 links:
   muiDocs: https://mui.com/material-ui/react-backdrop/
   apiReference: https://mui.com/material-ui/api/backdrop/

--- a/apps/website/src/content/docs/components/mui/Badge.md
+++ b/apps/website/src/content/docs/components/mui/Badge.md
@@ -35,7 +35,7 @@ Set the `inline` prop to display the badge in normal document flow instead of po
 - **Secondary:** The default.
 - **Primary:** Use accent when high emphasis is required.
 - **Info:** Use to call out an object or action as having an important attribute.
-- **Success:** Use to indicate a successful or completed state when it’s important to provide positive reinforcement.
+- **Success:** Use to indicate a successful or completed state when it's important to provide positive reinforcement.
 - **Warning:** Use for warnings and time-sensitive issues that require attention and potential action.
 - **Error:** Use for critical and irreversible issues that requires attention and potential action. Apply sparingly.
 
@@ -47,9 +47,9 @@ In most cases, you should supplement the `color` with [iconography](#icons).
 
 ### Icons
 
-All [colors](#colors) except **secondary** and **primary** convey a specific type of status. Supplement those colors with an icon so that color is not the only means of communication. See [WCAG’s Use Of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html).
+All [colors](#colors) except **secondary** and **primary** convey a specific type of status. Supplement those colors with an icon so that color is not the only means of communication. See [WCAG's Use Of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html).
 
-For example, include the `status-warning` icon when applying the ‘error’ color.
+For example, include the `status-warning` icon when applying the ‘error' color.
 
 ::example{src="mui/Badge.error"}
 
@@ -59,7 +59,7 @@ For example, include the `status-warning` icon when applying the ‘error’ col
 - Include a concise and descriptive label.
 - Use an [`icon`](#icons) to communicate a status `color` in a color-independent fashion.
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t make **Badge** interactive. It is for indicating status, not controlling it.
-- Don’t override colors set using `color` prop. These have been chosen carefully for their [contrast](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html).
+- Don't make **Badge** interactive. It is for indicating status, not controlling it.
+- Don't override colors set using `color` prop. These have been chosen carefully for their [contrast](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html).

--- a/apps/website/src/content/docs/components/mui/Button.md
+++ b/apps/website/src/content/docs/components/mui/Button.md
@@ -38,7 +38,7 @@ Modifications specific to `Button`:
 
 ### Icons
 
-An [**Icon**](/components/icon) can be displayed before or after the **Button’s** text label using the `startIcon` or `endIcon` props. It’s important the **Icon’s** `alt` is omitted, since the text already provides the accessible label. In the following example, a “+” icon is appended to the text “Create new”.
+An [**Icon**](/components/icon) can be displayed before or after the **Button's** text label using the `startIcon` or `endIcon` props. It's important the **Icon's** `alt` is omitted, since the text already provides the accessible label. In the following example, a "+" icon is appended to the text "Create new".
 
 ::example{src="mui/Button.icon"}
 
@@ -83,11 +83,11 @@ An [**Icon**](/components/icon) can be displayed before or after the **Button’
 
 - Use **Button** for form submissions, modal confirmations, and other non-navigational calls-to-action.
 - Include a clear and concise label, describing the action the Button will take.
-- Include supplementary Icons before and/or after the label to assist with apprehension. For example, a “+” icon after “Create new”.
-- Use two buttons together, defining alternative or opposing actions, such as “Confirm” and “Cancel”.
+- Include supplementary Icons before and/or after the label to assist with apprehension. For example, a "+" icon after "Create new".
+- Use two buttons together, defining alternative or opposing actions, such as "Confirm" and "Cancel".
 - Accompany text variants with icons, to increase affordance. Otherwise, they are less likely to be perceived as interactive.
 
-## 🚫 Don’t
+## 🚫 Don't
 
 - Don't use **Button** for navigation. Use a [**Link**](/components/link) or simple text link instead.
 - Don't include multiple **Buttons** with the same label.

--- a/apps/website/src/content/docs/components/mui/Checkbox.md
+++ b/apps/website/src/content/docs/components/mui/Checkbox.md
@@ -60,8 +60,8 @@ Use the `error` prop on `FormControl` to display the `FormHelperText` in an erro
 - Group related **Checkboxes** into a `<fieldset>`, using a `<legend>` as a label for the group.
 - Use **Checkboxes** inside a form that needs submission.
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t omit a programmatically associated label.
-- Don’t use the `checked` state of one **Checkbox** to alter the `checked` state of others (don't use **Checkboxes** as [**Radios**](/components/radio)).
-- Don’t use a **Checkbox** when the effect of checking it is instantaneous (no confirmation or submission is required). Use [**Switch**](/components/switch) instead.
+- Don't omit a programmatically associated label.
+- Don't use the `checked` state of one **Checkbox** to alter the `checked` state of others (don't use **Checkboxes** as [**Radios**](/components/radio)).
+- Don't use a **Checkbox** when the effect of checking it is instantaneous (no confirmation or submission is required). Use [**Switch**](/components/switch) instead.

--- a/apps/website/src/content/docs/components/mui/Divider.md
+++ b/apps/website/src/content/docs/components/mui/Divider.md
@@ -52,6 +52,6 @@ By default, the **Divider** appears in a horizontal orientation. Reorientate it 
 - Use the **Divider** to indicate divisions between grouped content such as lists.
 - Use _presentational_ **Divider** in cases where the semantics are superfluous, such as at the intersection between two unordered lists.
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t use a **Divider** where a heading would better introduce a section of content.
+- Don't use a **Divider** where a heading would better introduce a section of content.

--- a/apps/website/src/content/docs/components/mui/IconButton.md
+++ b/apps/website/src/content/docs/components/mui/IconButton.md
@@ -24,7 +24,7 @@ Make sure the **IconButton** is suitable for your use case. There may be other, 
 
 - The `"default"`, `"info"`, `"success"`, `"warning"`, `"inherit"` colors have been removed. The default color is now `"secondary"`.
 - The `size` options (`"small"`, `"medium"`, `"large"`) have all been decreased in height.
-- A `label` prop has been added. When specified, it is used as the **IconButton’s** accessible name and is also shown in a tooltip on hover and focus.
+- A `label` prop has been added. When specified, it is used as the **IconButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 
 ## Examples
@@ -35,7 +35,7 @@ Use a [**Badge**](/components/badge) component to indicate the functionality beh
 
 ::example{src="mui/Badge.default"}
 
-Make sure to provide an accessible description in the form of a visually hidden text explaining the significance of the badge’s presence. In this case, the value is _“You have 4 unread notifications”_.
+Make sure to provide an accessible description in the form of a visually hidden text explaining the significance of the badge's presence. In this case, the value is _"You have 4 unread notifications"_.
 
 ### Sizes
 
@@ -51,7 +51,7 @@ Make sure to provide an accessible description in the form of a visually hidden 
 - Use in [toolbars](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/toolbar_role).
 - Use it only when a stand-alone icon effectively communicates the action.
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t use to replace buttons.
-- Don’t use if an icon doesn’t clearly convey the action. Use a [**Button**](/components/button) with a text label or a more suitable icon.
+- Don't use to replace buttons.
+- Don't use if an icon doesn't clearly convey the action. Use a [**Button**](/components/button) with a text label or a more suitable icon.

--- a/apps/website/src/content/docs/components/mui/Link.md
+++ b/apps/website/src/content/docs/components/mui/Link.md
@@ -23,7 +23,7 @@ Make sure the **Link** is suitable for your use case. There may be other, more a
 - Add `tabindex="-1"` to the element representing the target section (fragment) to ensure it receives keyboard focus.
 - Provide a label that describes the purpose of the link. This label should still be understandable when removed from context.
 
-## 🚫 Don’t
+## 🚫 Don't
 
 - Don't use **Link** for non-navigational (linking) actions. Use a component like [**Button**](/components/button), [**IconButton**](/components/iconbutton), or [**Switch**](/components/switch) (depending on your use case).
-- Don't include **Links** with the same label but pointing to different locations. For “read more” links, you can include clarifying text with the [**VisuallyHidden**](/components/visuallyhidden) component. That is, two links appearing as “read more” can become “read more about x” and "read more about y" in screen reader output.
+- Don't include **Links** with the same label but pointing to different locations. For "read more" links, you can include clarifying text with the [**VisuallyHidden**](/components/visuallyhidden) component. That is, two links appearing as "read more" can become "read more about x" and "read more about y" in screen reader output.

--- a/apps/website/src/content/docs/components/mui/Select.md
+++ b/apps/website/src/content/docs/components/mui/Select.md
@@ -30,7 +30,7 @@ Make sure the **Select** is suitable for your use case. There may be other, more
 
 ### Icon
 
-An [**Icon**](/components/icon) can be displayed before or after the option’s text label using the [`ListItemIcon`](https://mui.com/material-ui/api/list-item-icon/) component. It’s important the **Icon’s** `alt` is omitted, since the text already provides the accessible label.
+An [**Icon**](/components/icon) can be displayed before or after the option's text label using the [`ListItemIcon`](https://mui.com/material-ui/api/list-item-icon/) component. It's important the **Icon's** `alt` is omitted, since the text already provides the accessible label.
 
 ::example{src="mui/Select.icon"}
 
@@ -42,7 +42,7 @@ Use the [`multiple`](https://mui.com/material-ui/api/select/#select-prop-multipl
 
 ### Native
 
-Use the [`NativeSelect`](https://mui.com/material-ui/api/native-select/) component to render a native [`<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/select) element. The native select has fewer customization options, however, it is more accessible and works much better on mobile devices. The native select also has the benefit of participating in the browser’s built-in form validation and autofill.
+Use the [`NativeSelect`](https://mui.com/material-ui/api/native-select/) component to render a native [`<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/select) element. The native select has fewer customization options, however, it is more accessible and works much better on mobile devices. The native select also has the benefit of participating in the browser's built-in form validation and autofill.
 
 ::example{src="mui/NativeSelect.default"}
 
@@ -55,12 +55,12 @@ Use the [`NativeSelect`](https://mui.com/material-ui/api/native-select/) compone
 
 ## ✅ Do
 
-- Use **Selects** for form fields. A **Select’s** options represent a choice of predefined input values.
+- Use **Selects** for form fields. A **Select's** options represent a choice of predefined input values.
 - Programmatically associate labels and descriptions to the **Select** for compatibility with assistive technologies.
 - Write helpful labels, descriptions, and error messages, so users can avoid errors.
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t steal keyboard focus and move it away from the **Select** when an option is chosen.
-- Don’t change application state without employing a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) to alert screen reader users of that change.
-- Don’t make **Select** options behave like buttons/commands. Use the [**Menu**](/components/menu) component instead.
+- Don't steal keyboard focus and move it away from the **Select** when an option is chosen.
+- Don't change application state without employing a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) to alert screen reader users of that change.
+- Don't make **Select** options behave like buttons/commands. Use the [**Menu**](/components/menu) component instead.

--- a/apps/website/src/content/docs/components/mui/Skeleton.md
+++ b/apps/website/src/content/docs/components/mui/Skeleton.md
@@ -30,16 +30,16 @@ Use the [`variant`](https://mui.com/material-ui/api/skeleton/#skeleton-prop-vari
 ::example{src="mui/Skeleton.variants" min-width="300px" min-height="200px"}
 
 :::tip
-Accurately representing the shape and structure of a loading interface is a case of combining multiple individual **Skeletons** of differing [variants](#variants) and sizes. The **Skeleton** itself is a visual component and is not conveyed to assistive technologies. Include only one visually hidden “Loading…” label since multiple loading messages are repetitive and unhelpful.
+Accurately representing the shape and structure of a loading interface is a case of combining multiple individual **Skeletons** of differing [variants](#variants) and sizes. The **Skeleton** itself is a visual component and is not conveyed to assistive technologies. Include only one visually hidden "Loading…" label since multiple loading messages are repetitive and unhelpful.
 :::
 
 ## ✅ Do
 
 - Combine different sizes and [variants](#variants) to best approximate the shape and size of the interface being loaded.
-- Use multiple **Skeletons** with the “text” variant to represent a multi-line text paragraph.
+- Use multiple **Skeletons** with the "text" variant to represent a multi-line text paragraph.
 - Include a _single_ visually hidden message per loading state.
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t use **Skeleton** where the size and shape of the content and functionality being loaded is not known.
-- Don’t use **Skeleton** to indicate the progress of any process except loading. For indicating the progress of calculations and other processes within a loaded interface, use [**Progress**](/components/progress).
+- Don't use **Skeleton** where the size and shape of the content and functionality being loaded is not known.
+- Don't use **Skeleton** to indicate the progress of any process except loading. For indicating the progress of calculations and other processes within a loaded interface, use [**Progress**](/components/progress).

--- a/apps/website/src/content/docs/components/mui/Switch.md
+++ b/apps/website/src/content/docs/components/mui/Switch.md
@@ -45,7 +45,7 @@ Use the `defaultChecked` prop to set the initial checked state. Alternatively, u
 - Use a clear, descriptive label for each **Switch**.
 - Use a **Switch** when the effect is instantaneous (no confirmation or submission is required).
 
-## 🚫 Don’t
+## 🚫 Don't
 
 - Don't use switches for mandatory actions. The checked state of a switch can never be _invalid_.
 - Don't use one switch to change multiple settings simultaneously.

--- a/apps/website/src/content/docs/components/mui/ToggleButton.md
+++ b/apps/website/src/content/docs/components/mui/ToggleButton.md
@@ -10,7 +10,7 @@ links:
 
 ## StrataKit MUI modifications
 
-- A `label` prop has been added. When specified, it is used as the **ToggleButton’s** accessible name and is also shown in a tooltip on hover and focus.
+- A `label` prop has been added. When specified, it is used as the **ToggleButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 - **ToggleButtons** are styled to match the visual appearance of the [**IconButton**](/components/iconbutton) component. Borders are displayed only when the buttons are wrapped in a `ToggleButtonGroup`. [Standalone](#standalone) **ToggleButtons** do not have borders.
 - **ToggleButtons** can now be rendered as regular [**Buttons**](/components/button) to [display text](#text).
@@ -49,7 +49,7 @@ In the example above, the [`exclusive`](https://mui.com/material-ui/api/toggle-b
 - Use the `label` prop in icon-only **ToggleButtons** to provide a descriptive, accessible name.
 - Use `ToggleButtonGroup` to group multiple related **ToggleButtons**.
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t use to replace buttons.
-- Don’t mix text and icon-only **ToggleButtons** in the same group.
+- Don't use to replace buttons.
+- Don't mix text and icon-only **ToggleButtons** in the same group.

--- a/apps/website/src/content/docs/components/mui/Tooltip.md
+++ b/apps/website/src/content/docs/components/mui/Tooltip.md
@@ -48,20 +48,20 @@ Use the `describeChild` prop to provide an accessible label via [`aria-label`](h
 
 The **Tooltip** is integrated into the [**IconButton**](/components/iconbutton) component and available via the `label` prop. The **Tooltip** component is _not_ needed.
 
-Since the **IconButton’s** tooltip represents its principle label, choose a `label` value that adequately explains the **IconButton’s** purpose.
+Since the **IconButton's** tooltip represents its principle label, choose a `label` value that adequately explains the **IconButton's** purpose.
 
 ::example{src="mui/IconButton.default"}
 
 ## ✅ Do
 
 - Use **IconButton** `label` prop to automatically apply **Tooltip**.
-- Use **Tooltips** as descriptions for **Button** elements, supplementing the **Button’s** existing label.
+- Use **Tooltips** as descriptions for **Button** elements, supplementing the **Button's** existing label.
 - Keep tooltip content _brief_, _relevant_, and _helpful_.
 
-## 🚫 Don’t
+## 🚫 Don't
 
-- Don’t use **Tooltips** around static elements (e.g. `<div>` or `<span>`).
-- Don’t place interactive elements _inside_ the **Tooltip** content. Use [**Popover**](/components/popover) instead.
-- Don’t use **Tooltips** for the labels or descriptions of form inputs. Use inline text elements instead.
-- Don’t use **Tooltips** for revealing truncated text.
-- Don’t omit a programmatically associated label or description unless an [accessible label/name](https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name) is in place by other means.
+- Don't use **Tooltips** around static elements (e.g. `<div>` or `<span>`).
+- Don't place interactive elements _inside_ the **Tooltip** content. Use [**Popover**](/components/popover) instead.
+- Don't use **Tooltips** for the labels or descriptions of form inputs. Use inline text elements instead.
+- Don't use **Tooltips** for revealing truncated text.
+- Don't omit a programmatically associated label or description unless an [accessible label/name](https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name) is in place by other means.

--- a/apps/website/src/content/docs/components/overview.md
+++ b/apps/website/src/content/docs/components/overview.md
@@ -14,13 +14,13 @@ See [**Develop with StrataKit**](/docs/getting-started/develop/) for detailed in
 
 By making an established open-source library responsible for generic components, we are free to focus efforts on developing components that solve more complex and specific tasks.
 
-**StrataKit**’s [**MUI** theme](https://www.npmjs.com/package/@stratakit/mui) ensures consistency across all components, incorporating **StrataKit’s** design tokens and [iconography](/docs/icons/).
+**StrataKit**'s [**MUI** theme](https://www.npmjs.com/package/@stratakit/mui) ensures consistency across all components, incorporating **StrataKit's** design tokens and [iconography](/docs/icons/).
 
 The theme includes the following modifications:
 
-1. **Styling**: The style has been aligned with **StrataKit’s** visual language.
-2. **Typography**: **StrataKit’s** principle font is [Inter](https://rsms.me/inter/), which needs to be [self-hosted](/getting-started/develop/#self-hosting-the-fonts).
-3. **Icons**: Component icons are taken exclusively from **StrataKit’s** own icon collection.
+1. **Styling**: The style has been aligned with **StrataKit's** visual language.
+2. **Typography**: **StrataKit's** principle font is [Inter](https://rsms.me/inter/), which needs to be [self-hosted](/getting-started/develop/#self-hosting-the-fonts).
+3. **Icons**: Component icons are taken exclusively from **StrataKit's** own icon collection.
 4. **API**: Some props have been adjusted or removed, and some new props have been added.
 5. **Structure and behavior**: The markup structure and interaction behavior of certain components have been modified to meet **StrataKit** UX and accessibility requirements.
 
@@ -38,18 +38,18 @@ All components are accompanied by implementation guidance. This adheres to the f
 - **Use cases**: Is this, or another, component right for my use case? (compares similar components in a table)
 - **StrataKit MUI modifications**: _(where applicable)_: What has been done to bring the **MUI** component in line with **StrataKit**?
 - **Examples**: What variants are there, and to which contexts are they suited?
-- **✅ Do**: What’s needed for an efficient and accessible implementation? What opportunities are there to improve user experience?
-- **🚫 Don’t**: What are some common pitfalls? What are the bad practices to avoid?
+- **✅ Do**: What's needed for an efficient and accessible implementation? What opportunities are there to improve user experience?
+- **🚫 Don't**: What are some common pitfalls? What are the bad practices to avoid?
 
 :::caution[MUI documentation]
 
-The entirety of the [**MUI** component docs](https://mui.com/material-ui/all-components/) are not reproduced here. The **StrataKit** docs exemplify how to _implement_ **MUI** components according to **StrataKit’s** standards. Consider this additional guidance a necessary companion to **MUI’s** documentation.
+The entirety of the [**MUI** component docs](https://mui.com/material-ui/all-components/) are not reproduced here. The **StrataKit** docs exemplify how to _implement_ **MUI** components according to **StrataKit's** standards. Consider this additional guidance a necessary companion to **MUI's** documentation.
 
 :::
 
 ## Component status
 
-Check the status before choosing to use a component in your product. You may be unwilling to undertake certain risks and uncertainties. You can find the status in the metadata at the top of each component’s guidance page. It will have one of the following values:
+Check the status before choosing to use a component in your product. You may be unwilling to undertake certain risks and uncertainties. You can find the status in the metadata at the top of each component's guidance page. It will have one of the following values:
 
 - **Unstable**: The component is available for consumption but is not comprehensively tested and may undergo breaking changes. As an early adopter, please provide feedback.
 - **Stable**: The component is established and meets our compatibility and accessibility standards.

--- a/apps/website/src/content/docs/contributing.md
+++ b/apps/website/src/content/docs/contributing.md
@@ -3,13 +3,13 @@ title: Contributing
 description: Help us improve these docs
 ---
 
-This documentation site is a living entity, growing and improving alongside **StrataKit** itself. You may find some information missing, unclear, superfluous, or in the wrong place. That’s where you can help.
+This documentation site is a living entity, growing and improving alongside **StrataKit** itself. You may find some information missing, unclear, superfluous, or in the wrong place. That's where you can help.
 
 Please follow the contribution instructions below. If you try to contribute via other channels or using different software, we will not be able to properly track, review, and publish your work.
 
-## “Edit page”
+## "Edit page"
 
-At the foot of every page, you’ll find a link labeled **✎ Edit page**. Press this link to an editable version of the page’s content on Github. Follow these steps to make your contribution:
+At the foot of every page, you'll find a link labeled **✎ Edit page**. Press this link to an editable version of the page's content on Github. Follow these steps to make your contribution:
 
 1. Make your changes to the markdown source. See [**Markdown help**](#markdown-help), if you are unfamiliar with the syntax.
 2. Click the **Commit changes** button in the top right corner of the Github interface.
@@ -19,7 +19,7 @@ At the foot of every page, you’ll find a link labeled **✎ Edit page**. Press
    3. **Commit email**: Use your bentley.com email if it is an option.
    4. **New branch name** Please use the format `[your username]/edit/[page title]`. Example: `heydon/edit/getting-started/` (since the page title uses multiple words, these are joined by a hyphen).
 4. Click **Propose changes** at the foot of the dialog.
-5. On the **Open a pull request** page that appears, double check the information you’ve supplied and click **Create pull request** when you’re happy.
+5. On the **Open a pull request** page that appears, double check the information you've supplied and click **Create pull request** when you're happy.
 6. Your pull request will need to be approved by a member of the **StrataKit** team. You may be asked questions in the comment stream of the pull request. Remember to check your Github notifications.
 7. Thank you!
 
@@ -32,15 +32,15 @@ Consistency supports both comprehension and navigation. Each component guide fol
   - **Usage:** How should I implement this component? With which other components? (a basic example is followed by some other cases)
   - **Configurations:** What options are there for changing the appearance and behavior of the component? (variants, tones, and other customization options)
   - **Do:** A summary of best practices and opportunities.
-  - **Don’t:** Things to avoid for an error-free and accessible implementation.
+  - **Don't:** Things to avoid for an error-free and accessible implementation.
 
 :::note[Headings]
-The major sections **Use cases** through to **Don’t** must each use a level 2 heading (`<h2>`). See [**Headings**](#headings) for the markdown syntax. Organize subsections under these headings using `<h3>` and `<h4>` as appropriate.
+The major sections **Use cases** through to **Don't** must each use a level 2 heading (`<h2>`). See [**Headings**](#headings) for the markdown syntax. Organize subsections under these headings using `<h3>` and `<h4>` as appropriate.
 :::
 
 ## Markdown help
 
-This site’s content is written in _markdown_: a minimal formatting syntax using special characters. In fact, in this case it’s a special flavour of markdown with some additional options. Here is a brief guide:
+This site's content is written in _markdown_: a minimal formatting syntax using special characters. In fact, in this case it's a special flavour of markdown with some additional options. Here is a brief guide:
 
 ### Inline text styling
 
@@ -121,7 +121,7 @@ links:
 
 ### Asides
 
-Occasionally, something needs to be noted but it doesn’t fit within the main flow of the document. You can interject notes (or “asides”) using a special syntax. The **Starlight** framework, on which these docs are based, has a [guide on asides and their syntax](https://starlight.astro.build/guides/authoring-content/#asides).
+Occasionally, something needs to be noted but it doesn't fit within the main flow of the document. You can interject notes (or "asides") using a special syntax. The **Starlight** framework, on which these docs are based, has a [guide on asides and their syntax](https://starlight.astro.build/guides/authoring-content/#asides).
 
 Here is an example from the [**Switch**](/components/switch) page:
 
@@ -133,4 +133,4 @@ You must use the **Switch** in conjunction with a label. See [Usage](#usage).
 
 ### Exercise caution
 
-You may encounter some syntax that isn’t documented above. The rule is: **if it’s not documented here, don’t try to use or edit it**. If some unfamiliar syntax needs to be moved inside the document, make sure you move it _in its current form, and in its entirety_. Otherwise, you are liable to cause errors.
+You may encounter some syntax that isn't documented above. The rule is: **if it's not documented here, don't try to use or edit it**. If some unfamiliar syntax needs to be moved inside the document, make sure you move it _in its current form, and in its entirety_. Otherwise, you are liable to cause errors.

--- a/apps/website/src/content/docs/guides/page-structure.md
+++ b/apps/website/src/content/docs/guides/page-structure.md
@@ -9,7 +9,7 @@ Each screen, or page, in your interface is likely to include **StrataKit** compo
 
 ### Page language
 
-Place a `lang` attribute on the `<html>` element to identify the predominant language of the page. For example, the value `en` designates English as the page’s language.
+Place a `lang` attribute on the `<html>` element to identify the predominant language of the page. For example, the value `en` designates English as the page's language.
 
 ```html
 <html lang="en"></html>
@@ -46,13 +46,13 @@ The semantic structure of your page or screen, defined in HTML, is paramount. It
 - `<main>`: Include just once per screen/page. This encapsulates the main, unique content of the screen.
 - `<header>`: Include just one at the start of the document. This may contain a principle `<nav>` element.
 - `<nav>`: Multiple can be used for different purposes, such as site navigation, pagination, and tables of content. Give each `<nav>` a unique label, like `<nav aria-label="table of content">`. This differentiates the landmarks when aggregated in screen reader software.
-- `role="search"`: Identifies the element containing the page’s principle search functionality. Apply the `role` attribution to an element containing the `<form>` element. Do not place `role="search"` on the `<form>` element itself.
-- `<aside>`: For complementary content and functionality. If your model is the content of `<main>`, then an `<aside>` might contain a tree component for calibrating your model’s layers. Alternatively, the tree may be considered part of the model and the `<aside>` part of the `<main>` content, alongside the model itself.
+- `role="search"`: Identifies the element containing the page's principle search functionality. Apply the `role` attribution to an element containing the `<form>` element. Do not place `role="search"` on the `<form>` element itself.
+- `<aside>`: For complementary content and functionality. If your model is the content of `<main>`, then an `<aside>` might contain a tree component for calibrating your model's layers. Alternatively, the tree may be considered part of the model and the `<aside>` part of the `<main>` content, alongside the model itself.
 - `<footer>`: Used once at the end of the document. Useful for including company and product identification, and related links.
 
 ### Headings
 
-If landmarks represent continents, then sections are countries: subdivisions of landmarks. While HTML offers the `<section>` element, headings more commonly define the implicit sections and subsections of the document. The provided heading elements, from `<h1>` to `<h6>`, are numbered according to section depth. For example, an `<h3>` following an `<h2>` introduces a subsection to the `<h2>`’s section.
+If landmarks represent continents, then sections are countries: subdivisions of landmarks. While HTML offers the `<section>` element, headings more commonly define the implicit sections and subsections of the document. The provided heading elements, from `<h1>` to `<h6>`, are numbered according to section depth. For example, an `<h3>` following an `<h2>` introduces a subsection to the `<h2>`'s section.
 
 Not just anything should be a heading; not all large or bold text should use heading semantics. A heading must introduce a section (or subsection) of thematically distinct content.
 
@@ -62,7 +62,7 @@ A skip link is a mechanism for bypassing header/navigation functionality to inte
 
 Typically, skip links are hidden until focused by keyboard. They are not needed by or available to mouse users.
 
-If you are implementing your own skip link, point the skip link’s `href` to the `<main>` element page fragment. To ensure keyboard focus follows the link, include `tabindex="-1"` on the target element.
+If you are implementing your own skip link, point the skip link's `href` to the `<main>` element page fragment. To ensure keyboard focus follows the link, include `tabindex="-1"` on the target element.
 
 ```html
 <a href="#main">skip to content</a>

--- a/apps/website/src/content/docs/index.md
+++ b/apps/website/src/content/docs/index.md
@@ -12,7 +12,7 @@ Drawing its name from _strata_ (the vertical layers in rock), **StrataKit** is o
 
 ## Tokens
 
-**StrataKit’s** design tokens (aka "variables") were built from the ground up, with accessibility in mind. Colors are defined using the [Oklab color space](https://en.wikipedia.org/wiki/Oklab_color_space) for its wide gamut and programmatic composability in CSS. The typographic scale is optimized for readability in dense and complex interfaces. [Inter](https://rsms.me/inter/) is **StrataKit’s** principle font, chosen for its configurability via multiple OpenType features.
+**StrataKit's** design tokens (aka "variables") were built from the ground up, with accessibility in mind. Colors are defined using the [Oklab color space](https://en.wikipedia.org/wiki/Oklab_color_space) for its wide gamut and programmatic composability in CSS. The typographic scale is optimized for readability in dense and complex interfaces. [Inter](https://rsms.me/inter/) is **StrataKit's** principle font, chosen for its configurability via multiple OpenType features.
 
 ## Icons
 
@@ -20,7 +20,7 @@ Drawing its name from _strata_ (the vertical layers in rock), **StrataKit** is o
 
 ## Components
 
-Elemental **StrataKit** components are taken from the open source **Material UI** (MUI) library and **StrataKit’s** custom MUI theme is optimized for accessibility. More complex and specialized components are custom made, incorporating the same **Tokens** for consistency. This site exemplifies how to correctly implement the entire component catalogue.
+Elemental **StrataKit** components are taken from the open source **Material UI** (MUI) library and **StrataKit's** custom MUI theme is optimized for accessibility. More complex and specialized components are custom made, incorporating the same **Tokens** for consistency. This site exemplifies how to correctly implement the entire component catalogue.
 
 ## Patterns
 


### PR DESCRIPTION
### Changes

This PR replaces typographic symbols in documentation site based on https://github.com/iTwin/stratakit/pull/1341#discussion_r3063222598:
- Typographic apostrophes `’` replaced with `'`
- Typographic quotes `“` and `”` replaced with `"`

These symbols are automatically replaced by [SmartyPants formatter](https://docs.astro.build/en/reference/configuration-reference/#markdownsmartypants) in the documentation site while allowing for easier authoring and search in the sources.

### Testing

- [Docs](https://stratakit.bentley.com/1450/docs/)
