### PR TITLE
Fix `Pagination` disabled & disabled + active styling

### DIFF
--- a/.changeset/loose-rabbits-pick.md
+++ b/.changeset/loose-rabbits-pick.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed pagination disabled and disabled + active styling.

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -65,4 +65,14 @@
 		border: 1px solid var(--stratakit-color-border-accent-strong);
 		color: var(--stratakit-color-text-accent-strong);
 	}
+
+	&:where(.Mui-disabled) {
+		color: var(--stratakit-color-text-neutral-disabled);
+		opacity: 1;
+
+		&:where(.Mui-selected) {
+			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
+			border-color: var(--stratakit-color-border-glow-on-surface-disabled);
+		}
+	}
 }

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -22,6 +22,7 @@
 @import "./~components/MuiInput.css";
 @import "./~components/MuiList.css";
 @import "./~components/MuiMenu.css";
+@import "./~components/MuiPagination.css";
 @import "./~components/MuiSelect.css";
 @import "./~components/MuiSlider.css";
 @import "./~components/MuiStepper.css";
@@ -56,23 +57,5 @@
 
 	&:where(:hover, :focus-visible) {
 		text-underline-offset: var(--stratakit-space-x1);
-	}
-}
-
-.MuiPaginationItem-root {
-	&:where(.Mui-selected) {
-		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
-		border: 1px solid var(--stratakit-color-border-accent-strong);
-		color: var(--stratakit-color-text-accent-strong);
-	}
-
-	&:where(.Mui-disabled) {
-		color: var(--stratakit-color-text-neutral-disabled);
-		opacity: 1;
-
-		&:where(.Mui-selected) {
-			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
-			border-color: var(--stratakit-color-border-glow-on-surface-disabled);
-		}
 	}
 }

--- a/packages/mui/src/~components/MuiPagination.css
+++ b/packages/mui/src/~components/MuiPagination.css
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiPaginationItem-root {
+	&:where(.Mui-selected) {
+		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+		border: 1px solid var(--stratakit-color-border-accent-strong);
+		color: var(--stratakit-color-text-accent-strong);
+	}
+
+	&:where(.Mui-disabled) {
+		color: var(--stratakit-color-text-neutral-disabled);
+		opacity: 1;
+
+		&:where(.Mui-selected) {
+			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
+			border-color: var(--stratakit-color-border-glow-on-surface-disabled);
+		}
+	}
+}

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -177,7 +177,7 @@
 }
 
 .MuiPaginationItem-root {
-	&:where(.Mui-selected) {
+	&:where(.Mui-selected:not(.Mui-disabled)) {
 		background-color: SelectedItem;
 		border-color: SelectedItemText;
 		color: SelectedItemText;


### PR DESCRIPTION
### Changes

- Visually corrected disabled paginator button styling (MUI was relying on `opacity`).
- Visually corrected disabled + active paginator button styling.

### Testing

- Used #1447 to visually test light, dark, `forced-colors`.

| Theme | Before | After |
| -- | -- | -- |
| Dark | <img width="838" height="240" alt="Screenshot 2026-04-28 at 12 53 07 PM" src="https://github.com/user-attachments/assets/ea897192-4311-493f-9f39-d6b48f062454" /> | <img width="838" height="240" alt="Screenshot 2026-04-28 at 12 52 35 PM" src="https://github.com/user-attachments/assets/c37c9040-23ab-435e-acd4-608984459738" /> |
| `forced-colors` dark | <img width="838" height="240" alt="Screenshot 2026-04-28 at 12 53 33 PM" src="https://github.com/user-attachments/assets/07459ab0-a344-464a-8c36-d13a9d495eaf" /> | <img width="838" height="240" alt="Screenshot 2026-04-28 at 12 53 49 PM" src="https://github.com/user-attachments/assets/1376cb70-58aa-4191-a119-970f2cbffede" /> |
