### PR TITLE
`ToggleButton` active + disabled & active + hover styling

### DIFF
--- a/.changeset/thin-pugs-begin.md
+++ b/.changeset/thin-pugs-begin.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `ToggleButton` disabled + active styling.

--- a/.changeset/thin-pugs-begin.md
+++ b/.changeset/thin-pugs-begin.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-Fixed `ToggleButton` disabled + active styling.
+Improved `ToggleButton` styling by fixing active + disabled state and added active + hover state.

--- a/packages/mui/src/~components/MuiToggleButton.css
+++ b/packages/mui/src/~components/MuiToggleButton.css
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 .MuiToggleButton-root {
-	--✨bg--active: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
-	--✨bg--active-hover: var(--stratakit-color-bg-glow-on-surface-accent-active-hover);
-	--✨bg--active-disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
+	--✨bg--selected: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+	--✨bg--selected-hover: var(--stratakit-color-bg-glow-on-surface-accent-active-hover);
+	--✨bg--selected-disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
 
-	--✨border--active: var(--stratakit-color-border-accent-strong);
-	--✨border--active-disabled: var(--stratakit-color-border-glow-on-surface-disabled);
+	--✨border--selected: var(--stratakit-color-border-accent-strong);
+	--✨border--selected-disabled: var(--stratakit-color-border-glow-on-surface-disabled);
 
 	/* Standalone ToggleButton. */
 	&:where(:not(.MuiToggleButtonGroup-grouped)) {
@@ -22,17 +22,17 @@
 	}
 
 	&:where(.Mui-selected) {
-		--_MuiToggleButton-bg--active: var(--✨bg--active);
-		--_MuiToggleButton-border--active: var(--✨border--active);
+		--_MuiToggleButton-bg--selected: var(--✨bg--selected);
+		--_MuiToggleButton-border--selected: var(--✨border--selected);
 
-		background-color: var(--_MuiToggleButton-bg--active);
-		border-color: var(--_MuiToggleButton-border--active);
+		background-color: var(--_MuiToggleButton-bg--selected);
+		border-color: var(--_MuiToggleButton-border--selected);
 		color: var(--stratakit-color-text-accent-strong);
 		--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
 
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--_MuiToggleButton-bg--active: var(--✨bg--active-hover);
+				--_MuiToggleButton-bg--selected: var(--✨bg--selected-hover);
 			}
 		}
 	}
@@ -40,8 +40,8 @@
 	&:where(.Mui-disabled) {
 		color: var(--stratakit-color-text-neutral-disabled);
 		--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
-		--_MuiToggleButton-bg--active: var(--✨bg--active-disabled);
-		--_MuiToggleButton-border--active: var(--✨border--active-disabled);
+		--_MuiToggleButton-bg--selected: var(--✨bg--selected-disabled);
+		--_MuiToggleButton-border--selected: var(--✨border--selected-disabled);
 	}
 }
 

--- a/packages/mui/src/~components/MuiToggleButton.css
+++ b/packages/mui/src/~components/MuiToggleButton.css
@@ -41,7 +41,7 @@
 		--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
 
 		&:where(.Mui-selected) {
-			background-color: var(--✨bg--selected-disabled);
+			--_MuiToggleButton-bg--active: var(--✨bg--selected-disabled);
 			border-color: var(--✨border--selected-disabled);
 		}
 	}

--- a/packages/mui/src/~components/MuiToggleButton.css
+++ b/packages/mui/src/~components/MuiToggleButton.css
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 .MuiToggleButton-root {
-	--✨bg--selected: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
-	--✨bg--selected-hover: var(--stratakit-color-bg-glow-on-surface-accent-active-hover);
-	--✨bg--selected-disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
+	--✨bg--active: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+	--✨bg--active-hover: var(--stratakit-color-bg-glow-on-surface-accent-active-hover);
+	--✨bg--active-disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
 
-	--✨border--selected: var(--stratakit-color-border-accent-strong);
-	--✨border--selected-disabled: var(--stratakit-color-border-glow-on-surface-disabled);
+	--✨border--active: var(--stratakit-color-border-accent-strong);
+	--✨border--active-disabled: var(--stratakit-color-border-glow-on-surface-disabled);
 
 	/* Standalone ToggleButton. */
 	&:where(:not(.MuiToggleButtonGroup-grouped)) {
@@ -22,8 +22,8 @@
 	}
 
 	&:where(.Mui-selected) {
-		--_MuiToggleButton-bg--active: var(--✨bg--selected);
-		--_MuiToggleButton-border--active: var(--✨border--selected);
+		--_MuiToggleButton-bg--active: var(--✨bg--active);
+		--_MuiToggleButton-border--active: var(--✨border--active);
 
 		background-color: var(--_MuiToggleButton-bg--active);
 		border-color: var(--_MuiToggleButton-border--active);
@@ -32,7 +32,7 @@
 
 		@media (any-hover: hover) {
 			&:where(:hover) {
-				--_MuiToggleButton-bg--active: var(--✨bg--selected-hover);
+				--_MuiToggleButton-bg--active: var(--✨bg--active-hover);
 			}
 		}
 	}
@@ -40,8 +40,8 @@
 	&:where(.Mui-disabled) {
 		color: var(--stratakit-color-text-neutral-disabled);
 		--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
-		--_MuiToggleButton-bg--active: var(--✨bg--selected-disabled);
-		--_MuiToggleButton-border--active: var(--✨border--selected-disabled);
+		--_MuiToggleButton-bg--active: var(--✨bg--active-disabled);
+		--_MuiToggleButton-border--active: var(--✨border--active-disabled);
 	}
 }
 

--- a/packages/mui/src/~components/MuiToggleButton.css
+++ b/packages/mui/src/~components/MuiToggleButton.css
@@ -23,9 +23,10 @@
 
 	&:where(.Mui-selected) {
 		--_MuiToggleButton-bg--active: var(--✨bg--selected);
+		--_MuiToggleButton-border--active: var(--✨border--selected);
 
 		background-color: var(--_MuiToggleButton-bg--active);
-		border-color: var(--✨border--selected);
+		border-color: var(--_MuiToggleButton-border--active);
 		color: var(--stratakit-color-text-accent-strong);
 		--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
 
@@ -39,11 +40,8 @@
 	&:where(.Mui-disabled) {
 		color: var(--stratakit-color-text-neutral-disabled);
 		--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
-
-		&:where(.Mui-selected) {
-			--_MuiToggleButton-bg--active: var(--✨bg--selected-disabled);
-			border-color: var(--✨border--selected-disabled);
-		}
+		--_MuiToggleButton-bg--active: var(--✨bg--selected-disabled);
+		--_MuiToggleButton-border--active: var(--✨border--selected-disabled);
 	}
 }
 

--- a/packages/mui/src/~components/MuiToggleButton.css
+++ b/packages/mui/src/~components/MuiToggleButton.css
@@ -4,6 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 .MuiToggleButton-root {
+	--✨bg--selected: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+	--✨bg--selected-hover: var(--stratakit-color-bg-glow-on-surface-accent-active-hover);
+	--✨bg--selected-disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
+
 	--✨border--selected: var(--stratakit-color-border-accent-strong);
 	--✨border--selected-disabled: var(--stratakit-color-border-glow-on-surface-disabled);
 
@@ -18,10 +22,18 @@
 	}
 
 	&:where(.Mui-selected) {
+		--_MuiToggleButton-bg--active: var(--✨bg--selected);
+
+		background-color: var(--_MuiToggleButton-bg--active);
 		border-color: var(--✨border--selected);
-		background-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 		color: var(--stratakit-color-text-accent-strong);
 		--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
+
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				--_MuiToggleButton-bg--active: var(--✨bg--selected-hover);
+			}
+		}
 	}
 
 	&:where(.Mui-disabled) {
@@ -29,7 +41,7 @@
 		--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
 
 		&:where(.Mui-selected) {
-			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
+			background-color: var(--✨bg--selected-disabled);
 			border-color: var(--✨border--selected-disabled);
 		}
 	}

--- a/packages/mui/src/~components/MuiToggleButton.css
+++ b/packages/mui/src/~components/MuiToggleButton.css
@@ -5,6 +5,7 @@
 
 .MuiToggleButton-root {
 	--✨border--selected: var(--stratakit-color-border-accent-strong);
+	--✨border--selected-disabled: var(--stratakit-color-border-glow-on-surface-disabled);
 
 	/* Standalone ToggleButton. */
 	&:where(:not(.MuiToggleButtonGroup-grouped)) {
@@ -26,6 +27,11 @@
 	&:where(.Mui-disabled) {
 		color: var(--stratakit-color-text-neutral-disabled);
 		--🥝Icon-color: var(--stratakit-color-icon-neutral-disabled);
+
+		&:where(.Mui-selected) {
+			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
+			border-color: var(--✨border--selected-disabled);
+		}
 	}
 }
 

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -177,7 +177,7 @@
 }
 
 .MuiPaginationItem-root {
-	&:where(.Mui-selected) {
+	&:where(.Mui-selected:not(.Mui-disabled)) {
 		background-color: SelectedItem;
 		border-color: SelectedItemText;
 		color: SelectedItemText;

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -274,9 +274,13 @@
 }
 
 .MuiToggleButton-root {
-	&:where(.Mui-selected) {
+	&:where(.Mui-selected:not(.Mui-disabled)) {
 		forced-color-adjust: none; /* removing the backplate */
 		background-color: SelectedItem;
 		color: SelectedItemText;
+	}
+
+	&:where(.Mui-selected.Mui-disabled) {
+		border-width: 2px;
 	}
 }

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -177,7 +177,7 @@
 }
 
 .MuiPaginationItem-root {
-	&:where(.Mui-selected:not(.Mui-disabled)) {
+	&:where(.Mui-selected) {
 		background-color: SelectedItem;
 		border-color: SelectedItemText;
 		color: SelectedItemText;
@@ -274,13 +274,9 @@
 }
 
 .MuiToggleButton-root {
-	&:where(.Mui-selected:not(.Mui-disabled)) {
+	&:where(.Mui-selected) {
 		forced-color-adjust: none; /* removing the backplate */
 		background-color: SelectedItem;
 		color: SelectedItemText;
-	}
-
-	&:where(.Mui-selected.Mui-disabled) {
-		border-width: 2px;
 	}
 }


### PR DESCRIPTION
### Changes

- Visually corrected active + disabled `ToggleButton` styling, similar to #1451.
- Added active + hover `ToggleButton` styling, similar to #1360.

### Testing

- Used #1447 to visually test light, dark, `forced-colors`.

| Theme | Before | After |
| -- | -- | -- |
| Light | <img width="480" height="250" alt="Screenshot 2026-04-28 at 3 17 27 PM" src="https://github.com/user-attachments/assets/d8e1f23f-2f4f-432f-a3af-866eab310a42" /> | <img width="480" height="250" alt="Screenshot 2026-04-28 at 3 16 02 PM" src="https://github.com/user-attachments/assets/8b0eee66-0505-4cde-9033-d3ecfc66797c" /> |
| Dark | <img width="480" height="250" alt="Screenshot 2026-04-28 at 3 17 35 PM" src="https://github.com/user-attachments/assets/cec7400a-85a8-4092-82e1-c9b8c388a8ab" /> | <img width="480" height="250" alt="Screenshot 2026-04-28 at 3 15 52 PM" src="https://github.com/user-attachments/assets/87dde302-7712-4138-a72c-41cb9a627b9f" /> |

<img width="656" height="190" alt="toggle-button-active-hover" src="https://github.com/user-attachments/assets/80b90131-3163-4dc2-9d89-89b5cfcad7f0" />
