### PR TITLE
`MenuItem` active + hover styling

### DIFF
--- a/.changeset/bold-spiders-share.md
+++ b/.changeset/bold-spiders-share.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Improved `MenuItem` styling by adding active + hover state styling.

--- a/packages/mui/src/~components/MuiMenu.css
+++ b/packages/mui/src/~components/MuiMenu.css
@@ -20,6 +20,7 @@
 	--✨color-bg--hover: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
 	--✨color-bg--pressed: var(--stratakit-color-bg-glow-on-surface-neutral-pressed);
 	--✨color-bg--selected: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
+	--✨color-bg--selected-hover: var(--stratakit-color-bg-glow-on-surface-accent-active-hover);
 	--✨color-bg--disabled: transparent;
 	--✨color-border--selected: var(--stratakit-color-border-accent-strong);
 	--✨color-icon--default: var(--stratakit-color-icon-neutral-base);
@@ -93,6 +94,12 @@
 		--_MuiMenuItem-background-color: var(--✨color-bg--selected);
 		--_MuiMenuItem-color: var(--✨color-text--selected);
 		--_MuiMenuItem-root-mask-image: var(--✨svg-checked);
+
+		@media (any-hover: hover) {
+			&:where(:hover) {
+				--_MuiMenuItem-background-color: var(--✨color-bg--selected-hover);
+			}
+		}
 
 		&:where(:not(.Mui-disabled)) {
 			--_MuiMenuItem-border-color: var(--✨color-border--selected);


### PR DESCRIPTION
### Changes

- Added active + hover state styling similar to #1360.

### Testing

- Tested light, dark, `forced-colors`.
- Tested active + hover, and active + disabled.

| Enabled | Disabled |
| -- | -- |
| <img src="https://github.com/user-attachments/assets/3dbb7fae-959a-4b5e-b63d-4b98dc4ca73d" /> | <img src="https://github.com/user-attachments/assets/a18b8c43-fe03-4247-b6ae-5a736d81c25b" /> |