### PR TITLE
migrate to `vite` v8 and related deps

### DIFF
--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -19,7 +19,7 @@
 		"@emotion/styled": "^11.14.1",
 		"@mui/material": "catalog:",
 		"@mui/utils": "catalog:",
-		"@react-router/node": "^7.13.2",
+		"@react-router/node": "^7.14.2",
 		"@stratakit/bricks": "workspace:*",
 		"@stratakit/foundations": "workspace:*",
 		"@stratakit/icons": "workspace:*",
@@ -33,23 +33,24 @@
 		"react": "catalog:",
 		"react-dom": "catalog:",
 		"react-resizable-panels": "^3.0.6",
-		"react-router": "^7.13.2",
+		"react-router": "^7.14.2",
 		"zustand": "^5.0.12"
 	},
 	"devDependencies": {
 		"@axe-core/playwright": "^4.11.1",
 		"@playwright/test": "catalog:",
-		"@react-router/dev": "^7.13.2",
+		"@react-router/dev": "^7.14.2",
+		"@rolldown/plugin-babel": "^0.2.3",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",
+		"@vitejs/plugin-react": "^6.0.1",
+		"babel-plugin-react-compiler": "~1.0.0",
 		"esbuild": "catalog:",
 		"lightningcss": "catalog:",
 		"typescript": "catalog:",
-		"vite": "^7.3.2",
-		"vite-plugin-babel": "^1.6.0",
-		"vite-plugin-devtools-json": "^1.0.0",
-		"vite-tsconfig-paths": "^6.1.1"
+		"vite": "^8.0.10",
+		"vite-plugin-devtools-json": "^1.0.0"
 	},
 	"wireit": {
 		"build": {

--- a/apps/test-app/vite.config.ts
+++ b/apps/test-app/vite.config.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { reactRouter } from "@react-router/dev/vite";
+import babel from "@rolldown/plugin-babel";
+import { reactCompilerPreset } from "@vitejs/plugin-react";
 import * as lightningcss from "lightningcss";
 import {
 	defaultClientConditions,
 	defaultServerConditions,
 	defineConfig,
 } from "vite";
-import babel from "vite-plugin-babel";
 import devtoolsJson from "vite-plugin-devtools-json";
-import tsconfigPaths from "vite-tsconfig-paths";
 import {
 	createVisitor,
 	customAtRules,
@@ -54,14 +54,7 @@ export const reactRouterConfig = {
 export default defineConfig({
 	plugins: [
 		reactRouter(),
-		babel({
-			filter: /\.[jt]sx?$/,
-			babelConfig: {
-				presets: ["@babel/preset-typescript"],
-				plugins: [["babel-plugin-react-compiler", {}]],
-			},
-		}),
-		tsconfigPaths(),
+		babel({ presets: [reactCompilerPreset()] }),
 		bundleCssPlugin(),
 		devtoolsJson(),
 	],
@@ -82,6 +75,7 @@ export default defineConfig({
 	},
 	resolve: {
 		conditions: [customConditions, defaultClientConditions].flat(),
+		tsconfigPaths: true,
 	},
 	ssr: {
 		resolve: {

--- a/internal/minimal-template/package.json
+++ b/internal/minimal-template/package.json
@@ -24,6 +24,6 @@
 		"@vitejs/plugin-react": "^5.1.1",
 		"babel-plugin-react-compiler": "^1.0.0",
 		"typescript": "~6.0.3",
-		"vite": "^7.3.1"
+		"vite": "^8.0.10"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         specifier: "catalog:"
         version: 9.0.0(@types/react@19.2.14)(react@19.2.5)
       "@react-router/node":
-        specifier: ^7.13.2
+        specifier: ^7.14.2
         version: 7.14.2(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       "@stratakit/bricks":
         specifier: workspace:*
@@ -149,7 +149,7 @@ importers:
         specifier: ^3.0.6
         version: 3.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-router:
-        specifier: ^7.13.2
+        specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zustand:
         specifier: ^5.0.12
@@ -162,8 +162,11 @@ importers:
         specifier: "catalog:"
         version: 1.58.2
       "@react-router/dev":
-        specifier: ^7.13.2
-        version: 7.14.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
+        specifier: ^7.14.2
+        version: 7.14.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+      "@rolldown/plugin-babel":
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
       "@types/node":
         specifier: "catalog:"
         version: 22.19.17
@@ -173,6 +176,12 @@ importers:
       "@types/react-dom":
         specifier: "catalog:"
         version: 19.2.3(@types/react@19.2.14)
+      "@vitejs/plugin-react":
+        specifier: ^6.0.1
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+      babel-plugin-react-compiler:
+        specifier: ~1.0.0
+        version: 1.0.0
       esbuild:
         specifier: "catalog:"
         version: 0.27.7
@@ -183,17 +192,11 @@ importers:
         specifier: "catalog:"
         version: 6.0.3
       vite:
-        specifier: ^7.3.2
-        version: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
-      vite-plugin-babel:
-        specifier: ^1.6.0
-        version: 1.6.0(@babel/core@7.29.0)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
       vite-plugin-devtools-json:
         specifier: ^1.0.0
-        version: 1.0.0(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
+        version: 1.0.0(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
 
   apps/website:
     dependencies:
@@ -926,10 +929,28 @@ packages:
       }
     engines: { node: ">=14" }
 
+  "@emnapi/core@1.10.0":
+    resolution:
+      {
+        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
+      }
+
+  "@emnapi/runtime@1.10.0":
+    resolution:
+      {
+        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
+      }
+
   "@emnapi/runtime@1.8.1":
     resolution:
       {
         integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==,
+      }
+
+  "@emnapi/wasi-threads@1.2.1":
+    resolution:
+      {
+        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
 
   "@emotion/babel-plugin@11.13.5":
@@ -1673,6 +1694,15 @@ packages:
       "@types/react":
         optional: true
 
+  "@napi-rs/wasm-runtime@1.1.4":
+    resolution:
+      {
+        integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
+      }
+    peerDependencies:
+      "@emnapi/core": ^1.7.1
+      "@emnapi/runtime": ^1.7.1
+
   "@nodelib/fs.scandir@2.1.5":
     resolution:
       {
@@ -1770,6 +1800,12 @@ packages:
     resolution:
       {
         integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==,
+      }
+
+  "@oxc-project/types@0.127.0":
+    resolution:
+      {
+        integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==,
       }
 
   "@pagefind/darwin-arm64@1.4.0":
@@ -1884,6 +1920,178 @@ packages:
     resolution:
       {
         integrity: sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA==,
+      }
+
+  "@rolldown/binding-android-arm64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@rolldown/binding-darwin-x64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@rolldown/plugin-babel@0.2.3":
+    resolution:
+      {
+        integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==,
+      }
+    engines: { node: ">=22.12.0 || ^24.0.0" }
+    peerDependencies:
+      "@babel/core": ^7.29.0 || ^8.0.0-rc.1
+      "@babel/plugin-transform-runtime": ^7.29.0 || ^8.0.0-rc.1
+      "@babel/runtime": ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      "@babel/plugin-transform-runtime":
+        optional: true
+      "@babel/runtime":
+        optional: true
+      vite:
+        optional: true
+
+  "@rolldown/pluginutils@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==,
+      }
+
+  "@rolldown/pluginutils@1.0.0-rc.7":
+    resolution:
+      {
+        integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==,
       }
 
   "@rollup/pluginutils@5.3.0":
@@ -2222,6 +2430,12 @@ packages:
         integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==,
       }
 
+  "@tybys/wasm-util@0.10.1":
+    resolution:
+      {
+        integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
+      }
+
   "@types/debug@4.1.13":
     resolution:
       {
@@ -2351,6 +2565,22 @@ packages:
       {
         integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
       }
+
+  "@vitejs/plugin-react@6.0.1":
+    resolution:
+      {
+        integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    peerDependencies:
+      "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      "@rolldown/plugin-babel":
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution:
@@ -3169,12 +3399,6 @@ packages:
         integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
       }
     engines: { node: ">= 6" }
-
-  globrex@0.1.2:
-    resolution:
-      {
-        integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==,
-      }
 
   graceful-fs@4.2.11:
     resolution:
@@ -4758,6 +4982,14 @@ packages:
       }
     engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
 
+  rolldown@1.0.0-rc.17:
+    resolution:
+      {
+        integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
   rollup@4.60.0:
     resolution:
       {
@@ -5266,15 +5498,6 @@ packages:
     engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
 
-  vite-plugin-babel@1.6.0:
-    resolution:
-      {
-        integrity: sha512-VtYA4FSmQREA2oaZ7+jfLS/fBk1/xZMUR94YZzB5s6U9WyptbvThUD1HSSv7oNDU28jGuHmdBZ1wTVGNIoChoQ==,
-      }
-    peerDependencies:
-      "@babel/core": ^7.0.0
-      vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-
   vite-plugin-devtools-json@1.0.0:
     resolution:
       {
@@ -5282,14 +5505,6 @@ packages:
       }
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
-
-  vite-tsconfig-paths@6.1.1:
-    resolution:
-      {
-        integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==,
-      }
-    peerDependencies:
-      vite: "*"
 
   vite@7.3.2:
     resolution:
@@ -5318,6 +5533,52 @@ packages:
       less:
         optional: true
       lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.10:
+    resolution:
+      {
+        integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      "@types/node": ^20.19.0 || >=22.12.0
+      "@vitejs/devtools": ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: ">=1.21.0"
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+      "@vitejs/devtools":
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
         optional: true
       sass:
         optional: true
@@ -5828,7 +6089,23 @@ snapshots:
 
   "@ctrl/tinycolor@4.2.0": {}
 
+  "@emnapi/core@1.10.0":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.10.0":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   "@emnapi/runtime@1.8.1":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.1":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6256,6 +6533,13 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.14
 
+  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@tybys/wasm-util": 0.10.1
+    optional: true
+
   "@nodelib/fs.scandir@2.1.5":
     dependencies:
       "@nodelib/fs.stat": 2.0.5
@@ -6321,6 +6605,8 @@ snapshots:
 
   "@oslojs/encoding@1.1.0": {}
 
+  "@oxc-project/types@0.127.0": {}
+
   "@pagefind/darwin-arm64@1.4.0":
     optional: true
 
@@ -6347,7 +6633,7 @@ snapshots:
 
   "@popperjs/core@2.11.8": {}
 
-  "@react-router/dev@7.14.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))":
+  "@react-router/dev@7.14.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/generator": 7.29.1
@@ -6377,7 +6663,7 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.16
       valibot: 1.3.1(typescript@6.0.3)
-      vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
     optionalDependencies:
       typescript: 6.0.3
@@ -6404,6 +6690,68 @@ snapshots:
       typescript: 6.0.3
 
   "@remix-run/node-fetch-server@0.13.0": {}
+
+  "@rolldown/binding-android-arm64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-darwin-x64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.17":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))":
+    dependencies:
+      "@babel/core": 7.29.0
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.17
+    optionalDependencies:
+      "@babel/runtime": 7.29.2
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
+
+  "@rolldown/pluginutils@1.0.0-rc.17": {}
+
+  "@rolldown/pluginutils@1.0.0-rc.7": {}
 
   "@rollup/pluginutils@5.3.0(rollup@4.60.0)":
     dependencies:
@@ -6572,6 +6920,11 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.16
 
+  "@tybys/wasm-util@0.10.1":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   "@types/debug@4.1.13":
     dependencies:
       "@types/ms": 2.1.0
@@ -6637,6 +6990,14 @@ snapshots:
       "@types/node": 24.12.0
 
   "@ungap/structured-clone@1.3.0": {}
+
+  "@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))":
+    dependencies:
+      "@rolldown/pluginutils": 1.0.0-rc.7
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
+    optionalDependencies:
+      "@rolldown/plugin-babel": 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+      babel-plugin-react-compiler: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -7155,8 +7516,6 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-
-  globrex@0.1.2: {}
 
   graceful-fs@4.2.11: {}
 
@@ -8458,6 +8817,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      "@oxc-project/types": 0.127.0
+      "@rolldown/pluginutils": 1.0.0-rc.17
+    optionalDependencies:
+      "@rolldown/binding-android-arm64": 1.0.0-rc.17
+      "@rolldown/binding-darwin-arm64": 1.0.0-rc.17
+      "@rolldown/binding-darwin-x64": 1.0.0-rc.17
+      "@rolldown/binding-freebsd-x64": 1.0.0-rc.17
+      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.17
+      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.17
+      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.17
+      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.17
+      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.17
+      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.17
+      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.17
+      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.17
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.17
+      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.17
+      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.17
+
   rollup@4.60.0:
     dependencies:
       "@types/estree": 1.0.8
@@ -8789,25 +9169,10 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-babel@1.6.0(@babel/core@7.29.0)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)):
-    dependencies:
-      "@babel/core": 7.29.0
-      vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
-
-  vite-plugin-devtools-json@1.0.0(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)):
+  vite-plugin-devtools-json@1.0.0(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       uuid: 11.1.0
-      vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
-
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
 
   vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0):
     dependencies:
@@ -8821,6 +9186,19 @@ snapshots:
       "@types/node": 22.19.17
       fsevents: 2.3.3
       lightningcss: 1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce)
+      tsx: 4.21.0
+
+  vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce)
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      "@types/node": 22.19.17
+      esbuild: 0.27.7
+      fsevents: 2.3.3
       tsx: 4.21.0
 
   vitefu@1.1.2(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)):


### PR DESCRIPTION
### Changes

Migrations:
- `vite` v7 → v8
- ~~`typescript` 5.9 → 6.0~~ (moved into #1458)
- ~~`astro` v5 → v6~~ (moved into #1459)
- `react-router` 7.13 → 7.14

Notes:
- `vite-tsconfig-paths` is now natively supported in Vite using `resolve.tsconfigPaths`.
- `vite-plugin-babel` replaced with first-party `@rolldown/plugin-babel`
  - also using `reactCompilerPreset` from `@vitejs/plugin-react`

### Testing

- [x] Build
- [x] Test
- [x] Dev
- [x] Docs
- [ ] Noticed a lightningcss minify warning