### PR TITLE
migrate to `typescript` 6

### DIFF
--- a/apps/test-app/tsconfig.json
+++ b/apps/test-app/tsconfig.json
@@ -16,8 +16,6 @@
 			"./app/types.d.ts",
 			"@stratakit/mui/types.d.ts"
 		],
-
-		"baseUrl": ".",
 		"paths": {
 			"~/*": ["./app/*"]
 		},

--- a/internal/minimal-template/package.json
+++ b/internal/minimal-template/package.json
@@ -23,7 +23,7 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^5.1.1",
 		"babel-plugin-react-compiler": "^1.0.0",
-		"typescript": "~5.9.3",
+		"typescript": "~6.0.3",
 		"vite": "^7.3.1"
 	}
 }

--- a/internal/minimal-template/tsconfig.json
+++ b/internal/minimal-template/tsconfig.json
@@ -17,7 +17,6 @@
 		"jsx": "react-jsx",
 
 		/* Linting */
-		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"erasableSyntaxOnly": true,

--- a/internal/tsconfig.json
+++ b/internal/tsconfig.json
@@ -6,7 +6,6 @@
 		"allowJs": true,
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,
-		"esModuleInterop": true,
 		"moduleDetection": "force",
 		"isolatedModules": true,
 		"verbatimModuleSyntax": true,
@@ -15,7 +14,6 @@
 		"preserveWatchOutput": true,
 
 		/* Strictness/Linting */
-		"strict": true,
 		"strictNullChecks": true,
 		"noImplicitOverride": true,
 		"noUnusedLocals": true,

--- a/internal/tsconfig.json
+++ b/internal/tsconfig.json
@@ -24,7 +24,7 @@
 		"forceConsistentCasingInFileNames": true,
 
 		/* Output */
-		"lib": ["DOM", "DOM.Iterable", "ES2022"],
+		"lib": ["DOM", "ES2022"],
 		"target": "es2022",
 		"module": "preserve",
 		"jsx": "react-jsx",

--- a/packages/bricks/tsconfig.json
+++ b/packages/bricks/tsconfig.json
@@ -2,8 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "internal/tsconfig.library.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"baseUrl": "."
+		"rootDir": "src"
 	},
 	"include": ["src", "types.d.ts"],
 	"exclude": ["node_modules", "dist/**/*"]

--- a/packages/foundations/tsconfig.json
+++ b/packages/foundations/tsconfig.json
@@ -2,8 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "internal/tsconfig.library.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"baseUrl": "."
+		"rootDir": "src"
 	},
 	"include": ["src", "types.d.ts"],
 	"exclude": ["node_modules", "dist/**/*"]

--- a/packages/mui/tsconfig.json
+++ b/packages/mui/tsconfig.json
@@ -2,8 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "internal/tsconfig.library.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"baseUrl": "."
+		"rootDir": "src"
 	},
 	"include": ["src", "types.d.ts"],
 	"exclude": ["node_modules", "dist/**/*"]

--- a/packages/structures/tsconfig.json
+++ b/packages/structures/tsconfig.json
@@ -2,8 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "internal/tsconfig.library.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"baseUrl": "."
+		"rootDir": "src"
 	},
 	"include": ["src", "types.d.ts"],
 	"exclude": ["node_modules", "dist/**/*"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^19.2.5
       version: 19.2.5
     typescript:
-      specifier: ~5.9.3
-      version: 5.9.3
+      specifier: ~6.0.3
+      version: 6.0.3
 
 overrides:
   brace-expansion@<5.0.0: ^5.0.5
@@ -84,7 +84,7 @@ importers:
         version: 4.21.0
       typescript:
         specifier: "catalog:"
-        version: 5.9.3
+        version: 6.0.3
       wireit:
         specifier: ^0.14.12
         version: 0.14.12(patch_hash=442051a61659ca584845f39c86d1cc7c09810a44100a1aa6c653a03859713f36)
@@ -108,7 +108,7 @@ importers:
         version: 9.0.0(@types/react@19.2.14)(react@19.2.5)
       "@react-router/node":
         specifier: ^7.13.2
-        version: 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+        version: 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       "@stratakit/bricks":
         specifier: workspace:*
         version: link:../../packages/bricks
@@ -163,7 +163,7 @@ importers:
         version: 1.58.2
       "@react-router/dev":
         specifier: ^7.13.2
-        version: 7.13.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
+        version: 7.13.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
       "@types/node":
         specifier: "catalog:"
         version: 22.19.17
@@ -181,7 +181,7 @@ importers:
         version: 1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce)
       typescript:
         specifier: "catalog:"
-        version: 5.9.3
+        version: 6.0.3
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
@@ -193,13 +193,13 @@ importers:
         version: 1.0.0(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
+        version: 6.1.1(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
 
   apps/website:
     dependencies:
       "@astrojs/starlight":
         specifier: ^0.37.7
-        version: 0.37.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3))
+        version: 0.37.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
       "@mui/material":
         specifier: "catalog:"
         version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -220,7 +220,7 @@ importers:
         version: link:../../packages/structures
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3)
+        version: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
       examples:
         specifier: workspace:*
         version: link:../../examples
@@ -358,7 +358,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       typescript:
         specifier: "catalog:"
-        version: 5.9.3
+        version: 6.0.3
 
   packages/foundations:
     dependencies:
@@ -395,7 +395,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       typescript:
         specifier: "catalog:"
-        version: 5.9.3
+        version: 6.0.3
 
   packages/icons: {}
 
@@ -446,7 +446,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       typescript:
         specifier: "catalog:"
-        version: 5.9.3
+        version: 6.0.3
 
   packages/structures:
     dependencies:
@@ -489,7 +489,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       typescript:
         specifier: "catalog:"
-        version: 5.9.3
+        version: 6.0.3
 
 packages:
   "@actions/github@9.1.0":
@@ -5283,10 +5283,10 @@ packages:
       }
     engines: { node: ">=16" }
 
-  typescript@5.9.3:
+  typescript@6.0.3:
     resolution:
       {
-        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+        integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==,
       }
     engines: { node: ">=14.17" }
     hasBin: true
@@ -5874,12 +5874,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3))":
+  "@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))":
     dependencies:
       "@astrojs/markdown-remark": 6.3.11
       "@mdx-js/mdx": 3.1.1
       acorn: 8.16.0
-      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3)
+      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5903,17 +5903,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  "@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3))":
+  "@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))":
     dependencies:
       "@astrojs/markdown-remark": 6.3.11
-      "@astrojs/mdx": 4.3.14(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3))
+      "@astrojs/mdx": 4.3.14(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
       "@astrojs/sitemap": 3.7.2
       "@pagefind/default-ui": 1.4.0
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3)
-      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3))
+      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
+      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -6780,7 +6780,7 @@ snapshots:
 
   "@popperjs/core@2.11.8": {}
 
-  "@react-router/dev@7.13.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))":
+  "@react-router/dev@7.13.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/generator": 7.29.1
@@ -6789,7 +6789,7 @@ snapshots:
       "@babel/preset-typescript": 7.28.5(@babel/core@7.29.0)
       "@babel/traverse": 7.29.0
       "@babel/types": 7.29.0
-      "@react-router/node": 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+      "@react-router/node": 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       "@remix-run/node-fetch-server": 0.13.0
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.12
@@ -6809,11 +6809,11 @@ snapshots:
       react-router: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       semver: 7.7.4
       tinyglobby: 0.2.15
-      valibot: 1.3.1(typescript@5.9.3)
+      valibot: 1.3.1(typescript@6.0.3)
       vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - "@types/node"
       - babel-plugin-macros
@@ -6829,12 +6829,12 @@ snapshots:
       - tsx
       - yaml
 
-  "@react-router/node@7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)":
+  "@react-router/node@7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)":
     dependencies:
       "@mjackson/node-fetch-server": 0.2.0
       react-router: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   "@remix-run/node-fetch-server@0.13.0": {}
 
@@ -7064,12 +7064,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3)):
+  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)):
     dependencies:
-      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3)
+      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
       rehype-expressive-code: 0.41.7
 
-  astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@5.9.3):
+  astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3):
     dependencies:
       "@astrojs/compiler": 2.13.1
       "@astrojs/internal-helpers": 0.7.6
@@ -7120,7 +7120,7 @@ snapshots:
       svgo: 4.0.1
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -7133,7 +7133,7 @@ snapshots:
       yocto-spinner: 0.2.3
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@6.0.3)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -9104,9 +9104,9 @@ snapshots:
       "@ts-morph/common": 0.28.1
       code-block-writer: 13.0.3
 
-  tsconfck@3.1.6(typescript@5.9.3):
+  tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tslib@2.8.1:
     optional: true
@@ -9122,7 +9122,7 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 
@@ -9225,9 +9225,9 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  valibot@1.3.1(typescript@5.9.3):
+  valibot@1.3.1(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   vfile-location@5.0.3:
     dependencies:
@@ -9275,11 +9275,11 @@ snapshots:
       uuid: 11.1.0
       vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)):
+  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@6.0.3)
       vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
@@ -9366,9 +9366,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
+  zod-to-ts@1.2.0(typescript@6.0.3)(zod@3.25.76):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
       zod: 3.25.76
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   lightningcss: ^1.32.0
   react: ^19.2.5
   react-dom: ^19.2.5
-  typescript: ~5.9.3
+  typescript: ~6.0.3
 
 minimumReleaseAge: 1440
 


### PR DESCRIPTION
### Changes

_Extracted out of #1457_

Migrates the monorepo to [TypeScript 6.0](http://typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html) (up from 5.9).
- Within the monorepo packages, all instances uses the pnpm catalog version.
- The minimal template is not part of the pnpm workspace and sets its own version.

`tsconfig` changes:
- Removed `baseUrl`, which is now [deprecated](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#deprecated---baseurl). The `paths` are already prefixed with `./`, so no other change is necessary.
- Removed `dom.iterable`, which is [now part of the `dom` lib](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#the-dom-lib-now-contains-domiterable-and-domasynciterable).
- Removed redundant `strict: true`. (see [comment](https://github.com/iTwin/stratakit/pull/1458#discussion_r3180714357))

Notes on TS 6.0 breaking changes:
- `rootDir` is already set to `"src"` (in all `packages/`).
- `types` is already explicitly defined (in all `apps/` and `examples`).

### Testing

- [x] Build and typecheck passes.
- [x] Type declarations are generated correctly.

Note: There are some peer dependency warnings during installation, but it works fine.