### PR TITLE
migrate to `astro` 6

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -53,14 +53,14 @@
 		}
 	},
 	"dependencies": {
-		"@astrojs/starlight": "^0.37.7",
+		"@astrojs/starlight": "^0.38.4",
 		"@mui/material": "catalog:",
 		"@stratakit/bricks": "workspace:*",
 		"@stratakit/foundations": "workspace:*",
 		"@stratakit/icons": "workspace:*",
 		"@stratakit/mui": "workspace:*",
 		"@stratakit/structures": "workspace:*",
-		"astro": "^5.18.1",
+		"astro": "^6.2.1",
 		"examples": "workspace:*",
 		"react": "catalog:",
 		"react-dom": "catalog:",
@@ -77,6 +77,7 @@
 		"github-slugger": "^2.0.0",
 		"remark-directive": "^4.0.0",
 		"ts-morph": "^27.0.2",
+		"typescript": "catalog:",
 		"unist-util-visit": "^5.1.0",
 		"wireit": "^0.14.12",
 		"xml2js": "^0.6.2"

--- a/apps/website/src/content.config.ts
+++ b/apps/website/src/content.config.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defineCollection, reference, z } from "astro:content";
+import { defineCollection, reference } from "astro:content";
 import * as fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import * as path from "node:path";
@@ -11,6 +11,7 @@ import * as path from "node:path";
 import { docsLoader } from "@astrojs/starlight/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
 import { file } from "astro/loaders";
+import { z } from "astro/zod";
 import { slug as generateSlug } from "github-slugger";
 
 import type { DataStore, Loader } from "astro/loaders";
@@ -67,7 +68,7 @@ export const collections = {
 };
 
 /** Content Loader that loads package entries from `api.json`. */
-function packagesLoader(): Loader {
+function packagesLoader() {
 	return file("./api.json", {
 		parser: (content) => {
 			const packages = JSON.parse(content) as Api;
@@ -121,7 +122,7 @@ function packagesLoader(): Loader {
 				}),
 			}));
 		},
-	});
+	}) satisfies Loader;
 }
 
 function packagesSchema() {
@@ -174,7 +175,7 @@ function packagesSchema() {
 }
 
 /** Content Loader that extracts JSDoc entries from `api.json`. */
-function jsdocLoader(): Loader {
+function jsdocLoader() {
 	return {
 		name: "jsdoc-loader",
 		load: async ({ store, watcher, renderMarkdown }) => {
@@ -283,23 +284,25 @@ function jsdocLoader(): Loader {
 			watcher?.on("change", handleDevelopmentChange);
 			watcher?.on("unlink", handleDevelopmentChange);
 		},
-	};
+	} satisfies Loader;
 }
 
 /** Content Loader that reads all `.tsx` and `.jsx` files from the `examples` package subdirectories. */
-function examplesLoader(): Loader {
+function examplesLoader() {
 	const populateExamples = async (store: DataStore) => {
 		store.clear();
 
 		const examplesPath = path.dirname(require.resolve("examples/package.json"));
 		const examplesDir = await fs.readdir(examplesPath);
-		const packages = examplesDir.filter((entry) => {
-			const entryPath = path.join(examplesPath, entry);
-			return fs
-				.stat(entryPath)
-				.then((stat) => stat.isDirectory()) // only include directories
-				.catch(() => false);
-		});
+		const packages = (
+			await Array.fromAsync(examplesDir, (entry) => {
+				const entryPath = path.join(examplesPath, entry);
+				return fs
+					.stat(entryPath)
+					.then((stat) => (stat.isDirectory() ? entry : null)) // only include directories
+					.catch(() => null);
+			})
+		).filter((value): value is string => value !== null);
 
 		for (const packageName of packages) {
 			const packagePath = path.join(examplesPath, packageName);
@@ -344,7 +347,7 @@ function examplesLoader(): Loader {
 			watcher?.on("change", handleDevelopmentChange);
 			watcher?.on("unlink", handleDevelopmentChange);
 		},
-	};
+	} satisfies Loader;
 }
 
 function getComponentId({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ importers:
         version: 9.0.0(@types/react@19.2.14)(react@19.2.5)
       "@react-router/node":
         specifier: ^7.13.2
-        version: 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
+        version: 7.14.2(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       "@stratakit/bricks":
         specifier: workspace:*
         version: link:../../packages/bricks
@@ -150,7 +150,7 @@ importers:
         version: 3.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-router:
         specifier: ^7.13.2
-        version: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
@@ -163,7 +163,7 @@ importers:
         version: 1.58.2
       "@react-router/dev":
         specifier: ^7.13.2
-        version: 7.13.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
+        version: 7.14.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
       "@types/node":
         specifier: "catalog:"
         version: 22.19.17
@@ -198,8 +198,8 @@ importers:
   apps/website:
     dependencies:
       "@astrojs/starlight":
-        specifier: ^0.37.7
-        version: 0.37.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
+        specifier: ^0.38.4
+        version: 0.38.4(astro@6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
       "@mui/material":
         specifier: "catalog:"
         version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -219,8 +219,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/structures
       astro:
-        specifier: ^5.18.1
-        version: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
+        specifier: ^6.2.1
+        version: 6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
       examples:
         specifier: workspace:*
         version: link:../../examples
@@ -264,6 +264,9 @@ importers:
       ts-morph:
         specifier: ^27.0.2
         version: 27.0.2
+      typescript:
+        specifier: "catalog:"
+        version: 6.0.3
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -528,39 +531,39 @@ packages:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  "@astrojs/compiler@2.13.1":
+  "@astrojs/compiler@4.0.0":
     resolution:
       {
-        integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==,
+        integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==,
       }
 
-  "@astrojs/internal-helpers@0.7.6":
+  "@astrojs/internal-helpers@0.9.0":
     resolution:
       {
-        integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==,
+        integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==,
       }
 
-  "@astrojs/markdown-remark@6.3.11":
+  "@astrojs/markdown-remark@7.1.1":
     resolution:
       {
-        integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==,
+        integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==,
       }
 
-  "@astrojs/mdx@4.3.14":
+  "@astrojs/mdx@5.0.4":
     resolution:
       {
-        integrity: sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA==,
+        integrity: sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
     peerDependencies:
-      astro: ^5.0.0
+      astro: ^6.0.0
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.1":
     resolution:
       {
-        integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==,
+        integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
 
   "@astrojs/sitemap@3.7.2":
     resolution:
@@ -568,18 +571,18 @@ packages:
         integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==,
       }
 
-  "@astrojs/starlight@0.37.7":
+  "@astrojs/starlight@0.38.4":
     resolution:
       {
-        integrity: sha512-KyBnou8aKIlPJUSNx6a1SN7XyH22oj/VAvTGC+Edld4Bnei1A//pmCRTBvSrSeoGrdUjK0ErFUfaEhhO1bPfDg==,
+        integrity: sha512-TGFIr2aVC+gcZCPQzJOO4ZnA/yL3jRnsUDcKlVdEhxhxaOQnWr9lZ9MRScg9zU6uh3HVeZAmmjkLCdTlHdcaZA==,
       }
     peerDependencies:
-      astro: ^5.5.0
+      astro: ^6.0.0
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.1":
     resolution:
       {
-        integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==,
+        integrity: sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==,
       }
     engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
@@ -902,6 +905,20 @@ packages:
       }
     engines: { node: ">=18" }
 
+  "@clack/core@1.3.0":
+    resolution:
+      {
+        integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==,
+      }
+    engines: { node: ">= 20.12.0" }
+
+  "@clack/prompts@1.3.0":
+    resolution:
+      {
+        integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==,
+      }
+    engines: { node: ">= 20.12.0" }
+
   "@ctrl/tinycolor@4.2.0":
     resolution:
       {
@@ -1008,15 +1025,6 @@ packages:
         integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==,
       }
 
-  "@esbuild/aix-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [aix]
-
   "@esbuild/aix-ppc64@0.27.7":
     resolution:
       {
@@ -1026,15 +1034,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [android]
-
   "@esbuild/android-arm64@0.27.7":
     resolution:
       {
@@ -1042,15 +1041,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
     os: [android]
 
   "@esbuild/android-arm@0.27.7":
@@ -1062,15 +1052,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [android]
-
   "@esbuild/android-x64@0.27.7":
     resolution:
       {
@@ -1080,15 +1061,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [darwin]
-
   "@esbuild/darwin-arm64@0.27.7":
     resolution:
       {
@@ -1096,15 +1068,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [darwin]
 
   "@esbuild/darwin-x64@0.27.7":
@@ -1116,15 +1079,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [freebsd]
-
   "@esbuild/freebsd-arm64@0.27.7":
     resolution:
       {
@@ -1132,15 +1086,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [freebsd]
 
   "@esbuild/freebsd-x64@0.27.7":
@@ -1152,15 +1097,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [linux]
-
   "@esbuild/linux-arm64@0.27.7":
     resolution:
       {
@@ -1168,15 +1104,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
     os: [linux]
 
   "@esbuild/linux-arm@0.27.7":
@@ -1188,15 +1115,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [linux]
-
   "@esbuild/linux-ia32@0.27.7":
     resolution:
       {
@@ -1204,15 +1122,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
-      }
-    engines: { node: ">=18" }
-    cpu: [loong64]
     os: [linux]
 
   "@esbuild/linux-loong64@0.27.7":
@@ -1224,15 +1133,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.25.12":
-    resolution:
-      {
-        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [mips64el]
-    os: [linux]
-
   "@esbuild/linux-mips64el@0.27.7":
     resolution:
       {
@@ -1240,15 +1140,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
     os: [linux]
 
   "@esbuild/linux-ppc64@0.27.7":
@@ -1260,15 +1151,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [riscv64]
-    os: [linux]
-
   "@esbuild/linux-riscv64@0.27.7":
     resolution:
       {
@@ -1276,15 +1158,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
-    os: [linux]
-
-  "@esbuild/linux-s390x@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [s390x]
     os: [linux]
 
   "@esbuild/linux-s390x@0.27.7":
@@ -1296,15 +1169,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [linux]
-
   "@esbuild/linux-x64@0.27.7":
     resolution:
       {
@@ -1314,15 +1178,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [netbsd]
-
   "@esbuild/netbsd-arm64@0.27.7":
     resolution:
       {
@@ -1330,15 +1185,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [netbsd]
-
-  "@esbuild/netbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [netbsd]
 
   "@esbuild/netbsd-x64@0.27.7":
@@ -1350,15 +1196,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openbsd]
-
   "@esbuild/openbsd-arm64@0.27.7":
     resolution:
       {
@@ -1366,15 +1203,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [openbsd]
 
   "@esbuild/openbsd-x64@0.27.7":
@@ -1386,15 +1214,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openharmony]
-
   "@esbuild/openharmony-arm64@0.27.7":
     resolution:
       {
@@ -1403,15 +1222,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
-
-  "@esbuild/sunos-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [sunos]
 
   "@esbuild/sunos-x64@0.27.7":
     resolution:
@@ -1422,15 +1232,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [win32]
-
   "@esbuild/win32-arm64@0.27.7":
     resolution:
       {
@@ -1440,15 +1241,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [win32]
-
   "@esbuild/win32-ia32@0.27.7":
     resolution:
       {
@@ -1456,15 +1248,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [win32]
 
   "@esbuild/win32-x64@0.27.7":
@@ -2057,20 +1840,20 @@ packages:
         integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==,
       }
 
-  "@react-router/dev@7.13.2":
+  "@react-router/dev@7.14.2":
     resolution:
       {
-        integrity: sha512-8Lgf+WCEIPDhp22YB3fyoiWnNyM39sjkfWnSxAwy+Sg83OHxnQFQg0OK1oPM9lm1n/hxJe4lLYOPNwDSyeGiog==,
+        integrity: sha512-lU88Ls4iC78RdPOKkER54+hlsHzzS8WSZrf2/cGQumbIN2A5WvO0LDyv72cdJmLWujgZ9rpNoGzmqWINssShGQ==,
       }
     engines: { node: ">=20.0.0" }
     hasBin: true
     peerDependencies:
-      "@react-router/serve": ^7.13.2
-      "@vitejs/plugin-rsc": ~0.5.7
-      react-router: ^7.13.2
+      "@react-router/serve": ^7.14.2
+      "@vitejs/plugin-rsc": ~0.5.21
+      react-router: ^7.14.2
       react-server-dom-webpack: ^19.2.3
-      typescript: ^5.1.0
-      vite: ^5.1.0 || ^6.0.0 || ^7.0.0
+      typescript: ^5.1.0 || ^6.0.0
+      vite: ^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       wrangler: ^3.28.2 || ^4.0.0
     peerDependenciesMeta:
       "@react-router/serve":
@@ -2084,15 +1867,15 @@ packages:
       wrangler:
         optional: true
 
-  "@react-router/node@7.13.2":
+  "@react-router/node@7.14.2":
     resolution:
       {
-        integrity: sha512-1q0v1gclPga2mNQ7Q+MLuLdEPRpDefAmz25jOlrEz+jSyYkaFt9qbSdkTUPw/QIg/DDnnT3QV8lhgr6r5iIAOA==,
+        integrity: sha512-8zxVfgKOXjk0k8YxSBDTFyNAuVdr+og1wFbQpmJJOxo7ObxfI81EbHenyyxGvFiw77rNFLS9Dqgnv5xZgHZfCw==,
       }
     engines: { node: ">=20.0.0" }
     peerDependencies:
-      react-router: 7.13.2
-      typescript: ^5.1.0
+      react-router: 7.14.2
+      typescript: ^5.1.0 || ^6.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2334,11 +2117,25 @@ packages:
         integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
       }
 
+  "@shikijs/core@4.0.2":
+    resolution:
+      {
+        integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==,
+      }
+    engines: { node: ">=20" }
+
   "@shikijs/engine-javascript@3.23.0":
     resolution:
       {
         integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
       }
+
+  "@shikijs/engine-javascript@4.0.2":
+    resolution:
+      {
+        integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/engine-oniguruma@3.23.0":
     resolution:
@@ -2346,11 +2143,32 @@ packages:
         integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
       }
 
+  "@shikijs/engine-oniguruma@4.0.2":
+    resolution:
+      {
+        integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==,
+      }
+    engines: { node: ">=20" }
+
   "@shikijs/langs@3.23.0":
     resolution:
       {
         integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
       }
+
+  "@shikijs/langs@4.0.2":
+    resolution:
+      {
+        integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==,
+      }
+    engines: { node: ">=20" }
+
+  "@shikijs/primitive@4.0.2":
+    resolution:
+      {
+        integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/themes@3.23.0":
     resolution:
@@ -2358,11 +2176,25 @@ packages:
         integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
       }
 
+  "@shikijs/themes@4.0.2":
+    resolution:
+      {
+        integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==,
+      }
+    engines: { node: ">=20" }
+
   "@shikijs/types@3.23.0":
     resolution:
       {
         integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
       }
+
+  "@shikijs/types@4.0.2":
+    resolution:
+      {
+        integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/vscode-textmate@10.0.2":
     resolution:
@@ -2536,33 +2368,6 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
-  ansi-align@3.0.1:
-    resolution:
-      {
-        integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
-      }
-
-  ansi-regex@5.0.1:
-    resolution:
-      {
-        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
-      }
-    engines: { node: ">=8" }
-
-  ansi-regex@6.2.2:
-    resolution:
-      {
-        integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
-      }
-    engines: { node: ">=12" }
-
-  ansi-styles@6.2.3:
-    resolution:
-      {
-        integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
-      }
-    engines: { node: ">=12" }
-
   anymatch@3.1.3:
     resolution:
       {
@@ -2610,12 +2415,12 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@5.18.1:
+  astro@6.2.1:
     resolution:
       {
-        integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==,
+        integrity: sha512-3g1sYNly+QAkuO5ErNEQBYvsxorNDSCUNIeStBs+kcXGchvKQl1Q9EuDNOvSg010XLlHJFLVFZs9LV18Jjp4Hg==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: ">=9.6.5", pnpm: ">=7.1.0" }
+    engines: { node: ">=22.12.0", npm: ">=9.6.5", pnpm: ">=7.1.0" }
     hasBin: true
 
   axe-core@4.11.2:
@@ -2664,12 +2469,6 @@ packages:
       }
     engines: { node: 18 || 20 || >=22 }
 
-  base-64@1.0.0:
-    resolution:
-      {
-        integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==,
-      }
-
   baseline-browser-mapping@2.10.0:
     resolution:
       {
@@ -2709,13 +2508,6 @@ packages:
         integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
       }
 
-  boxen@8.0.1:
-    resolution:
-      {
-        integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==,
-      }
-    engines: { node: ">=18" }
-
   brace-expansion@5.0.5:
     resolution:
       {
@@ -2752,13 +2544,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  camelcase@8.0.0:
-    resolution:
-      {
-        integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==,
-      }
-    engines: { node: ">=16" }
-
   caniuse-lite@1.0.30001774:
     resolution:
       {
@@ -2770,13 +2555,6 @@ packages:
       {
         integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
       }
-
-  chalk@5.6.2:
-    resolution:
-      {
-        integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
-      }
-    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
 
   character-entities-html4@2.1.0:
     resolution:
@@ -2836,13 +2614,6 @@ packages:
         integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==,
       }
 
-  cli-boxes@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
-      }
-    engines: { node: ">=10" }
-
   clsx@2.1.1:
     resolution:
       {
@@ -2881,11 +2652,12 @@ packages:
       }
     engines: { node: ">=16" }
 
-  common-ancestor-path@1.0.1:
+  common-ancestor-path@2.0.0:
     resolution:
       {
-        integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
+        integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==,
       }
+    engines: { node: ">= 18" }
 
   confbox@0.2.4:
     resolution:
@@ -3040,13 +2812,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  deterministic-object-hash@2.0.2:
-    resolution:
-      {
-        integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==,
-      }
-    engines: { node: ">=18" }
-
   devalue@5.6.4:
     resolution:
       {
@@ -3123,18 +2888,6 @@ packages:
         integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==,
       }
 
-  emoji-regex@10.6.0:
-    resolution:
-      {
-        integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
-      }
-
-  emoji-regex@8.0.0:
-    resolution:
-      {
-        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
-      }
-
   entities@4.5.0:
     resolution:
       {
@@ -3161,6 +2914,12 @@ packages:
         integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
       }
 
+  es-module-lexer@2.1.0:
+    resolution:
+      {
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
+      }
+
   esast-util-from-estree@2.0.0:
     resolution:
       {
@@ -3172,14 +2931,6 @@ packages:
       {
         integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
       }
-
-  esbuild@0.25.12:
-    resolution:
-      {
-        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-      }
-    engines: { node: ">=18" }
-    hasBin: true
 
   esbuild@0.27.7:
     resolution:
@@ -3302,6 +3053,24 @@ packages:
       }
     engines: { node: ">=8.6.0" }
 
+  fast-string-truncated-width@3.0.3:
+    resolution:
+      {
+        integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==,
+      }
+
+  fast-string-width@3.0.2:
+    resolution:
+      {
+        integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==,
+      }
+
+  fast-wrap-ansi@0.2.0:
+    resolution:
+      {
+        integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==,
+      }
+
   fastq@1.20.1:
     resolution:
       {
@@ -3381,13 +3150,6 @@ packages:
         integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
       }
     engines: { node: ">=6.9.0" }
-
-  get-east-asian-width@1.5.0:
-    resolution:
-      {
-        integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==,
-      }
-    engines: { node: ">=18" }
 
   get-tsconfig@4.13.1:
     resolution:
@@ -3602,12 +3364,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  import-meta-resolve@4.2.0:
-    resolution:
-      {
-        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
-      }
-
   inline-style-parser@0.2.7:
     resolution:
       {
@@ -3666,19 +3422,20 @@ packages:
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     hasBin: true
 
+  is-docker@4.0.0:
+    resolution:
+      {
+        integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==,
+      }
+    engines: { node: ">=20" }
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution:
       {
         integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
       }
     engines: { node: ">=0.10.0" }
-
-  is-fullwidth-code-point@3.0.0:
-    resolution:
-      {
-        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
-      }
-    engines: { node: ">=8" }
 
   is-glob@4.0.3:
     resolution:
@@ -3769,13 +3526,6 @@ packages:
       {
         integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==,
       }
-
-  kleur@3.0.3:
-    resolution:
-      {
-        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
-      }
-    engines: { node: ">=6" }
 
   klona@2.0.6:
     resolution:
@@ -4470,6 +4220,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  obug@2.1.1:
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
+
   ofetch@1.5.1:
     resolution:
       {
@@ -4494,12 +4250,12 @@ packages:
         integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==,
       }
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     resolution:
       {
-        integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==,
+        integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
   p-map@7.0.4:
     resolution:
@@ -4508,19 +4264,19 @@ packages:
       }
     engines: { node: ">=18" }
 
-  p-queue@8.1.1:
+  p-queue@9.2.0:
     resolution:
       {
-        integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==,
+        integrity: sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
-  p-timeout@6.1.4:
+  p-timeout@7.0.1:
     resolution:
       {
-        integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==,
+        integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==,
       }
-    engines: { node: ">=14.16" }
+    engines: { node: ">=20" }
 
   package-manager-detector@1.6.0:
     resolution:
@@ -4662,10 +4418,10 @@ packages:
       }
     engines: { node: ">=4" }
 
-  postcss@8.5.8:
+  postcss@8.5.12:
     resolution:
       {
-        integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
+        integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -4683,13 +4439,6 @@ packages:
         integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==,
       }
     engines: { node: ">=6" }
-
-  prompts@2.4.2:
-    resolution:
-      {
-        integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
-      }
-    engines: { node: ">= 6" }
 
   prop-types@15.8.1:
     resolution:
@@ -4765,10 +4514,10 @@ packages:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
-  react-router@7.13.2:
+  react-router@7.14.2:
     resolution:
       {
-        integrity: sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==,
+        integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==,
       }
     engines: { node: ">=20.0.0" }
     peerDependencies:
@@ -5070,6 +4819,13 @@ packages:
         integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
       }
 
+  shiki@4.0.2:
+    resolution:
+      {
+        integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==,
+      }
+    engines: { node: ">=20" }
+
   signal-exit@3.0.7:
     resolution:
       {
@@ -5130,39 +4886,11 @@ packages:
         integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==,
       }
 
-  string-width@4.2.3:
-    resolution:
-      {
-        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
-      }
-    engines: { node: ">=8" }
-
-  string-width@7.2.0:
-    resolution:
-      {
-        integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
-      }
-    engines: { node: ">=18" }
-
   stringify-entities@4.0.4:
     resolution:
       {
         integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
       }
-
-  strip-ansi@6.0.1:
-    resolution:
-      {
-        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
-      }
-    engines: { node: ">=8" }
-
-  strip-ansi@7.2.0:
-    resolution:
-      {
-        integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
-      }
-    engines: { node: ">=12" }
 
   style-to-js@1.1.21:
     resolution:
@@ -5203,6 +4931,13 @@ packages:
         integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==,
       }
 
+  tinyclip@0.1.12:
+    resolution:
+      {
+        integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==,
+      }
+    engines: { node: ^16.14.0 || >= 17.3.0 }
+
   tinyexec@1.0.4:
     resolution:
       {
@@ -5210,10 +4945,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     resolution:
       {
-        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
       }
     engines: { node: ">=12.0.0" }
 
@@ -5275,13 +5010,6 @@ packages:
         integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==,
       }
     engines: { node: ">=0.6.11 <=0.7.0 || >=0.7.3" }
-
-  type-fest@4.41.0:
-    resolution:
-      {
-        integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
-      }
-    engines: { node: ">=16" }
 
   typescript@6.0.3:
     resolution:
@@ -5406,10 +5134,10 @@ packages:
         integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==,
       }
 
-  unstorage@1.17.4:
+  unstorage@1.17.5:
     resolution:
       {
-        integrity: sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==,
+        integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==,
       }
     peerDependencies:
       "@azure/app-configuration": ^1.8.0
@@ -5563,49 +5291,6 @@ packages:
     peerDependencies:
       vite: "*"
 
-  vite@6.4.2:
-    resolution:
-      {
-        integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
-    hasBin: true
-    peerDependencies:
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: ">=1.21.0"
-      less: "*"
-      lightningcss: 1.30.1
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      "@types/node":
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.3.2:
     resolution:
       {
@@ -5673,13 +5358,6 @@ packages:
       }
     engines: { node: ">=4" }
 
-  widest-line@5.0.0:
-    resolution:
-      {
-        integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==,
-      }
-    engines: { node: ">=18" }
-
   wireit@0.14.12:
     resolution:
       {
@@ -5687,13 +5365,6 @@ packages:
       }
     engines: { node: ">=18.0.0" }
     hasBin: true
-
-  wrap-ansi@9.0.2:
-    resolution:
-      {
-        integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
-      }
-    engines: { node: ">=18" }
 
   xml2js@0.6.2:
     resolution:
@@ -5728,12 +5399,12 @@ packages:
       }
     engines: { node: ">= 6" }
 
-  yargs-parser@21.1.1:
+  yargs-parser@22.0.0:
     resolution:
       {
-        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+        integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
       }
-    engines: { node: ">=12" }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
 
   yocto-queue@1.2.2:
     resolution:
@@ -5741,43 +5412,6 @@ packages:
         integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==,
       }
     engines: { node: ">=12.20" }
-
-  yocto-spinner@0.2.3:
-    resolution:
-      {
-        integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==,
-      }
-    engines: { node: ">=18.19" }
-
-  yoctocolors@2.1.2:
-    resolution:
-      {
-        integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==,
-      }
-    engines: { node: ">=18" }
-
-  zod-to-json-schema@3.25.1:
-    resolution:
-      {
-        integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==,
-      }
-    peerDependencies:
-      zod: ^3.25 || ^4
-
-  zod-to-ts@1.2.0:
-    resolution:
-      {
-        integrity: sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==,
-      }
-    peerDependencies:
-      typescript: ^4.9.4 || ^5.0.2
-      zod: ^3
-
-  zod@3.25.76:
-    resolution:
-      {
-        integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
-      }
 
   zod@4.3.6:
     resolution:
@@ -5844,18 +5478,19 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  "@astrojs/compiler@2.13.1": {}
+  "@astrojs/compiler@4.0.0": {}
 
-  "@astrojs/internal-helpers@0.7.6": {}
-
-  "@astrojs/markdown-remark@6.3.11":
+  "@astrojs/internal-helpers@0.9.0":
     dependencies:
-      "@astrojs/internal-helpers": 0.7.6
-      "@astrojs/prism": 3.3.0
+      picomatch: 4.0.4
+
+  "@astrojs/markdown-remark@7.1.1":
+    dependencies:
+      "@astrojs/internal-helpers": 0.9.0
+      "@astrojs/prism": 4.0.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      import-meta-resolve: 4.2.0
       js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
@@ -5864,7 +5499,8 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      shiki: 3.23.0
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
       smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
@@ -5874,13 +5510,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))":
+  "@astrojs/mdx@5.0.4(astro@6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))":
     dependencies:
-      "@astrojs/markdown-remark": 6.3.11
+      "@astrojs/markdown-remark": 7.1.1
       "@mdx-js/mdx": 3.1.1
       acorn: 8.16.0
-      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
-      es-module-lexer: 1.7.0
+      astro: 6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
+      es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
@@ -5893,7 +5529,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.1":
     dependencies:
       prismjs: 1.30.0
 
@@ -5903,17 +5539,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  "@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))":
+  "@astrojs/starlight@0.38.4(astro@6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))":
     dependencies:
-      "@astrojs/markdown-remark": 6.3.11
-      "@astrojs/mdx": 4.3.14(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
+      "@astrojs/markdown-remark": 7.1.1
+      "@astrojs/mdx": 5.0.4(astro@6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
       "@astrojs/sitemap": 3.7.2
       "@pagefind/default-ui": 1.4.0
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
-      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
+      astro: 6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
+      astro-expressive-code: 0.41.7(astro@6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -5937,17 +5573,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.1":
     dependencies:
       ci-info: 4.4.0
-      debug: 4.4.3
       dlv: 1.1.3
       dset: 3.1.4
-      is-docker: 3.0.0
+      is-docker: 4.0.0
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
 
   "@axe-core/playwright@4.11.1(playwright-core@1.58.2)":
     dependencies:
@@ -6181,6 +5814,18 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
+  "@clack/core@1.3.0":
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  "@clack/prompts@1.3.0":
+    dependencies:
+      "@clack/core": 1.3.0
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
   "@ctrl/tinycolor@4.2.0": {}
 
   "@emnapi/runtime@1.8.1":
@@ -6271,157 +5916,79 @@ snapshots:
 
   "@emotion/weak-memoize@0.4.0": {}
 
-  "@esbuild/aix-ppc64@0.25.12":
-    optional: true
-
   "@esbuild/aix-ppc64@0.27.7":
-    optional: true
-
-  "@esbuild/android-arm64@0.25.12":
     optional: true
 
   "@esbuild/android-arm64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm@0.25.12":
-    optional: true
-
   "@esbuild/android-arm@0.27.7":
-    optional: true
-
-  "@esbuild/android-x64@0.25.12":
     optional: true
 
   "@esbuild/android-x64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-arm64@0.25.12":
-    optional: true
-
   "@esbuild/darwin-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/darwin-x64@0.25.12":
     optional: true
 
   "@esbuild/darwin-x64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.25.12":
-    optional: true
-
   "@esbuild/freebsd-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/freebsd-x64@0.25.12":
     optional: true
 
   "@esbuild/freebsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm64@0.25.12":
-    optional: true
-
   "@esbuild/linux-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/linux-arm@0.25.12":
     optional: true
 
   "@esbuild/linux-arm@0.27.7":
     optional: true
 
-  "@esbuild/linux-ia32@0.25.12":
-    optional: true
-
   "@esbuild/linux-ia32@0.27.7":
-    optional: true
-
-  "@esbuild/linux-loong64@0.25.12":
     optional: true
 
   "@esbuild/linux-loong64@0.27.7":
     optional: true
 
-  "@esbuild/linux-mips64el@0.25.12":
-    optional: true
-
   "@esbuild/linux-mips64el@0.27.7":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.25.12":
     optional: true
 
   "@esbuild/linux-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/linux-riscv64@0.25.12":
-    optional: true
-
   "@esbuild/linux-riscv64@0.27.7":
-    optional: true
-
-  "@esbuild/linux-s390x@0.25.12":
     optional: true
 
   "@esbuild/linux-s390x@0.27.7":
     optional: true
 
-  "@esbuild/linux-x64@0.25.12":
-    optional: true
-
   "@esbuild/linux-x64@0.27.7":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.25.12":
     optional: true
 
   "@esbuild/netbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/netbsd-x64@0.25.12":
-    optional: true
-
   "@esbuild/netbsd-x64@0.27.7":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.25.12":
     optional: true
 
   "@esbuild/openbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/openbsd-x64@0.25.12":
-    optional: true
-
   "@esbuild/openbsd-x64@0.27.7":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.25.12":
     optional: true
 
   "@esbuild/openharmony-arm64@0.27.7":
     optional: true
 
-  "@esbuild/sunos-x64@0.25.12":
-    optional: true
-
   "@esbuild/sunos-x64@0.27.7":
-    optional: true
-
-  "@esbuild/win32-arm64@0.25.12":
     optional: true
 
   "@esbuild/win32-arm64@0.27.7":
     optional: true
 
-  "@esbuild/win32-ia32@0.25.12":
-    optional: true
-
   "@esbuild/win32-ia32@0.27.7":
-    optional: true
-
-  "@esbuild/win32-x64@0.25.12":
     optional: true
 
   "@esbuild/win32-x64@0.27.7":
@@ -6434,8 +6001,8 @@ snapshots:
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.8
-      postcss-nested: 6.2.0(postcss@8.5.8)
+      postcss: 8.5.12
+      postcss-nested: 6.2.0(postcss@8.5.12)
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
@@ -6780,7 +6347,7 @@ snapshots:
 
   "@popperjs/core@2.11.8": {}
 
-  "@react-router/dev@7.13.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))":
+  "@react-router/dev@7.14.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/generator": 7.29.1
@@ -6789,7 +6356,7 @@ snapshots:
       "@babel/preset-typescript": 7.28.5(@babel/core@7.29.0)
       "@babel/traverse": 7.29.0
       "@babel/types": 7.29.0
-      "@react-router/node": 7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
+      "@react-router/node": 7.14.2(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       "@remix-run/node-fetch-server": 0.13.0
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.12
@@ -6806,9 +6373,9 @@ snapshots:
       pkg-types: 2.3.0
       prettier: 3.8.1
       react-refresh: 0.14.2
-      react-router: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       valibot: 1.3.1(typescript@6.0.3)
       vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
@@ -6829,10 +6396,10 @@ snapshots:
       - tsx
       - yaml
 
-  "@react-router/node@7.13.2(react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)":
+  "@react-router/node@7.14.2(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)":
     dependencies:
       "@mjackson/node-fetch-server": 0.2.0
-      react-router: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -6928,9 +6495,23 @@ snapshots:
       "@types/hast": 3.0.4
       hast-util-to-html: 9.0.5
 
+  "@shikijs/core@4.0.2":
+    dependencies:
+      "@shikijs/primitive": 4.0.2
+      "@shikijs/types": 4.0.2
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+      hast-util-to-html: 9.0.5
+
   "@shikijs/engine-javascript@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
+      "@shikijs/vscode-textmate": 10.0.2
+      oniguruma-to-es: 4.3.5
+
+  "@shikijs/engine-javascript@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
       "@shikijs/vscode-textmate": 10.0.2
       oniguruma-to-es: 4.3.5
 
@@ -6939,15 +6520,39 @@ snapshots:
       "@shikijs/types": 3.23.0
       "@shikijs/vscode-textmate": 10.0.2
 
+  "@shikijs/engine-oniguruma@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
+      "@shikijs/vscode-textmate": 10.0.2
+
   "@shikijs/langs@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
+
+  "@shikijs/langs@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
+
+  "@shikijs/primitive@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
 
   "@shikijs/themes@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
 
+  "@shikijs/themes@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
+
   "@shikijs/types@3.23.0":
+    dependencies:
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+
+  "@shikijs/types@4.0.2":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
@@ -6965,7 +6570,7 @@ snapshots:
     dependencies:
       minimatch: 10.2.3
       path-browserify: 1.0.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
 
   "@types/debug@4.1.13":
     dependencies:
@@ -7039,16 +6644,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ansi-align@3.0.1:
-    dependencies:
-      string-width: 4.2.3
-
-  ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@6.2.3: {}
-
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -7064,76 +6659,67 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)):
+  astro-expressive-code@0.41.7(astro@6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)):
     dependencies:
-      astro: 5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
+      astro: 6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3)
       rehype-expressive-code: 0.41.7
 
-  astro@5.18.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3):
+  astro@6.2.1(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.60.0)(tsx@4.21.0)(typescript@6.0.3):
     dependencies:
-      "@astrojs/compiler": 2.13.1
-      "@astrojs/internal-helpers": 0.7.6
-      "@astrojs/markdown-remark": 6.3.11
-      "@astrojs/telemetry": 3.3.0
+      "@astrojs/compiler": 4.0.0
+      "@astrojs/internal-helpers": 0.9.0
+      "@astrojs/markdown-remark": 7.1.1
+      "@astrojs/telemetry": 3.3.1
       "@capsizecss/unpack": 4.0.0
+      "@clack/prompts": 1.3.0
       "@oslojs/encoding": 1.1.0
       "@rollup/pluginutils": 5.3.0(rollup@4.60.0)
-      acorn: 8.16.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
-      boxen: 8.0.1
       ci-info: 4.4.0
       clsx: 2.1.1
-      common-ancestor-path: 1.0.1
+      common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      cssesc: 3.0.0
-      debug: 4.4.3
-      deterministic-object-hash: 2.0.2
       devalue: 5.6.4
       diff: 8.0.4
-      dlv: 1.1.3
       dset: 3.1.4
-      es-module-lexer: 1.7.0
+      es-module-lexer: 2.1.0
       esbuild: 0.27.7
-      estree-walker: 3.0.3
       flattie: 1.1.1
       fontace: 0.4.1
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      import-meta-resolve: 4.2.0
       js-yaml: 4.1.1
       magic-string: 0.30.21
       magicast: 0.5.2
       mrmime: 2.0.1
       neotraverse: 0.6.18
-      p-limit: 6.2.0
-      p-queue: 8.1.1
+      obug: 2.1.1
+      p-limit: 7.3.0
+      p-queue: 9.2.0
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
       picomatch: 4.0.4
-      prompts: 2.4.2
       rehype: 13.0.2
       semver: 7.7.4
-      shiki: 3.23.0
+      shiki: 4.0.2
       smol-toml: 1.6.1
       svgo: 4.0.1
+      tinyclip: 0.1.12
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
-      unstorage: 1.17.4
+      unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 6.4.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
-      vitefu: 1.1.2(vite@6.4.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
+      vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
+      vitefu: 1.1.2(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0))
       xxhash-wasm: 1.1.0
-      yargs-parser: 21.1.1
-      yocto-spinner: 0.2.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@6.0.3)(zod@3.25.76)
+      yargs-parser: 22.0.0
+      zod: 4.3.6
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -7198,8 +6784,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base-64@1.0.0: {}
-
   baseline-browser-mapping@2.10.0: {}
 
   bcp-47-match@2.0.3: {}
@@ -7215,17 +6799,6 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   boolbase@1.0.0: {}
-
-  boxen@8.0.1:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 8.0.0
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      string-width: 7.2.0
-      type-fest: 4.41.0
-      widest-line: 5.0.0
-      wrap-ansi: 9.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -7247,13 +6820,9 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase@8.0.0: {}
-
   caniuse-lite@1.0.30001774: {}
 
   ccount@2.0.1: {}
-
-  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -7287,8 +6856,6 @@ snapshots:
 
   classnames@2.5.1: {}
 
-  cli-boxes@3.0.0: {}
-
   clsx@2.1.1: {}
 
   code-block-writer@13.0.3: {}
@@ -7301,7 +6868,7 @@ snapshots:
 
   commander@11.1.0: {}
 
-  common-ancestor-path@1.0.1: {}
+  common-ancestor-path@2.0.0: {}
 
   confbox@0.2.4: {}
 
@@ -7375,10 +6942,6 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  deterministic-object-hash@2.0.2:
-    dependencies:
-      base-64: 1.0.0
-
   devalue@5.6.4: {}
 
   devlop@1.1.0:
@@ -7418,10 +6981,6 @@ snapshots:
 
   electron-to-chromium@1.5.302: {}
 
-  emoji-regex@10.6.0: {}
-
-  emoji-regex@8.0.0: {}
-
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -7431,6 +6990,8 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -7445,35 +7006,6 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
-
-  esbuild@0.25.12:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.12
-      "@esbuild/android-arm": 0.25.12
-      "@esbuild/android-arm64": 0.25.12
-      "@esbuild/android-x64": 0.25.12
-      "@esbuild/darwin-arm64": 0.25.12
-      "@esbuild/darwin-x64": 0.25.12
-      "@esbuild/freebsd-arm64": 0.25.12
-      "@esbuild/freebsd-x64": 0.25.12
-      "@esbuild/linux-arm": 0.25.12
-      "@esbuild/linux-arm64": 0.25.12
-      "@esbuild/linux-ia32": 0.25.12
-      "@esbuild/linux-loong64": 0.25.12
-      "@esbuild/linux-mips64el": 0.25.12
-      "@esbuild/linux-ppc64": 0.25.12
-      "@esbuild/linux-riscv64": 0.25.12
-      "@esbuild/linux-s390x": 0.25.12
-      "@esbuild/linux-x64": 0.25.12
-      "@esbuild/netbsd-arm64": 0.25.12
-      "@esbuild/netbsd-x64": 0.25.12
-      "@esbuild/openbsd-arm64": 0.25.12
-      "@esbuild/openbsd-x64": 0.25.12
-      "@esbuild/openharmony-arm64": 0.25.12
-      "@esbuild/sunos-x64": 0.25.12
-      "@esbuild/win32-arm64": 0.25.12
-      "@esbuild/win32-ia32": 0.25.12
-      "@esbuild/win32-x64": 0.25.12
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -7570,6 +7102,16 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -7603,8 +7145,6 @@ snapshots:
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
-
-  get-east-asian-width@1.5.0: {}
 
   get-tsconfig@4.13.1:
     dependencies:
@@ -7848,8 +7388,6 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-meta-resolve@4.2.0: {}
-
   inline-style-parser@0.2.7: {}
 
   iron-webcrypto@1.2.1: {}
@@ -7875,9 +7413,9 @@ snapshots:
 
   is-docker@3.0.0: {}
 
-  is-extglob@2.1.1: {}
+  is-docker@4.0.0: {}
 
-  is-fullwidth-code-point@3.0.0: {}
+  is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -7912,8 +7450,6 @@ snapshots:
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
-
-  kleur@3.0.3: {}
 
   klona@2.0.6: {}
 
@@ -8543,6 +8079,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  obug@2.1.1: {}
+
   ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
@@ -8559,18 +8097,18 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     dependencies:
       yocto-queue: 1.2.2
 
   p-map@7.0.4: {}
 
-  p-queue@8.1.1:
+  p-queue@9.2.0:
     dependencies:
       eventemitter3: 5.0.4
-      p-timeout: 6.1.4
+      p-timeout: 7.0.1
 
-  p-timeout@6.1.4: {}
+  p-timeout@7.0.1: {}
 
   package-manager-detector@1.6.0: {}
 
@@ -8649,9 +8187,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-nested@6.2.0(postcss@8.5.8):
+  postcss-nested@6.2.0(postcss@8.5.12):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.12
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -8659,7 +8197,7 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.8:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8668,11 +8206,6 @@ snapshots:
   prettier@3.8.1: {}
 
   prismjs@1.30.0: {}
-
-  prompts@2.4.2:
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -8712,7 +8245,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  react-router@7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       cookie: 1.1.1
       react: 19.2.5
@@ -9012,6 +8545,17 @@ snapshots:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
+  shiki@4.0.2:
+    dependencies:
+      "@shikijs/core": 4.0.2
+      "@shikijs/engine-javascript": 4.0.2
+      "@shikijs/engine-oniguruma": 4.0.2
+      "@shikijs/langs": 4.0.2
+      "@shikijs/themes": 4.0.2
+      "@shikijs/types": 4.0.2
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+
   signal-exit@3.0.7: {}
 
   sisteransi@1.0.5: {}
@@ -9035,30 +8579,10 @@ snapshots:
 
   stream-replace-string@2.0.0: {}
 
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   style-to-js@1.1.21:
     dependencies:
@@ -9084,9 +8608,11 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinyclip@0.1.12: {}
+
   tinyexec@1.0.4: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -9119,8 +8645,6 @@ snapshots:
       fsevents: 2.3.3
 
   tunnel@0.0.6: {}
-
-  type-fest@4.41.0: {}
 
   typescript@6.0.3: {}
 
@@ -9200,7 +8724,7 @@ snapshots:
 
   universal-user-agent@7.0.3: {}
 
-  unstorage@1.17.4:
+  unstorage@1.17.5:
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -9285,45 +8809,27 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@6.4.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      "@types/node": 22.19.17
-      fsevents: 2.3.3
-      lightningcss: 1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce)
-      tsx: 4.21.0
-
   vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.12
       rollup: 4.60.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       "@types/node": 22.19.17
       fsevents: 2.3.3
       lightningcss: 1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce)
       tsx: 4.21.0
 
-  vitefu@1.1.2(vite@6.4.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)):
+  vitefu@1.1.2(vite@7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)):
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.17)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.21.0)
 
   web-namespaces@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
-
-  widest-line@5.0.0:
-    dependencies:
-      string-width: 7.2.0
 
   wireit@0.14.12(patch_hash=442051a61659ca584845f39c86d1cc7c09810a44100a1aa6c653a03859713f36):
     dependencies:
@@ -9332,12 +8838,6 @@ snapshots:
       fast-glob: 3.3.3
       jsonc-parser: 3.3.1
       proper-lockfile: 4.1.2
-
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
 
   xml2js@0.6.2:
     dependencies:
@@ -9352,26 +8852,9 @@ snapshots:
 
   yaml@1.10.3: {}
 
-  yargs-parser@21.1.1: {}
+  yargs-parser@22.0.0: {}
 
   yocto-queue@1.2.2: {}
-
-  yocto-spinner@0.2.3:
-    dependencies:
-      yoctocolors: 2.1.2
-
-  yoctocolors@2.1.2: {}
-
-  zod-to-json-schema@3.25.1(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod-to-ts@1.2.0(typescript@6.0.3)(zod@3.25.76):
-    dependencies:
-      typescript: 6.0.3
-      zod: 3.25.76
-
-  zod@3.25.76: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
### Changes

_Extracted out of #1457._

Migrates the `website` to [Astro v6](https://docs.astro.build/en/guides/upgrade-to/v6/).
- Bumped `astro` to 6.2
- Bumped `@astrojs/starlight` to 0.38
- Updated [zod import](https://docs.astro.build/en/guides/upgrade-to/v6/#deprecated-astroschema-and-z-from-astrocontent).
- Updated [Loader return type](https://docs.astro.build/en/guides/upgrade-to/v6/#changed-schema-types-are-inferred-instead-of-generated-content-loader-api).
- (unrelated) Fixed `packages` filtering logic. See [comment](https://github.com/iTwin/stratakit/pull/1459#discussion_r3174875046).

Misc notes:
- Astro 6 unfortunately still uses Vite 7. I was expecting it would use Vite 8, since they were released at the same time.
- There are now two versions of Shiki in the lockfile. Expressive Code, a dependency of Starlight, is still using Shiki 3 ([expressive-code#434](https://redirect.github.com/expressive-code/expressive-code/issues/434))

### Testing

Docs continue to work, both in dev (`pnpm run docs`) and prod (`pnpm run build`).

I've quickly clicked through a few pages to verify that major features work (e.g. embedded demos, syntax highlighting, icon previews, API reference).

[Deploy preview (docs)](https://stratakit.bentley.com/1459/docs)