### PR TITLE
Adjust `forced-colors` visuals for active + disabled state

### DIFF
--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -88,15 +88,13 @@
 		--_MuiCheckbox-color: SelectedItemText;
 	}
 
-	:where(.MuiFormControlLabel-root.Mui-error) & {
+	:where(.MuiFormControlLabel-root.Mui-error) &:where(:not(.Mui-disabled)) {
 		--_MuiCheckbox-background-color: Mark;
 		--_MuiCheckbox-color: MarkText;
 	}
 
 	&:where(.Mui-disabled) {
-		--_MuiCheckbox-background-color: Canvas;
 		--_MuiCheckbox-border-color: GrayText;
-		--_MuiCheckbox-color: GrayText;
 	}
 }
 
@@ -177,7 +175,7 @@
 }
 
 .MuiPaginationItem-root {
-	&:where(.Mui-selected:not(.Mui-disabled)) {
+	&:where(.Mui-selected) {
 		background-color: SelectedItem;
 		border-color: SelectedItemText;
 		color: SelectedItemText;
@@ -252,7 +250,7 @@
 .MuiSwitch-switchBase {
 	--_MuiSwitch-thumb-background-color: CanvasText;
 
-	&:where(.Mui-checked:not(.Mui-disabled)) {
+	&:where(.Mui-checked) {
 		--_MuiSwitch-thumb-background-color: SelectedItemText;
 
 		+ .MuiSwitch-track {
@@ -261,7 +259,9 @@
 	}
 
 	&:where(.Mui-disabled) {
-		--_MuiSwitch-thumb-background-color: GrayText;
+		&:where(:not(.Mui-checked)) {
+			--_MuiSwitch-thumb-background-color: GrayText;
+		}
 
 		+ .MuiSwitch-track {
 			--_MuiSwitch-track-border-color: GrayText;


### PR DESCRIPTION
### Changes

Changed visuals for the active + disabled state in the following:
- `Checkbox` / `Radio`
- `Pagination`
- `Switch`

Stemming from https://github.com/iTwin/stratakit/pull/1453#discussion_r3156648614.

### Testing

- Active + disabled
- Active + error + disabled (disabled overtakes error)

| Default state | Disabled state before | Disabled state after |
| -- | -- | -- |
| <img width="497" height="432" alt="Screenshot 2026-05-05 at 3 18 14 PM" src="https://github.com/user-attachments/assets/bc6aa6d6-5412-4b4f-bf97-00724af3daf5" /> | <img width="497" height="432" alt="Screenshot 2026-05-05 at 3 19 32 PM" src="https://github.com/user-attachments/assets/f1e8b6f9-ebb4-42d4-af17-e89e6c55bb98" /> | <img width="497" height="432" alt="Screenshot 2026-05-05 at 3 18 58 PM" src="https://github.com/user-attachments/assets/1a4dcaa1-a98f-4021-86cf-476f250e4fef" /> |
| <img width="308" height="150" alt="Screenshot 2026-05-05 at 3 20 53 PM" src="https://github.com/user-attachments/assets/bae19ef3-3779-49a8-b8c5-ef0d9de232b6" /> | <img width="308" height="150" alt="Screenshot 2026-05-05 at 3 21 31 PM" src="https://github.com/user-attachments/assets/3d0c74a9-2cbb-4adb-816e-0b8ab85eec06" /> | <img width="308" height="150" alt="Screenshot 2026-05-05 at 3 21 05 PM" src="https://github.com/user-attachments/assets/333f441e-c31f-48dd-bc37-52b52302e269" /> |
| <img width="604" height="79" alt="Screenshot 2026-05-05 at 3 22 35 PM" src="https://github.com/user-attachments/assets/daa2ef54-3f43-4c63-b0a5-4d2b0d684154" /> | <img width="604" height="79" alt="Screenshot 2026-05-05 at 3 22 59 PM" src="https://github.com/user-attachments/assets/20caa161-8354-4897-9c65-aff8bfcc2bdd" /> | <img width="604" height="79" alt="Screenshot 2026-05-05 at 3 22 47 PM" src="https://github.com/user-attachments/assets/d2dea613-6e41-4bc9-b936-0590d034c7c8" /> |
