### PR TITLE
Remove `role="dialog"` from `paper` slot of `Menu`

### DIFF
--- a/.changeset/big-ghosts-vanish.md
+++ b/.changeset/big-ghosts-vanish.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Removed `role="dialog"` from the `paper` slot of the `Menu` component.

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -11,7 +11,7 @@ links:
 ## StrataKit MUI modifications
 
 - Restyled using StrataKit's visual language.
-- Removed [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) semantics from the [`paper`](https://mui.com/material-ui/api/menu/#Menu-css-MuiMenu-paper) slot. The **Menu** is no longer treated as a dialog by assistive technologies.
+- Removed [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) semantics from the [`paper`](https://mui.com/material-ui/api/menu/#Menu-css-MuiMenu-paper) slot.
 - Includes full `forced-colors` support.
 
 ## Examples

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -11,6 +11,7 @@ links:
 ## StrataKit MUI modifications
 
 - Restyled using StrataKit's visual language.
+- Removed [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) semantics from the [`paper`](https://mui.com/material-ui/api/menu/#Menu-css-MuiMenu-paper) slot. The **Menu** is no longer treated as a dialog by assistive technologies.
 - Includes full `forced-colors` support.
 
 ## Examples

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -353,7 +353,16 @@ function createTheme() {
 				},
 			},
 			MuiListSubheader: { defaultProps: { component: Role.li } },
-			MuiMenu: { defaultProps: { component: Role.div } },
+			MuiMenu: {
+				defaultProps: {
+					component: Role.div,
+					slotProps: {
+						paper: {
+							role: "presentation", // Removes role="dialog"
+						},
+					},
+				},
+			},
 			MuiMenuItem: { defaultProps: { component: Role.li } },
 			MuiMenuList: { defaultProps: { component: Role.ul } },
 			MuiMobileStepper: { defaultProps: { component: Role.div } },


### PR DESCRIPTION
### Changes

This PR removes `role="dialog"` from the `paper` slot of the `Menu` component.

Both [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) and [`role="menu"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role) are [required to have an accessible name](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role#labeling). This results in a verbose and redundant output by the screen readers.

Additionally, as element with the dialog role is not labelled in our [Menu.default example](https://stratakit.bentley.com/docs/examples/mui/Menu.default/) it is [flagged](https://dequeuniversity.com/rules/axe/4.11/aria-dialog-name) by the Axe DevTools (when the menu is opened).

Lastly and most importantly the `Menu` doesn't behave like a `Dialog` (e.g. keyboard navigation, focus management).

### Testing

Screen reader output of https://stratakit.bentley.com/docs/examples/mui/Menu.default/ (VO + Chrome v145):
- Before: `User actions, dialog, Profile, menu item, (1 of 3), menu User actions 3 items`
- After: `Profile, menu item, (1 of 3), menu User actions 3 items`

[PR deployment](https://stratakit.bentley.com/1464/docs/components/menu/)

