### PR TITLE
`Alert` design tweaks

### DIFF
--- a/packages/mui/src/~components/MuiAlert.css
+++ b/packages/mui/src/~components/MuiAlert.css
@@ -5,6 +5,7 @@
 
 .MuiAlert-root {
 	border: 1px solid var(--stratakit-color-border-neutral-base);
+	padding-block: var(--stratakit-space-x3);
 
 	&:where(.MuiAlert-outlined) {
 		background-color: var(--stratakit-color-bg-elevation-base);
@@ -25,7 +26,14 @@
 }
 
 .MuiAlert-icon {
-	align-items: center; /* Fix vertical alignment of differently sized icons */
+	align-self: start;
+	align-items: center;
+	font-size: inherit;
+	block-size: 1lh;
+
+	padding: 0;
+	opacity: 1; /* Stock MUI reduces the icon opacity for some reason. */
+	margin-inline-end: var(--stratakit-space-x2);
 
 	:where(.MuiAlert-root.MuiAlert-colorSuccess) & {
 		color: var(--stratakit-color-icon-positive-base);
@@ -39,4 +47,13 @@
 	:where(.MuiAlert-root.MuiAlert-colorError) & {
 		color: var(--stratakit-color-icon-critical-base);
 	}
+}
+
+.MuiAlert-message {
+	padding: 0;
+}
+
+.MuiAlertTitle-root {
+	margin: 0;
+	margin-block-end: var(--stratakit-space-x1);
 }


### PR DESCRIPTION
### Changes

A few tweaks to `Alert`:
- spacing and gap reduced / made consistent.
- icon properly aligned with the main text at the top.
- fixed opacity of icon.

Now looks closer to the deprecated `Banner.css`.

### Testing

| Before | After |
| --- | --- |
| <img width="250" height="317" alt="screenshot" src="https://github.com/user-attachments/assets/20327855-57d7-4a8f-8874-f6b12c128708" /> | <img width="245" height="296" alt="screenshot" src="https://github.com/user-attachments/assets/877db8b1-c613-4862-b49e-4ff6dc825370" /> |

[Deploy preview](https://stratakit.bentley.com/1465/mui/#alert)
