### PR TITLE
Simplify examples by removing `aria-controls`

### DIFF
--- a/examples/mui/Card.menu.tsx
+++ b/examples/mui/Card.menu.tsx
@@ -58,14 +58,12 @@ function ActionsMenu() {
 	const handleClose = () => setAnchorEl(null);
 
 	const buttonId = React.useId();
-	const menuId = React.useId();
 
 	return (
 		<>
 			<IconButton
 				label="More actions"
 				id={buttonId}
-				aria-controls={open ? menuId : undefined}
 				aria-haspopup="true"
 				aria-expanded={open ? "true" : "false"}
 				onClick={(event) => setAnchorEl(event.currentTarget)}
@@ -73,7 +71,6 @@ function ActionsMenu() {
 				<Icon href={svgMore} />
 			</IconButton>
 			<Menu
-				id={menuId}
 				anchorEl={anchorEl}
 				open={open}
 				onClose={handleClose}

--- a/examples/mui/Menu.default.tsx
+++ b/examples/mui/Menu.default.tsx
@@ -16,13 +16,11 @@ export default () => {
 	};
 
 	const buttonId = React.useId();
-	const menuId = React.useId();
 
 	return (
 		<>
 			<Button
 				id={buttonId}
-				aria-controls={open ? menuId : undefined}
 				aria-haspopup="true"
 				aria-expanded={open ? "true" : "false"}
 				onClick={(event) => setAnchorEl(event.currentTarget)}
@@ -30,7 +28,6 @@ export default () => {
 				User actions
 			</Button>
 			<Menu
-				id={menuId}
 				anchorEl={anchorEl}
 				open={open}
 				onClose={handleClose}

--- a/examples/mui/Menu.dense.tsx
+++ b/examples/mui/Menu.dense.tsx
@@ -16,13 +16,11 @@ export default () => {
 	};
 
 	const buttonId = React.useId();
-	const menuId = React.useId();
 
 	return (
 		<>
 			<Button
 				id={buttonId}
-				aria-controls={open ? menuId : undefined}
 				aria-haspopup="true"
 				aria-expanded={open ? "true" : "false"}
 				onClick={(event) => setAnchorEl(event.currentTarget)}
@@ -31,7 +29,6 @@ export default () => {
 				Open dense menu
 			</Button>
 			<Menu
-				id={menuId}
 				anchorEl={anchorEl}
 				open={open}
 				onClose={handleClose}

--- a/examples/mui/Tabs.default.tsx
+++ b/examples/mui/Tabs.default.tsx
@@ -16,46 +16,22 @@ export default () => {
 	return (
 		<Box>
 			<Tabs value={value} onChange={(_, value) => setValue(value)}>
-				<Tab
-					label="Item One"
-					id={`${baseId}-tab0`}
-					aria-controls={`${baseId}-panel0`}
-				/>
-				<Tab
-					label="Item Two"
-					id={`${baseId}-tab1`}
-					aria-controls={`${baseId}-panel1`}
-				/>
-				<Tab
-					label="Item Three"
-					id={`${baseId}-tab2`}
-					aria-controls={`${baseId}-panel2`}
-				/>
+				<Tab label="Item One" id={`${baseId}-tab0`} />
+				<Tab label="Item Two" id={`${baseId}-tab1`} />
+				<Tab label="Item Three" id={`${baseId}-tab2`} />
 			</Tabs>
 			{value === 0 && (
-				<div
-					role="tabpanel"
-					id={`${baseId}-panel0`}
-					aria-labelledby={`${baseId}-tab0`}
-				>
+				<div role="tabpanel" aria-labelledby={`${baseId}-tab0`}>
 					Item One
 				</div>
 			)}
 			{value === 1 && (
-				<div
-					role="tabpanel"
-					id={`${baseId}-panel1`}
-					aria-labelledby={`${baseId}-tab1`}
-				>
+				<div role="tabpanel" aria-labelledby={`${baseId}-tab1`}>
 					Item Two
 				</div>
 			)}
 			{value === 2 && (
-				<div
-					role="tabpanel"
-					id={`${baseId}-panel2`}
-					aria-labelledby={`${baseId}-tab2`}
-				>
+				<div role="tabpanel" aria-labelledby={`${baseId}-tab2`}>
 					Item Three
 				</div>
 			)}

--- a/examples/mui/Tabs.scrollable.tsx
+++ b/examples/mui/Tabs.scrollable.tsx
@@ -36,15 +36,10 @@ export default () => {
 						key={index}
 						label={`Item ${index}`}
 						id={`${baseId}-tab${index}`}
-						aria-controls={`${baseId}-panel${index}`}
 					/>
 				))}
 			</Tabs>
-			<div
-				role="tabpanel"
-				id={`${baseId}-panel${value}`}
-				aria-labelledby={`${baseId}-tab${value}`}
-			>
+			<div role="tabpanel" aria-labelledby={`${baseId}-tab${value}`}>
 				Item {value}
 			</div>
 		</Box>


### PR DESCRIPTION
### Changes

This PR removes leftover usage of `aria-controls` in our examples. This was already done for other components in https://github.com/iTwin/stratakit/pull/1297,  https://github.com/iTwin/stratakit/pull/1420

The superfluous attribute is removed due to [poor support](https://a11ysupport.io/tech/aria/aria-controls_attribute) by browser/screen-reader vendors which results in no value added, while still complicating and making examples (and in turn component usage by our consumers) more complicated/verbose.

Related reading: [Aria-Controls is Poop](https://heydonworks.com/article/aria-controls-is-poop/)

### Testing

N/A
