### PR TITLE
fix shorthand declarations for safari

### DIFF
--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -39,7 +39,8 @@
 .MuiAppBar-root {
 	background-color: var(--stratakit-color-bg-page-base);
 	box-shadow: none;
-	border-block-end: 1px solid var(--stratakit-color-border-page-base);
+	border-block-end: 1px solid;
+	border-color: var(--stratakit-color-border-page-base);
 	color: var(--stratakit-color-text-neutral-primary);
 }
 

--- a/packages/mui/src/~components/MuiButton.css
+++ b/packages/mui/src/~components/MuiButton.css
@@ -14,8 +14,10 @@
 .MuiButton-root {
 	min-block-size: var(--_MuiButton-height);
 	min-inline-size: var(--_MuiButton-height);
-	padding-block: var(--_MuiButton-padding-block);
-	padding-inline: var(--_MuiButton-padding-inline);
+	padding-block-start: var(--_MuiButton-padding-block);
+	padding-block-end: var(--_MuiButton-padding-block);
+	padding-inline-start: var(--_MuiButton-padding-inline);
+	padding-inline-end: var(--_MuiButton-padding-inline);
 
 	&:where(.MuiButton-sizeSmall) {
 		@apply --typography("body-sm");

--- a/packages/mui/src/~components/MuiChip.css
+++ b/packages/mui/src/~components/MuiChip.css
@@ -31,7 +31,8 @@
 }
 
 .MuiChip-label {
-	padding-inline: var(--_MuiChip-padding-inline);
+	padding-inline-start: var(--_MuiChip-padding-inline);
+	padding-inline-end: var(--_MuiChip-padding-inline);
 
 	:where(.MuiChip-root.MuiChip-sizeSmall) & {
 		@apply --typography("body-sm");

--- a/packages/mui/src/~components/MuiInput.css
+++ b/packages/mui/src/~components/MuiInput.css
@@ -65,7 +65,8 @@
 	height: unset;
 	min-block-size: calc(var(--_MuiInput-block-size) - 2px); /* Accommodate for border width */
 	padding-block: 0;
-	padding-inline: var(--_MuiInput-padding-inline);
+	padding-inline-start: var(--_MuiInput-padding-inline);
+	padding-inline-end: var(--_MuiInput-padding-inline);
 	align-content: center;
 
 	&:where(input, textarea) {

--- a/packages/mui/src/~components/MuiTooltip.css
+++ b/packages/mui/src/~components/MuiTooltip.css
@@ -7,6 +7,9 @@
 	--✨border-width: 1px;
 	--✨margin: var(--stratakit-space-x05);
 
+	--✨padding-block: calc(var(--stratakit-space-x1) - var(--✨border-width));
+	--✨padding-inline: calc(var(--stratakit-space-x2) - var(--✨border-width));
+
 	@apply --typography("body-sm");
 	overflow-wrap: anywhere;
 	hyphens: auto;
@@ -17,8 +20,10 @@
 
 	border: var(--✨border-width) solid transparent;
 	border-radius: 4px;
-	padding-block: calc(var(--stratakit-space-x1) - var(--✨border-width));
-	padding-inline: calc(var(--stratakit-space-x2) - var(--✨border-width));
+	padding-block-start: var(--✨padding-block);
+	padding-block-end: var(--✨padding-block);
+	padding-inline-start: var(--✨padding-inline);
+	padding-inline-end: var(--✨padding-inline);
 	min-block-size: 1rem;
 	max-inline-size: 12.25rem;
 


### PR DESCRIPTION
### Changes

This PR fixes a strange issue in Safari, where it wasn't correctly computing shorthand declarations that were set to CSS variables. The web inspector was showing empty values for these declarations, though it was still working normally in most places. The one case where it wasn't working was in the docs embeds, where we use `revert-layer` (see #1240).

I haven't been able to figure out exactly why this is happening — it reminds me of the [substitution in shorthands](https://www.w3.org/TR/css-values-5/#substitution-in-shorthands) CSS quirk that was first brought to our attention in https://github.com/iTwin/appui/issues/893. Seeing as this issue doesn't happen in Chrome/Firefox, this is likely a bug in Safari (which I would like to report, but I haven't the time or energy to create a minimal repro and file a bug report). For now, we can at least work around it on our end by assigning the same CSS variable to the individual longhands.

Components changed:
- `Button`
- `Input` (and `Select`)
- `AppBar`
- `Chip`
- `Tooltip`

### Testing

[Deploy preview (docs)](https://stratakit.bentley.com/1468/docs/components/button/). I've tested this in Safari 26.

| Before | After |
| --- | --- |
| <img width="198" height="80" alt="screenshot showing a button with no padding" src="https://github.com/user-attachments/assets/a00e59e1-7a2d-4afa-96ee-9415c75f2c30" /> | <img width="206" height="88" alt="screenshot of the same button with correct padding" src="https://github.com/user-attachments/assets/6ad0d82a-5a4e-4d3a-b656-5bc2bc7d967c" /> |
| <img width="164" height="68" alt="Chip" src="https://github.com/user-attachments/assets/98ce7191-f339-41df-b241-0f71990c531e" /> | <img width="176" height="72" alt="Chip (fixed)" src="https://github.com/user-attachments/assets/dc135847-dd96-4cb7-878a-cf4b50c8dc84" /> |
| <img width="155" height="88" alt="Select" src="https://github.com/user-attachments/assets/18ff5037-0f0e-45bc-9680-8a94721814bf" /> | <img width="160" height="82" alt="Select (fixed)" src="https://github.com/user-attachments/assets/4d396041-7798-47cc-bbc2-9b2eaf8fbf6d" /> |

Clicked through all the docs pages, fixing the ones where I noticed this issue. Hopefully there aren't others.