### PR TITLE
fix `Rating` size in safari

### DIFF
--- a/.changeset/tough-flies-laugh.md
+++ b/.changeset/tough-flies-laugh.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `Rating` component collapsing to zero width in Safari.

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -59,3 +59,7 @@
 		text-underline-offset: var(--stratakit-space-x1);
 	}
 }
+
+.MuiRating-root {
+	inline-size: fit-content;
+}


### PR DESCRIPTION
### Changes

When working on #1468, I noticed the `Rating` component was literally not showing up in Safari (yes really).

The `width: min-content` declaration from stock MUI was collapsing this component to zero width. I've changed it to `fit-content`.

### Testing

| Before | After |
| --- | --- |
| <img width="180" height="61" alt="empty space" src="https://github.com/user-attachments/assets/831f41a6-15ad-42ee-8eb6-7c295faa6a2b" /> | <img width="170" height="67" alt="Rating component with all 5 stars visible" src="https://github.com/user-attachments/assets/bcf054b0-f03c-4c09-9db2-26b68e0d9a1e" /> |

[Deploy preview](https://stratakit.bentley.com/1469/mui#rating) (open it in Safari)