### PR TITLE
add checkmark to selected `MenuItem`

### DIFF
--- a/.changeset/ready-spiders-enter.md
+++ b/.changeset/ready-spiders-enter.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `MenuItem` styling to support `role="menuitemradio"` and `role="menuitemcheckbox"` with `aria-checked`.

--- a/apps/test-app/app/mui/Menu.showcase.tsx
+++ b/apps/test-app/app/mui/Menu.showcase.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import MenuDefault from "examples/mui/Menu.default.tsx";
 import MenuDense from "examples/mui/Menu.dense.tsx";
+import MenuSelectable from "examples/mui/Menu.selectable.tsx";
 import MenuListDefault_ from "examples/mui/MenuList._default.tsx";
 
 export default function MenuExamples() {
@@ -11,6 +12,7 @@ export default function MenuExamples() {
 		<>
 			<MenuDefault />
 			<MenuDense />
+			<MenuSelectable />
 			<MenuListDefault_ />
 		</>
 	);

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -23,3 +23,20 @@ Pass the [`dense`](https://mui.com/material-ui/api/list/#list-prop-dense) prop t
 The `dense` prop is also available via [`MenuList`](https://mui.com/material-ui/api/menu-list/).
 
 ::example{src="mui/Menu.dense"}
+
+## Selectable
+
+To make `MenuItem`s selectable, override the default `role` to either:
+
+- [`role="menuitemradio"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitemradio_role) when only one item within a group is selectable
+- [`role="menuitemcheckbox"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitemcheckbox_role) when the items are individually selectable.
+
+With the appropriate role in place, use [`aria-checked="true"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-checked) and the [`selected`](https://mui.com/material-ui/api/menu-item/#menu-item-prop-selected) prop to mark the selected item(s).
+
+::example{src="mui/Menu.selectable"}
+
+:::caution[Labelling the menu button]
+
+Make sure the triggering button starts with a predictable label that stays consistent regardless of the selected item. In the example above, the text "Sort by:" remains stable, while the text following it changes based on the selected item. This allows assistive technology users to easily find and operate the menu button.
+
+:::

--- a/apps/website/src/content/docs/components/stratakit/Toolbar.md
+++ b/apps/website/src/content/docs/components/stratakit/Toolbar.md
@@ -44,6 +44,6 @@ In the example below, one of the toolbar items is rendered as a [**ToggleButton*
 
 ### Menu
 
-In the example below, the toolbar item for selecting the font family is using a [**Menu**](/components/menu/). Menu items use [`role="menuitemradio"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitemradio_role), since only one font family can be selected at a time.
+In the example below, the toolbar item for selecting the font family is using a [**Menu**](/components/menu/). The `MenuItem`s are [selectable](/components/menu/#selectable) and use [`role="menuitemradio"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitemradio_role), since only one font family can be selected at a time.
 
 ::example{src="structures/Toolbar.menu" min-width="300px"}

--- a/examples/mui/Menu.selectable.tsx
+++ b/examples/mui/Menu.selectable.tsx
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Typography from "@mui/material/Typography";
+
+export default () => {
+	const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+	const open = Boolean(anchorEl);
+	const handleClose = () => setAnchorEl(null);
+
+	const mainLabelId = React.useId();
+
+	const [sortOrder, setSortOrder] = React.useState("Newest first");
+
+	return (
+		<>
+			<Button
+				id={mainLabelId}
+				aria-haspopup="true"
+				aria-expanded={open ? "true" : "false"}
+				onClick={(event) => setAnchorEl(event.currentTarget)}
+			>
+				<Typography color="textSecondary" id={mainLabelId}>
+					Sort by:
+				</Typography>
+				&nbsp;{sortOrder}
+			</Button>
+			<Menu
+				anchorEl={anchorEl}
+				open={open}
+				onClose={handleClose}
+				slotProps={{
+					list: {
+						"aria-labelledby": mainLabelId,
+					},
+				}}
+			>
+				<MenuItem
+					role="menuitemradio"
+					aria-checked={sortOrder === "Newest first" ? "true" : "false"}
+					onClick={() => setSortOrder("Newest first")}
+				>
+					Newest first
+				</MenuItem>
+				<MenuItem
+					role="menuitemradio"
+					aria-checked={sortOrder === "Oldest first" ? "true" : "false"}
+					onClick={() => setSortOrder("Oldest first")}
+				>
+					Oldest first
+				</MenuItem>
+				<MenuItem
+					role="menuitemradio"
+					aria-checked={sortOrder === "Most comments" ? "true" : "false"}
+					onClick={() => setSortOrder("Most comments")}
+				>
+					Most comments
+				</MenuItem>
+			</Menu>
+		</>
+	);
+};

--- a/examples/structures/Toolbar.menu.tsx
+++ b/examples/structures/Toolbar.menu.tsx
@@ -20,14 +20,11 @@ import svgCopy from "@stratakit/icons/copy.svg";
 export default () => {
 	const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 	const open = Boolean(anchorEl);
+	const closeMenu = () => setAnchorEl(null);
 
 	const [fontFamily, setFontFamily] = React.useState("Sans-serif");
 
 	const fontFamilyLabelId = React.useId();
-
-	const closeMenu = () => {
-		setAnchorEl(null);
-	};
 
 	return (
 		<Toolbar.Group variant="solid">
@@ -75,7 +72,7 @@ export default () => {
 				<MenuItem
 					role="menuitemradio"
 					selected={fontFamily === "Sans-serif"}
-					aria-checked={fontFamily === "Sans-serif"}
+					aria-checked={fontFamily === "Sans-serif" ? "true" : "false"}
 					onClick={() => {
 						setFontFamily("Sans-serif");
 						closeMenu();
@@ -86,7 +83,7 @@ export default () => {
 				<MenuItem
 					role="menuitemradio"
 					selected={fontFamily === "Serif"}
-					aria-checked={fontFamily === "Serif"}
+					aria-checked={fontFamily === "Serif" ? "true" : "false"}
 					onClick={() => {
 						setFontFamily("Serif");
 						closeMenu();
@@ -97,7 +94,7 @@ export default () => {
 				<MenuItem
 					role="menuitemradio"
 					selected={fontFamily === "Monospace"}
-					aria-checked={fontFamily === "Monospace"}
+					aria-checked={fontFamily === "Monospace" ? "true" : "false"}
 					onClick={() => {
 						setFontFamily("Monospace");
 						closeMenu();

--- a/packages/mui/src/~components/MuiMenu.css
+++ b/packages/mui/src/~components/MuiMenu.css
@@ -58,7 +58,7 @@
 		--_MuiMenuItem-height: var(--✨size--small);
 	}
 
-	&:where([role="option"]) {
+	&:where([role="option"], [role="menuitemradio"], [role="menuitemcheckbox"]) {
 		--_MuiMenuItem-root-mask-image: var(--✨svg-unchecked);
 
 		/* This pseudo-element displays a checkmark for selected menu items */
@@ -89,7 +89,7 @@
 		outline-offset: calc(var(--🥝focus-outline-offset) * -1);
 	}
 
-	&:where(.Mui-selected, [aria-selected="true"]) {
+	&:where(.Mui-selected, [aria-selected="true"], [aria-checked="true"]) {
 		--🥝Icon-color: var(--✨color-icon--selected);
 		--_MuiMenuItem-background-color: var(--✨color-bg--selected);
 		--_MuiMenuItem-color: var(--✨color-text--selected);


### PR DESCRIPTION
### Changes

This PR extends the `MenuItem` selected styling, which was first added in #1253.

In addition to `role="option"`, it will now properly support `role="menuitemradio"` and `role="menuitemcheckbox"`, with `aria-checked="true"` used in combination with the `selected` prop to mark selected items.

Added new docs section in the `Menu.md` page and updated the `Toolbar.md` page to cross-link.

### Testing

Verified that a checked `menuitemradio` (or `menuitemcheckbox`) appears correctly with the checkmark and is reflected in the accessibility tree.

[Deploy preview](https://stratakit.bentley.com/1471/mui#menu)
[Docs](https://stratakit.bentley.com/1471/docs/components/menu)