### PR TITLE
`Accordion` remnants

### DIFF
--- a/apps/website/src/content/docs/components/mui/Accordion.md
+++ b/apps/website/src/content/docs/components/mui/Accordion.md
@@ -12,25 +12,25 @@ links:
 
 Make sure the **Accordion** is suitable for your use case. There may be other, more appropriate components available.
 
-| Use case                                                                                                              | [Accordion](/components/accordion) | [Tree](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tree_role) | [Tabs](/components/tabs) | [Dialog](/components/dialog) |
-| --------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------- |
-| Progressive disclosure of content (single level of data)                                                              | ✅                                 | ❌                                                                                                | ❌                       | ❌                           |
-| One level of indentation possible at all times                                                                        | ✅                                 | ❌                                                                                                | ❌                       | ❌                           |
-| Expandable content varies from simple list items to more complex form components (such as text fields, buttons, etc.) | ✅                                 | ❌                                                                                                | ❌                       | ❌                           |
-| Progressive disclosure of content (several levels of data ). Folder drilling.                                         | ❌                                 | ✅                                                                                                | ❌                       | ❌                           |
-| Hierarchy can branch and isn't necessarily linear.                                                                    | ❌                                 | ✅                                                                                                | ❌                       | ❌                           |
-| Organizing long forms or sections.                                                                                    | ✅                                 | ❌                                                                                                | ❌                       | ❌                           |
-| Displaying metadata or form content                                                                                   | ✅                                 | ❌                                                                                                | ❌                       | ❌                           |
-| Switching between distinct views or content areas                                                                     | ❌                                 | ❌                                                                                                | ✅                       | ❌                           |
-| Temporary, interruptive content (e.g. confirmation, form)                                                             | ❌                                 | ❌                                                                                                | ❌                       | ✅                           |
-| Reordering sections                                                                                                   | ✅                                 | ❌                                                                                                | ❌                       | ❌                           |
+| Use case                                                                                                              | [Accordion](/components/accordion) | [Tree](/components/tree) | [Tabs](/components/tabs) | [Dialog](/components/dialog) |
+| --------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------ | ------------------------ | ---------------------------- |
+| Progressive disclosure of content (single level of data)                                                              | ✅                                 | ❌                       | ❌                       | ❌                           |
+| One level of indentation possible at all times                                                                        | ✅                                 | ❌                       | ❌                       | ❌                           |
+| Expandable content varies from simple list items to more complex form components (such as text fields, buttons, etc.) | ✅                                 | ❌                       | ❌                       | ❌                           |
+| Progressive disclosure of content (several levels of data ). Folder drilling.                                         | ❌                                 | ✅                       | ❌                       | ❌                           |
+| Hierarchy can branch and isn't necessarily linear.                                                                    | ❌                                 | ✅                       | ❌                       | ❌                           |
+| Organizing long forms or sections.                                                                                    | ✅                                 | ❌                       | ❌                       | ❌                           |
+| Displaying metadata or form content                                                                                   | ✅                                 | ❌                       | ❌                       | ❌                           |
+| Switching between distinct views or content areas                                                                     | ❌                                 | ❌                       | ✅                       | ❌                           |
+| Temporary, interruptive content (e.g. confirmation, form)                                                             | ❌                                 | ❌                       | ❌                       | ✅                           |
+| Reordering sections                                                                                                   | ✅                                 | ❌                       | ❌                       | ❌                           |
 
 ## StrataKit MUI modifications
 
 - Restyled using StrataKit's visual language.
 - The overall size has been decreased.
 - The default `disableGutters` is now `"true"`.
-- The `square` prop defaults to true except when `variant="outlined"`.
+- The `slotProps.root.square` prop defaults to true except when `variant="outlined"`.
 - You are not required to attribute `<AccordionSummary>` with `aria-controls`.
 - Removed [`role="region"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/region_role) semantics. The **Accordion** no longer creates a region landmark.
 - Includes full `forced-colors` support.

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -119,9 +119,9 @@ function createTheme() {
 					component: Role.div,
 					disableGutters: true,
 					slotProps: {
-						root({ variant }) {
+						root({ variant, square }) {
 							return {
-								square: variant !== "outlined" ? true : undefined, // Disable rounded corners on non-outlined variants
+								square: square ?? (variant !== "outlined" ? true : undefined), // Disable rounded corners on non-outlined variants
 							};
 						},
 						region: {


### PR DESCRIPTION
### Changes

Follow-up from https://github.com/iTwin/stratakit/pull/1454#discussion_r3204226154. This makes the `Accordion` respect the `square` prop if passed.

Docs updates:
- Clarifying `slotProps.root.square` over `square`.
- Changed `Tree` link to point to our docs.

### Testing

Tested that `<Accordion variant="outlined" square>` works correctly now.