### PR TITLE
Better `ToggleButton` examples

### DIFF
--- a/examples/mui/ToggleButton._placements.tsx
+++ b/examples/mui/ToggleButton._placements.tsx
@@ -7,15 +7,25 @@ import * as React from "react";
 import ToggleButton from "@mui/material/ToggleButton";
 import { Icon } from "@stratakit/mui";
 
-import svgPlaceholder from "@stratakit/icons/placeholder.svg";
+import svgArrowDown from "@stratakit/icons/arrow-down.svg";
+import svgArrowLeft from "@stratakit/icons/arrow-left.svg";
+import svgArrowRight from "@stratakit/icons/arrow-right.svg";
+import svgArrowUp from "@stratakit/icons/arrow-up.svg";
 
 type ToggleButtonProps = React.ComponentProps<typeof ToggleButton>;
 const placements = [
-	"top",
-	"right",
-	"bottom",
 	"left",
+	"top",
+	"bottom",
+	"right",
 ] as const satisfies ToggleButtonProps["labelPlacement"][];
+
+const iconByPlacement = {
+	left: svgArrowLeft,
+	top: svgArrowUp,
+	bottom: svgArrowDown,
+	right: svgArrowRight,
+} as const;
 
 export default () => {
 	const [selected, setSelected] = React.useState<string[]>([]);
@@ -34,7 +44,7 @@ export default () => {
 				)
 			}
 		>
-			<Icon href={svgPlaceholder} />
+			<Icon href={iconByPlacement[placement]} />
 		</ToggleButton>
 	));
 };

--- a/examples/mui/ToggleButton.default.tsx
+++ b/examples/mui/ToggleButton.default.tsx
@@ -8,30 +8,30 @@ import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import { Icon } from "@stratakit/mui";
 
-import svgTextAlignCenter from "@stratakit/icons/text-align-center.svg";
-import svgTextAlignJustify from "@stratakit/icons/text-align-justify.svg";
-import svgTextAlignLeft from "@stratakit/icons/text-align-left.svg";
-import svgTextAlignRight from "@stratakit/icons/text-align-right.svg";
+import svgBold from "@stratakit/icons/font-bold.svg";
+import svgItalic from "@stratakit/icons/font-italic.svg";
+import svgStrikethrough from "@stratakit/icons/font-strikethrough.svg";
+import svgUnderline from "@stratakit/icons/font-underline.svg";
 
 export default () => {
-	const [alignment, setAlignment] = React.useState(["center"]);
+	const [formats, setFormats] = React.useState(["bold"]);
 	return (
 		<ToggleButtonGroup
-			value={alignment}
-			onChange={(_, newAlignment) => setAlignment(newAlignment)}
-			aria-label="text alignment"
+			value={formats}
+			onChange={(_, newFormats) => setFormats(newFormats)}
+			aria-label="Text formatting"
 		>
-			<ToggleButton value="left" label="Left aligned">
-				<Icon href={svgTextAlignLeft} />
+			<ToggleButton value="bold" label="Bold">
+				<Icon href={svgBold} />
 			</ToggleButton>
-			<ToggleButton value="center" label="Centered">
-				<Icon href={svgTextAlignCenter} />
+			<ToggleButton value="italic" label="Italic">
+				<Icon href={svgItalic} />
 			</ToggleButton>
-			<ToggleButton value="right" label="Right aligned">
-				<Icon href={svgTextAlignRight} />
+			<ToggleButton value="underline" label="Underline">
+				<Icon href={svgUnderline} />
 			</ToggleButton>
-			<ToggleButton value="justify" label="Justified">
-				<Icon href={svgTextAlignJustify} />
+			<ToggleButton value="strikethrough" label="Strikethrough">
+				<Icon href={svgStrikethrough} />
 			</ToggleButton>
 		</ToggleButtonGroup>
 	);

--- a/examples/mui/ToggleButton.standalone.tsx
+++ b/examples/mui/ToggleButton.standalone.tsx
@@ -7,20 +7,20 @@ import * as React from "react";
 import ToggleButton from "@mui/material/ToggleButton";
 import { Icon } from "@stratakit/mui";
 
-import svgFontUnderline from "@stratakit/icons/font-underline.svg";
+import svgEdit from "@stratakit/icons/edit.svg";
 
 export default () => {
 	const [selected, setSelected] = React.useState(false);
 	return (
 		<ToggleButton
-			value="left"
-			label="Underlined"
+			value="edit"
+			label="Edit"
 			selected={selected}
 			onChange={() => {
 				setSelected((prev) => !prev);
 			}}
 		>
-			<Icon href={svgFontUnderline} />
+			<Icon href={svgEdit} />
 		</ToggleButton>
 	);
 };


### PR DESCRIPTION
### Changes

- `ToggleButton.default.tsx` allows for multiple buttons to be active, so **text alignment** (left, center, right, justified) didn't make sense.  Replaced with **text formatting** (bold, italic, underline, strikethrough).
- `ToggleButton.standalone.tsx` displayed **underline** which is typically not standalone.  Replaced with **edit** which was a usecase in our [iTwinUI information panel](https://itwin.github.io/iTwinUI/css/information-panel) examples.
- `ToggleButton._placements.tsx` tooltips would overlap adjacent buttons.  Reordered so tooltips never overlap and replaced placeholder icon with arrow icons.
	- This sample is not used in the docs, but hey, why not.

[**Deploy preview**](https://stratakit.bentley.com/1481/mui/#togglebutton) 👀

### Testing

n/a