### PR TITLE
`Chip` hover & disabled styling

### DIFF
--- a/.changeset/chilly-results-guess.md
+++ b/.changeset/chilly-results-guess.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added hover & disabled styling to `Chip`.

--- a/apps/test-app/app/mui/Chip.showcase.tsx
+++ b/apps/test-app/app/mui/Chip.showcase.tsx
@@ -30,6 +30,9 @@ export const knobs = {
 			MuiChip: {
 				disabled: true,
 			},
+			MuiIconButton: {
+				disabled: true,
+			},
 		},
 	}),
 };

--- a/apps/website/src/content/docs/components/mui/Chip.md
+++ b/apps/website/src/content/docs/components/mui/Chip.md
@@ -14,6 +14,8 @@ links:
 - The root element is no longer interactive. Instead, a deletable **Chip** now renders an interactive delete button, and a clickable **Chip** renders its label as an interactive button.
 - Added a `deleteLabel` prop to provide an accessible label for the delete button.
 - Replaced the icon used by deletable `Chip`.
+- Restyled using StrataKit's visual language.
+- Includes full `forced-colors` support.
 
 ## Examples
 

--- a/packages/mui/src/~components/MuiChip.css
+++ b/packages/mui/src/~components/MuiChip.css
@@ -65,7 +65,7 @@
 	&:where(.Mui-disabled) {
 		cursor: not-allowed;
 		opacity: 1;
-		pointer-events: initial;
+		pointer-events: auto; /* Revert MUI's disabled pointer-events */
 
 		--_MuiChip-border-color: var(--✨border--disabled);
 		--_MuiChip-text-color: var(--✨text--disabled);

--- a/packages/mui/src/~components/MuiChip.css
+++ b/packages/mui/src/~components/MuiChip.css
@@ -4,7 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 .MuiChip-root {
+	/* #region Variables */
+	--✨bg--filled-default: var(--stratakit-color-bg-neutral-base);
+	--✨bg--filled-disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
+	--✨bg--outlined-default: transparent;
+	--✨border--default: var(--stratakit-color-border-neutral-base);
+	--✨border--disabled: var(--stratakit-color-border-glow-on-surface-disabled);
+	--✨text--default: var(--stratakit-color-text-neutral-primary);
+	--✨text--disabled: var(--stratakit-color-text-neutral-disabled);
+	/* #endregion */
+
+	background-color: var(--_MuiChip-background-color);
 	block-size: var(--_MuiChip-block-size);
+	border: 1px solid var(--_MuiChip-border-color);
+	color: var(--_MuiChip-text-color);
+
+	--_MuiChip-border-color: var(--✨border--default);
+	--_MuiChip-text-color: var(--✨text--default);
 
 	&:where(.MuiChip-sizeSmall) {
 		--_MuiChip-block-size: var(--stratakit-size-control-field-height-small);
@@ -16,9 +32,26 @@
 		--_MuiChip-padding-inline: var(--stratakit-space-x3);
 	}
 
-	&:where(.MuiChip-filled.MuiChip-colorDefault) {
-		background-color: var(--stratakit-color-bg-neutral-base);
-		border: 1px solid var(--stratakit-color-border-neutral-base);
+	&:where(.MuiChip-filled) {
+		--_MuiChip-background-color: var(--✨bg--filled-default);
+	}
+
+	&:where(.MuiChip-outlined) {
+		--_MuiChip-background-color: var(--✨bg--outlined-default);
+	}
+
+	&:where(.MuiChip-clickable) {
+		transition: background-color 150ms ease-out;
+
+		@media (any-hover: hover) {
+			&:where(:not(.Mui-disabled):hover) {
+				background-color: color-mix(
+					in oklch,
+					var(--_MuiChip-background-color) 100%,
+					var(--stratakit-color-glow-hue) var(--stratakit-color-bg-glow-base-hover-\%)
+				);
+			}
+		}
 	}
 
 	&:where(.MuiButtonBase-root) {
@@ -27,6 +60,19 @@
 
 	&:where(:has(.MuiChip-label:focus-visible)) {
 		outline: var(--🥝focus-outline);
+	}
+
+	&:where(.Mui-disabled) {
+		cursor: not-allowed;
+		opacity: 1;
+		pointer-events: initial;
+
+		--_MuiChip-border-color: var(--✨border--disabled);
+		--_MuiChip-text-color: var(--✨text--disabled);
+
+		&:where(.MuiChip-filled) {
+			--_MuiChip-background-color: var(--✨bg--filled-disabled);
+		}
 	}
 }
 
@@ -45,6 +91,7 @@
 	&:where(button) {
 		/* Move the outline from the interactive label to the root element. */
 		outline: unset !important;
+		cursor: inherit;
 	}
 }
 

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -113,6 +113,13 @@
 	}
 }
 
+.MuiChip-root {
+	&:where(.Mui-disabled) {
+		border-color: GrayText;
+		color: GrayText;
+	}
+}
+
 .MuiDialog-paper {
 	border: 1px solid;
 }


### PR DESCRIPTION
### Changes

- Added hover styling when clickable.
- Added disabled styling. 
- Fix delete button not disabling when using knobs.
- Fix cursor on disabled + clickable state.
- Updated StrataKit modifications documentation.

[**Deploy preview**](https://stratakit.bentley.com/1482/mui/#chip) 👀

| Context | Before | After |
| -- | -- | -- |
| Light & disabled | <img width="500" height="420" alt="before-light-disabled" src="https://github.com/user-attachments/assets/28dbd377-5922-4dbd-96e2-da61ce1cfa0f" /> | <img width="500" height="420" alt="after-light-disabled" src="https://github.com/user-attachments/assets/e7d6c340-d658-40e5-9a09-61d2fd211eb2" /> |
| Dark & disabled | <img width="500" height="420" alt="before-dark-disabled" src="https://github.com/user-attachments/assets/2a8bb71b-e8fb-4093-ae29-43654deba5ba" /> | <img width="500" height="420" alt="after-dark-disabled" src="https://github.com/user-attachments/assets/2f4ce9e6-5009-4b54-a967-03283059bb66" /> |
| `forced-colors` & disabled | <img width="500" height="420" alt="before-forced-colors-disabled" src="https://github.com/user-attachments/assets/2c9bfe66-8c9d-4ca9-b973-6a35d3351338" /> | <img width="500" height="420" alt="after-forced-colors-disabled" src="https://github.com/user-attachments/assets/945c44d9-66e0-4e7c-8dc9-01c69fddeac7" /> | 

| Hover light | Hover dark |
| -- | -- |
| <img width="378" height="346" alt="hover-light" src="https://github.com/user-attachments/assets/bdc3c7f2-4d15-4cfd-be28-8ebf530e00bc" /> | <img width="378" height="346" alt="hover-dark" src="https://github.com/user-attachments/assets/38c8eaa9-cd48-4a27-bcbb-4e5358e6653b" /> |

### Testing

- Light, dark, forced-colors.
- Default, outlined.
- Hovered, disabled.
- With icon, with avatar.
	- Disabled chip with avatar could use some work.
<img width="319" height="107" alt="Screenshot 2026-05-21 at 3 45 49 PM" src="https://github.com/user-attachments/assets/5ff49b74-f29b-459a-a611-9fb581d27a94" />
<img width="269" height="107" alt="Screenshot 2026-05-21 at 3 46 13 PM" src="https://github.com/user-attachments/assets/9956d301-26af-4ccc-ae45-161273ecf90d" />

