### PR TITLE
`ThemeProvider`: disable localStorage and double rendering

### DIFF
--- a/.changeset/busy-news-kneel.md
+++ b/.changeset/busy-news-kneel.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Disabled transitions and double rendering in `ThemeProvider`.

--- a/.changeset/fast-poems-cross.md
+++ b/.changeset/fast-poems-cross.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Disabled the `storageManager` in `ThemeProvider`. The `colorScheme` must now be manually synchronized to `localStorage` if you want to persist it across sessions.

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -54,7 +54,13 @@ const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 
 	return (
 		<StyledEngineProvider>
-			<ThemeProvider theme={theme} defaultMode={colorScheme}>
+			<ThemeProvider
+				theme={theme}
+				defaultMode={colorScheme}
+				storageManager={null}
+				disableTransitionOnChange
+				noSsr
+			>
 				<ColorScheme colorScheme={colorScheme} />
 				<RootInner
 					{...rest}


### PR DESCRIPTION
### Changes

Disabled the following from `ThemeProvider`:

1. [Local storage synchronization](https://mui.com/material-ui/customization/dark-mode/#storage-manager). This creates redundancy/conflicts when the app has its own localStorage logic. (See [related comment](https://github.com/iTwin/stratakit/pull/1399#discussion_r3054176302))
2. [Double initial render](https://mui.com/material-ui/customization/dark-mode/#disable-double-rendering). This is not necessary with client-side rendering and can hurt performance.
3. [Transitions during theme changes](https://mui.com/material-ui/customization/dark-mode/#disable-transitions). This looks cheap unless done with care.

### Testing

Confirmed that the chosen color-scheme is still persisted in localStorage in both `test-app` ([preview](https://stratakit.bentley.com/1483/)) and `website` ([preview](https://stratakit.bentley.com/1483/docs)).