### PR TITLE
update format script

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -84,7 +84,7 @@ jobs:
       - run: pnpm install
 
       - name: Format code
-        run: pnpm prettier --write && pnpm format --write
+        run: pnpm format
 
       - name: Commit changes
         run: |

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
 		"build": "WIREIT_LOGGER=metrics pnpm --filter=\"./apps/**\" build",
 		"dev": "WIREIT_LOGGER=simple pnpm --filter=@stratakit/test-app dev",
 		"docs": "WIREIT_LOGGER=simple pnpm --filter=@stratakit/website dev",
-		"format": "biome format .",
+		"format": "pnpm format:biome && pnpm prettier --write",
+		"format:biome": "biome format . --write",
 		"lint": "biome check --error-on-warnings --formatter-enabled=false --linter-enabled=true .",
 		"lint:copyright": "tsx internal/copyright-linter.ts",
 		"prettier": "prettier . '!**/*.{js,jsx,ts,tsx,cjs,cts,mjs,mts,css,json,jsonc}' --check",
 		"test": "pnpm --filter=@stratakit/test-app --filter=internal test",
 		"changeset": "pnpx @changesets/cli@2.29.7",
-		"changeset:version": "pnpm run changeset version && pnpm format --write",
+		"changeset:version": "pnpm run changeset version && pnpm format",
 		"changeset:publish": "pnpm run build && pnpm run changeset publish"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### Changes

`pnpm format` will now run both biome and prettier with `--write` flags, making it easier to manually run the formatter. This is a follow-up to https://github.com/iTwin/stratakit/pull/1443#discussion_r3270075366.

### Testing

Confirmed that `pnpm format` works correctly, and that `pnpm prettier` flows are also unaffected.
