### PR TITLE
add `aria-current` to Breadcrumbs

### DIFF
--- a/apps/website/src/content/docs/components/mui/Breadcrumbs.md
+++ b/apps/website/src/content/docs/components/mui/Breadcrumbs.md
@@ -7,3 +7,7 @@ links:
 ---
 
 ::example{src="mui/Breadcrumbs.default"}
+
+## StrataKit MUI modifications
+
+- Updated the examples to use [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current) on the current breadcrumb for improved accessibility.

--- a/examples/mui/Breadcrumbs.default.tsx
+++ b/examples/mui/Breadcrumbs.default.tsx
@@ -12,7 +12,9 @@ export default () => {
 		<Breadcrumbs aria-label="breadcrumb">
 			<Link href="/">Home</Link>
 			<Link href="#packages">Packages</Link>
-			<Typography color="text.primary">@stratakit/mui</Typography>
+			<Typography render={<a />} aria-current="true" color="text.primary">
+				@stratakit/mui
+			</Typography>
 		</Breadcrumbs>
 	);
 };


### PR DESCRIPTION
### Changes

Just in time for [GAAD](https://accessibility.day/)!

Updated the Breadcrumbs example to use `<a aria-current="true">` instead of a generic `<p>` for the active item. Fixes #1227 

Documented it, even though there is no change within the component.

### Testing

Verified that "current" attribute is reflected in the accessibility tree and announced correctly by the following screen-reader/browser combinations:

- VoiceOver + Safari 26.0 on macOS (announced as _"current item"_)
- NVDA 2026.1 + Edge 147 on Windows 11 (announced as _"current"_)