### PR TITLE
expand more shorthands

### DIFF
--- a/packages/bricks/src/Badge.css
+++ b/packages/bricks/src/Badge.css
@@ -17,7 +17,8 @@
 		color: var(--🥝Badge-text-color);
 		font-weight: 500;
 		block-size: 1.25rem;
-		padding-inline: var(--stratakit-space-x1);
+		padding-inline-start: var(--stratakit-space-x1);
+		padding-inline-end: var(--stratakit-space-x1);
 	}
 
 	@layer modifiers {
@@ -139,7 +140,8 @@
 
 .🥝BadgeLabel {
 	@layer base {
-		margin-inline: var(--stratakit-space-x1);
+		margin-inline-start: var(--stratakit-space-x1);
+		margin-inline-end: var(--stratakit-space-x1);
 	}
 }
 

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -177,8 +177,10 @@
 
 		min-block-size: var(--✨height);
 		border-radius: 4px;
-		padding-inline: var(--🥝Button-padding-inline, var(--✨padding-inline));
-		padding-block: var(--✨padding-block);
+		padding-inline-start: var(--🥝Button-padding-inline, var(--✨padding-inline));
+		padding-inline-end: var(--🥝Button-padding-inline, var(--✨padding-inline));
+		padding-block-start: var(--✨padding-block);
+		padding-block-end: var(--✨padding-block);
 		--🥝GhostAligner-inline-offset: var(--✨padding-inline);
 		--🥝GhostAligner-block-offset: var(--✨padding-block);
 

--- a/packages/bricks/src/Divider.css
+++ b/packages/bricks/src/Divider.css
@@ -21,8 +21,10 @@
 			--🥝Divider-border-image-outset: 0 100cqi;
 
 			block-size: 1px;
-			margin-inline: var(--🥝Divider-main-axis-margin);
-			margin-block: var(--🥝Divider-cross-axis-margin);
+			margin-inline-start: var(--🥝Divider-main-axis-margin);
+			margin-inline-end: var(--🥝Divider-main-axis-margin);
+			margin-block-start: var(--🥝Divider-cross-axis-margin);
+			margin-block-end: var(--🥝Divider-cross-axis-margin);
 		}
 
 		&:where([aria-orientation="vertical"], [data-_sk-orientation="vertical"]) {
@@ -30,8 +32,10 @@
 
 			inline-size: 1px;
 			min-block-size: 100%;
-			margin-inline: var(--🥝Divider-cross-axis-margin);
-			margin-block: var(--🥝Divider-main-axis-margin);
+			margin-inline-start: var(--🥝Divider-cross-axis-margin);
+			margin-inline-end: var(--🥝Divider-cross-axis-margin);
+			margin-block-start: var(--🥝Divider-main-axis-margin);
+			margin-block-end: var(--🥝Divider-main-axis-margin);
 		}
 
 		&:where(:not([data-_sk-bleed="true"])) {

--- a/packages/bricks/src/Kbd.css
+++ b/packages/bricks/src/Kbd.css
@@ -24,7 +24,8 @@
 		&:where([data-_sk-variant="solid"], [data-_sk-variant="muted"]) {
 			border-radius: 4px;
 			background-color: var(--stratakit-color-bg-neutral-base);
-			padding-inline: var(--stratakit-space-x1);
+			padding-inline-start: var(--stratakit-space-x1);
+			padding-inline-end: var(--stratakit-space-x1);
 		}
 
 		&:where([data-_sk-variant="solid"]) {

--- a/packages/bricks/src/TextBox.css
+++ b/packages/bricks/src/TextBox.css
@@ -34,7 +34,8 @@
 		min-inline-size: 0;
 
 		min-block-size: var(--✨height);
-		padding-inline: var(--✨padding-inline);
+		padding-inline-start: var(--✨padding-inline);
+		padding-inline-end: var(--✨padding-inline);
 		border-radius: 4px;
 
 		background-color: var(--🥝TextBox-background-color);
@@ -108,7 +109,8 @@
 			min-inline-size: 0;
 			border: 1px solid var(--🥝TextBox-border-color);
 			cursor: var(--🥝TextBox-cursor);
-			padding-block: var(--✨padding-block);
+			padding-block-start: var(--✨padding-block);
+			padding-block-end: var(--✨padding-block);
 
 			&::placeholder {
 				color: var(--✨color--placeholder);

--- a/packages/mui/src/~components/MuiAlert.css
+++ b/packages/mui/src/~components/MuiAlert.css
@@ -5,7 +5,8 @@
 
 .MuiAlert-root {
 	border: 1px solid var(--stratakit-color-border-neutral-base);
-	padding-block: var(--stratakit-space-x3);
+	padding-block-start: var(--stratakit-space-x3);
+	padding-block-end: var(--stratakit-space-x3);
 
 	&:where(.MuiAlert-outlined) {
 		background-color: var(--stratakit-color-bg-elevation-base);

--- a/packages/mui/src/~components/MuiAutocomplete.css
+++ b/packages/mui/src/~components/MuiAutocomplete.css
@@ -25,7 +25,8 @@
 }
 
 .MuiAutocomplete-tag:is(.MuiChip-root) {
-	margin-block: var(--stratakit-space-x05);
+	margin-block-start: var(--stratakit-space-x05);
+	margin-block-end: var(--stratakit-space-x05);
 	margin-inline: 0; /* Now relying on `column-gap` */
 }
 

--- a/packages/mui/src/~components/MuiDialog.css
+++ b/packages/mui/src/~components/MuiDialog.css
@@ -19,7 +19,9 @@
 	border-end-start-radius: inherit;
 
 	&:where(.MuiDialogActions-spacing) {
-		padding-block: var(--stratakit-space-x4);
-		padding-inline: var(--stratakit-space-x5);
+		padding-block-start: var(--stratakit-space-x4);
+		padding-block-end: var(--stratakit-space-x4);
+		padding-inline-start: var(--stratakit-space-x5);
+		padding-inline-end: var(--stratakit-space-x5);
 	}
 }

--- a/packages/mui/src/~components/MuiList.css
+++ b/packages/mui/src/~components/MuiList.css
@@ -5,7 +5,8 @@
 
 .MuiList-root {
 	&:where(.MuiList-padding) {
-		padding-block: var(--stratakit-space-x1);
+		padding-block-start: var(--stratakit-space-x1);
+		padding-block-end: var(--stratakit-space-x1);
 	}
 }
 
@@ -21,8 +22,10 @@
 	border-block: 1px solid transparent;
 	margin-block-end: -1px; /* prevent double border */
 
-	padding-block: var(--stratakit-space-x1);
-	padding-inline: var(--stratakit-space-x3);
+	padding-block-start: var(--stratakit-space-x1);
+	padding-block-end: var(--stratakit-space-x1);
+	padding-inline-start: var(--stratakit-space-x3);
+	padding-inline-end: var(--stratakit-space-x3);
 	gap: var(--stratakit-space-x2);
 
 	:where(.MuiList-root.MuiList-dense) & {

--- a/packages/mui/src/~components/MuiMenu.css
+++ b/packages/mui/src/~components/MuiMenu.css
@@ -46,7 +46,8 @@
 	column-gap: calc(var(--stratakit-space-x1) + var(--stratakit-space-x05));
 	min-block-size: var(--_MuiMenuItem-height);
 	padding-block: 0;
-	padding-inline: var(--✨padding);
+	padding-inline-start: var(--✨padding);
+	padding-inline-end: var(--✨padding);
 
 	--🥝Icon-color: var(--✨color-icon--default);
 	--_MuiMenuItem-background-color: var(--✨color-bg--default);

--- a/packages/mui/src/~components/MuiTable.css
+++ b/packages/mui/src/~components/MuiTable.css
@@ -36,13 +36,15 @@
 .MuiTableCell-root {
 	&:where(.MuiTableCell-sizeMedium) {
 		block-size: 3rem;
-		padding-block: var(--stratakit-space-x2);
+		padding-block-start: var(--stratakit-space-x2);
+		padding-block-end: var(--stratakit-space-x2);
 		padding-inline-start: var(--stratakit-space-x4);
 		padding-inline-end: var(--stratakit-space-x3);
 	}
 
 	&:where(.MuiTableCell-paddingCheckbox) {
-		padding-inline: var(--stratakit-space-x4);
+		padding-inline-start: var(--stratakit-space-x4);
+		padding-inline-end: var(--stratakit-space-x4);
 		text-align: center;
 	}
 }

--- a/packages/structures/src/AccordionItem.css
+++ b/packages/structures/src/AccordionItem.css
@@ -138,7 +138,8 @@
 	@layer base {
 		grid-row: content;
 		grid-column: body-content;
-		padding-block: var(--🥝AccordionItem-padding);
+		padding-block-start: var(--🥝AccordionItem-padding);
+		padding-block-end: var(--🥝AccordionItem-padding);
 		text-box: cap alphabetic;
 		color: var(--stratakit-color-text-neutral-secondary);
 	}

--- a/packages/structures/src/Chip.css
+++ b/packages/structures/src/Chip.css
@@ -11,7 +11,8 @@
 		position: relative;
 
 		--🥝Chip-padding-inline: var(--stratakit-space-x2);
-		padding-inline: var(--🥝Chip-padding-inline);
+		padding-inline-start: var(--🥝Chip-padding-inline);
+		padding-inline-end: var(--🥝Chip-padding-inline);
 
 		min-block-size: 1.5rem;
 

--- a/packages/structures/src/Dialog.css
+++ b/packages/structures/src/Dialog.css
@@ -56,8 +56,10 @@
 	--✨padding-inline: var(--stratakit-space-x5);
 
 	@layer base {
-		padding-block: var(--✨padding-block);
-		padding-inline: var(--✨padding-inline);
+		padding-block-start: var(--✨padding-block);
+		padding-block-end: var(--✨padding-block);
+		padding-inline-start: var(--✨padding-inline);
+		padding-inline-end: var(--✨padding-inline);
 
 		display: flex;
 		align-items: center;
@@ -79,7 +81,8 @@
 		color: var(--stratakit-color-text-neutral-primary);
 
 		padding-block-end: var(--✨padding);
-		padding-inline: var(--✨padding);
+		padding-inline-start: var(--✨padding);
+		padding-inline-end: var(--✨padding);
 	}
 
 	@layer modifiers {
@@ -100,8 +103,10 @@
 		border-end-end-radius: var(--✨border-radius);
 		background-color: var(--stratakit-color-bg-page-base);
 
-		padding-inline: var(--✨padding);
-		padding-block: var(--✨padding);
+		padding-inline-start: var(--✨padding);
+		padding-inline-end: var(--✨padding);
+		padding-block-start: var(--✨padding);
+		padding-block-end: var(--✨padding);
 
 		display: flex;
 		align-items: center;

--- a/packages/structures/src/DropdownMenu.css
+++ b/packages/structures/src/DropdownMenu.css
@@ -86,7 +86,8 @@
 			color: var(--✨divider-color);
 			block-size: var(--✨divider-thickness);
 			border-image: var(--✨divider-border-image);
-			margin-block: var(--✨divider-spacing);
+			margin-block-start: var(--✨divider-spacing);
+			margin-block-end: var(--✨divider-spacing);
 		}
 
 		/* Removes redundant dividers from the very first/last group and between adjacent groups */
@@ -112,7 +113,8 @@
 	--✨height: 1.75rem;
 
 	@layer base {
-		padding-inline: var(--✨padding-inline);
+		padding-inline-start: var(--✨padding-inline);
+		padding-inline-end: var(--✨padding-inline);
 		color: var(--✨color);
 		font-weight: 500;
 

--- a/packages/structures/src/ErrorRegion.css
+++ b/packages/structures/src/ErrorRegion.css
@@ -17,8 +17,10 @@
 		}
 
 		&:where([data-_sk-visible="true"]) {
-			padding-inline: var(--✨padding);
-			padding-block: var(--✨padding);
+			padding-inline-start: var(--✨padding);
+			padding-inline-end: var(--✨padding);
+			padding-block-start: var(--✨padding);
+			padding-block-end: var(--✨padding);
 
 			block-size: 2.625rem;
 		}
@@ -154,7 +156,8 @@
 		display: flex;
 		flex-direction: column;
 
-		padding-block: var(--✨padding-block);
+		padding-block-start: var(--✨padding-block);
+		padding-block-end: var(--✨padding-block);
 		padding-inline-start: var(--✨padding-inline-start);
 		padding-inline-end: var(--stratakit-space-x1);
 

--- a/packages/structures/src/NavigationList.css
+++ b/packages/structures/src/NavigationList.css
@@ -26,6 +26,7 @@
 .🥝NavigationListItemAction {
 	--✨height--default: 2rem;
 	--✨padding-inline: var(--stratakit-space-x2);
+	--✨padding-block: var(--stratakit-space-x1);
 
 	--✨bg--default: transparent;
 	--✨bg--hover: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
@@ -50,9 +51,11 @@
 
 		inline-size: stretch;
 		min-block-size: var(--✨height--default);
-		padding-inline: var(--✨padding-inline);
 		border-radius: 4px;
-		padding-block: var(--stratakit-space-x1);
+		padding-inline-start: var(--✨padding-inline);
+		padding-inline-end: var(--✨padding-inline);
+		padding-block-start: var(--✨padding-block);
+		padding-block-end: var(--✨padding-block);
 
 		font-size: var(--stratakit-font-size-12);
 		line-height: 1.2;

--- a/packages/structures/src/NavigationRail.css
+++ b/packages/structures/src/NavigationRail.css
@@ -37,8 +37,10 @@
 		display: flex;
 		align-items: center;
 
-		padding-block: var(--stratakit-space-x2);
-		padding-inline: var(--stratakit-space-x4);
+		padding-block-start: var(--stratakit-space-x2);
+		padding-block-end: var(--stratakit-space-x2);
+		padding-inline-start: var(--stratakit-space-x4);
+		padding-inline-end: var(--stratakit-space-x4);
 		min-block-size: var(--✨header-height);
 	}
 }
@@ -95,8 +97,10 @@
 
 .🥝NavigationRailContent {
 	@layer base {
-		padding-block: var(--stratakit-space-x1);
-		padding-inline: var(--stratakit-space-x2);
+		padding-block-start: var(--stratakit-space-x1);
+		padding-block-end: var(--stratakit-space-x1);
+		padding-inline-start: var(--stratakit-space-x2);
+		padding-inline-end: var(--stratakit-space-x2);
 
 		flex: 999;
 		overflow: auto;

--- a/packages/structures/src/Table.css
+++ b/packages/structures/src/Table.css
@@ -37,7 +37,8 @@
 
 	@layer base {
 		min-block-size: var(--✨cell-height-min);
-		padding-block: var(--✨cell-padding-block);
+		padding-block-start: var(--✨cell-padding-block);
+		padding-block-end: var(--✨cell-padding-block);
 		padding-inline-start: var(--✨cell-padding-inline-start);
 		padding-inline-end: var(--✨cell-padding-inline-end);
 		overflow-wrap: anywhere;

--- a/packages/structures/src/Tabs.css
+++ b/packages/structures/src/Tabs.css
@@ -67,7 +67,8 @@
 		border: none;
 		border-radius: 4px;
 		block-size: var(--✨height);
-		padding-inline: var(--🥝Tab-padding-inline);
+		padding-inline-start: var(--🥝Tab-padding-inline);
+		padding-inline-end: var(--🥝Tab-padding-inline);
 		position: relative;
 		user-select: none;
 		white-space: nowrap;

--- a/packages/structures/src/~utils.ListItem.css
+++ b/packages/structures/src/~utils.ListItem.css
@@ -33,7 +33,8 @@
 			decoration-after-start] auto [decoration-after-end];
 
 		min-block-size: var(--🥝ListItem-height, var(--✨height--default));
-		padding-inline: var(--✨padding-inline);
+		padding-inline-start: var(--✨padding-inline);
+		padding-inline-end: var(--✨padding-inline);
 		background-color: var(--🥝ListItem-background-color);
 
 		--🥝ListItem-background-color: var(--🌀ListItem-state--default, var(--✨bg--default))
@@ -115,7 +116,8 @@
 
 		:where(.🥝ListItemContent) ~ & {
 			grid-column: decoration-after;
-			margin-inline: var(--✨gap) 0;
+			margin-inline-start: var(--✨gap);
+			margin-inline-end: 0;
 		}
 	}
 }


### PR DESCRIPTION
### Changes

Follow-up to https://github.com/iTwin/stratakit/pull/1468.

This expands all instances of `padding-block`, `padding-inline`, `margin-block` and `margin-inline` shorthands that use CSS variables, across all packages.

### Testing

Confirmed this fixes the issue noted in https://github.com/iTwin/stratakit/pull/1446#issuecomment-4519453092, but I don't know how feasible it is to keep avoiding shorthands in the long term. We should find some time to report the Safari bug.