### PR TITLE
Fix `FormControlLabel` `labelPlacement` when `top` or `bottom`

### DIFF
--- a/.changeset/dull-waves-open.md
+++ b/.changeset/dull-waves-open.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `FormControlLabel` layout when `labelPlacement` is `top` or `bottom`.

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -8,15 +8,11 @@
 }
 
 .MuiFormControlLabel-root {
+	gap: var(--stratakit-space-x1);
 	margin-inline: 0;
 
 	&:where(.MuiFormControlLabel-labelPlacementTop, .MuiFormControlLabel-labelPlacementBottom) {
 		align-items: start;
-		row-gap: var(--stratakit-space-x1);
-	}
-
-	&:where(.MuiFormControlLabel-labelPlacementStart, .MuiFormControlLabel-labelPlacementEnd) {
-		column-gap: var(--stratakit-space-x1);
 	}
 
 	&:where(.Mui-disabled) {

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -31,7 +31,6 @@
 .MuiFormGroup-root {
 	/* Accounts for the increased tap target of the checkbox/radio */
 	row-gap: var(--stratakit-space-x1);
-	align-self: start;
 }
 
 .MuiFormHelperText-root {

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -8,9 +8,16 @@
 }
 
 .MuiFormControlLabel-root {
-	/* Accounts for the increased tap target of the checkbox/radio */
-	column-gap: var(--stratakit-space-x1);
 	margin-inline: 0;
+
+	&:where(.MuiFormControlLabel-labelPlacementTop, .MuiFormControlLabel-labelPlacementBottom) {
+		align-items: start;
+		row-gap: var(--stratakit-space-x1);
+	}
+
+	&:where(.MuiFormControlLabel-labelPlacementStart, .MuiFormControlLabel-labelPlacementEnd) {
+		column-gap: var(--stratakit-space-x1);
+	}
 
 	&:where(.Mui-disabled) {
 		cursor: not-allowed;
@@ -24,6 +31,7 @@
 .MuiFormGroup-root {
 	/* Accounts for the increased tap target of the checkbox/radio */
 	row-gap: var(--stratakit-space-x1);
+	align-self: start;
 }
 
 .MuiFormHelperText-root {


### PR DESCRIPTION
### Changes

- Fix `FormControlLabel` `labelPlacement` when `top` or `bottom`.  Alignment was incorrect and gap was missing.

| Before | After |
| -- | -- |
| <img width="537" height="295" alt="Screenshot 2026-05-22 at 11 19 40 AM" src="https://github.com/user-attachments/assets/4429df0a-3983-442c-bad0-59194e92ca9a" /> | <img width="537" height="295" alt="Screenshot 2026-05-22 at 11 19 50 AM" src="https://github.com/user-attachments/assets/432e3a01-0aea-47b3-b65a-3f514347163d" /> |

### Testing

- Applied pink background so I could see all areas this effects (`Checkbox`, `Radio`, `Switch`).
