### PR TITLE
automatically label `Menu` and `Popover`

### DIFF
--- a/.changeset/strong-needles-fetch.md
+++ b/.changeset/strong-needles-fetch.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added fallback mechanism for automatically labelling `Menu` using `anchorEl`.

--- a/.changeset/strong-needles-fetch.md
+++ b/.changeset/strong-needles-fetch.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-Added fallback mechanism for automatically labelling `Menu` using `anchorEl`.
+Added fallback mechanism for automatically labelling `Menu` and `Popover` components using `anchorEl`.

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -12,6 +12,7 @@ links:
 
 - Restyled using StrataKit's visual language.
 - Removed [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) semantics from the [`paper`](https://mui.com/material-ui/api/menu/#Menu-css-MuiMenu-paper) slot.
+- Added fallback mechanism for automatically labelling the [`list`](https://mui.com/material-ui/api/menu/#Menu-css-MuiMenu-list) slot using the trigger element (`anchorEl`).
 - Includes full `forced-colors` support.
 - `disableScrollLock` is used to prevent scroll locking when the menu is open.
 

--- a/apps/website/src/content/docs/components/mui/Popover.md
+++ b/apps/website/src/content/docs/components/mui/Popover.md
@@ -10,13 +10,14 @@ links:
 
 ## StrataKit MUI modifications
 
-- Added [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) to the `paper` slot.
+- Added [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) to the [`paper`](https://mui.com/material-ui/api/popover/#Popover-css-MuiPopover-paper) slot.
+- Added fallback mechanism for automatically labelling the `paper` slot using the trigger element (`anchorEl`).
 - `disableScrollLock` is used to prevent scroll locking when the popover is open.
 
 ## ✅ Do
 
-- [Label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role#labeling) the **Popover's** `paper` slot using an `aria-labelledby` attribute pointing to a heading inside the popover or the trigger element's `id`.
+- Consider [labelling](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role#labeling) the **Popover's** `paper` slot using an `aria-labelledby` attribute pointing to a heading inside the popover.
 
 ## 🚫 Don't
 
-- Don't forget to provide an accessible [label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role#labeling)
+- Don't forget to validate that the **Popover** has an appropriate accessible [label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role#labeling).

--- a/examples/mui/Card.menu.tsx
+++ b/examples/mui/Card.menu.tsx
@@ -57,29 +57,17 @@ function ActionsMenu() {
 	const open = Boolean(anchorEl);
 	const handleClose = () => setAnchorEl(null);
 
-	const buttonId = React.useId();
-
 	return (
 		<>
 			<IconButton
 				label="More actions"
-				id={buttonId}
 				aria-haspopup="true"
 				aria-expanded={open ? "true" : "false"}
 				onClick={(event) => setAnchorEl(event.currentTarget)}
 			>
 				<Icon href={svgMore} />
 			</IconButton>
-			<Menu
-				anchorEl={anchorEl}
-				open={open}
-				onClose={handleClose}
-				slotProps={{
-					list: {
-						"aria-labelledby": buttonId,
-					},
-				}}
-			>
+			<Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
 				<MenuItem onClick={handleClose}>Favorite</MenuItem>
 				<MenuItem onClick={handleClose}>Delete</MenuItem>
 			</Menu>

--- a/examples/mui/Menu.default.tsx
+++ b/examples/mui/Menu.default.tsx
@@ -15,28 +15,16 @@ export default () => {
 		setAnchorEl(null);
 	};
 
-	const buttonId = React.useId();
-
 	return (
 		<>
 			<Button
-				id={buttonId}
 				aria-haspopup="true"
 				aria-expanded={open ? "true" : "false"}
 				onClick={(event) => setAnchorEl(event.currentTarget)}
 			>
 				User actions
 			</Button>
-			<Menu
-				anchorEl={anchorEl}
-				open={open}
-				onClose={handleClose}
-				slotProps={{
-					list: {
-						"aria-labelledby": buttonId,
-					},
-				}}
-			>
+			<Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
 				<MenuItem onClick={handleClose}>Profile</MenuItem>
 				<MenuItem onClick={handleClose}>My account</MenuItem>
 				<MenuItem onClick={handleClose}>Logout</MenuItem>

--- a/examples/mui/Menu.dense.tsx
+++ b/examples/mui/Menu.dense.tsx
@@ -15,12 +15,9 @@ export default () => {
 		setAnchorEl(null);
 	};
 
-	const buttonId = React.useId();
-
 	return (
 		<>
 			<Button
-				id={buttonId}
 				aria-haspopup="true"
 				aria-expanded={open ? "true" : "false"}
 				onClick={(event) => setAnchorEl(event.currentTarget)}
@@ -34,7 +31,6 @@ export default () => {
 				onClose={handleClose}
 				slotProps={{
 					list: {
-						"aria-labelledby": buttonId,
 						dense: true,
 					},
 				}}

--- a/examples/mui/Menu.selectable.tsx
+++ b/examples/mui/Menu.selectable.tsx
@@ -21,7 +21,6 @@ export default () => {
 	return (
 		<>
 			<Button
-				id={mainLabelId}
 				aria-haspopup="true"
 				aria-expanded={open ? "true" : "false"}
 				onClick={(event) => setAnchorEl(event.currentTarget)}

--- a/examples/mui/Popover.default.tsx
+++ b/examples/mui/Popover.default.tsx
@@ -14,11 +14,10 @@ export default () => {
 		null,
 	);
 	const [open, setOpen] = React.useState(false);
-	const buttonId = React.useId();
+
 	return (
 		<>
 			<Button
-				id={buttonId}
 				aria-haspopup="dialog"
 				aria-expanded={open}
 				onClick={() => setOpen(true)}
@@ -37,9 +36,6 @@ export default () => {
 				slotProps={{
 					paper: {
 						className: styles.popover,
-						// note that the paper slot gets role="dialog" from the theme, so labelling by the button
-						// ensures that the dialog is labeled by the button text
-						"aria-labelledby": buttonId,
 					},
 				}}
 			>

--- a/packages/mui/src/~components/MuiMenu.tsx
+++ b/packages/mui/src/~components/MuiMenu.tsx
@@ -3,12 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import * as React from "react";
 import MenuList from "@mui/material/MenuList";
 import {
 	forwardRef,
 	useMergedRefs,
 } from "@stratakit/foundations/secret-internals";
+import { useFallbackLabel } from "./MuiPopover.js";
 
 import type { MenuOwnerState } from "@mui/material/Menu";
 import type { MenuListProps } from "@mui/material/MenuList";
@@ -21,34 +21,10 @@ interface MuiMenuListSlotProps extends MenuListProps {
 
 const MuiMenuListSlot = forwardRef<"ul", MuiMenuListSlotProps>(
 	(props, forwardedRef) => {
-		const {
-			"aria-label": ariaLabel,
-			"aria-labelledby": ariaLabelledBy,
-			ownerState = {},
-		} = props;
-
-		const addFallbackLabel = React.useCallback(
-			(element?: HTMLElement) => {
-				if (!element || !(ownerState.anchorEl instanceof HTMLElement)) return;
-				if (
-					ariaLabel ||
-					ariaLabelledBy ||
-					element.ariaLabel ||
-					element.ariaLabelledByElements?.length
-				) {
-					return;
-				}
-
-				// Use the trigger button as the fallback accessible name for the menu.
-				element.ariaLabelledByElements = [ownerState.anchorEl];
-			},
-			[ownerState.anchorEl, ariaLabel, ariaLabelledBy],
-		);
-
 		return (
 			<MenuList
 				{...props}
-				ref={useMergedRefs(forwardedRef, addFallbackLabel)}
+				ref={useMergedRefs(forwardedRef, useFallbackLabel(props))}
 			/>
 		);
 	},

--- a/packages/mui/src/~components/MuiMenu.tsx
+++ b/packages/mui/src/~components/MuiMenu.tsx
@@ -21,22 +21,28 @@ interface MuiMenuListSlotProps extends MenuListProps {
 
 const MuiMenuListSlot = forwardRef<"ul", MuiMenuListSlotProps>(
 	(props, forwardedRef) => {
-		const { anchorEl } = props.ownerState || {};
+		const {
+			"aria-label": ariaLabel,
+			"aria-labelledby": ariaLabelledBy,
+			ownerState = {},
+		} = props;
 
 		const addFallbackLabel = React.useCallback(
 			(element?: HTMLElement) => {
-				if (!element || !(anchorEl instanceof HTMLElement)) return;
+				if (!element || !(ownerState.anchorEl instanceof HTMLElement)) return;
 				if (
-					element.getAttribute("aria-labelledby") != null ||
-					element.getAttribute("aria-label") != null
+					ariaLabel ||
+					ariaLabelledBy ||
+					element.ariaLabel ||
+					element.ariaLabelledByElements?.length
 				) {
 					return;
 				}
 
 				// Use the trigger button as the fallback accessible name for the menu.
-				element.ariaLabelledByElements = [anchorEl];
+				element.ariaLabelledByElements = [ownerState.anchorEl];
 			},
-			[anchorEl],
+			[ownerState.anchorEl, ariaLabel, ariaLabelledBy],
 		);
 
 		return (

--- a/packages/mui/src/~components/MuiMenu.tsx
+++ b/packages/mui/src/~components/MuiMenu.tsx
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import MenuList from "@mui/material/MenuList";
+import {
+	forwardRef,
+	useMergedRefs,
+} from "@stratakit/foundations/secret-internals";
+
+import type { MenuOwnerState } from "@mui/material/Menu";
+import type { MenuListProps } from "@mui/material/MenuList";
+
+// ----------------------------------------------------------------------------
+
+interface MuiMenuListSlotProps extends MenuListProps {
+	ownerState?: Pick<MenuOwnerState, "anchorEl">;
+}
+
+const MuiMenuListSlot = forwardRef<"ul", MuiMenuListSlotProps>(
+	(props, forwardedRef) => {
+		const { anchorEl } = props.ownerState || {};
+
+		const addFallbackLabel = React.useCallback(
+			(element?: HTMLElement) => {
+				if (!element || !(anchorEl instanceof HTMLElement)) return;
+				if (
+					element.getAttribute("aria-labelledby") != null ||
+					element.getAttribute("aria-label") != null
+				) {
+					return;
+				}
+
+				// Use the trigger button as the fallback accessible name for the menu.
+				element.ariaLabelledByElements = [anchorEl];
+			},
+			[anchorEl],
+		);
+
+		return (
+			<MenuList
+				{...props}
+				ref={useMergedRefs(forwardedRef, addFallbackLabel)}
+			/>
+		);
+	},
+);
+DEV: MuiMenuListSlot.displayName = "MuiMenuListSlot";
+
+// ----------------------------------------------------------------------------
+
+export { MuiMenuListSlot };

--- a/packages/mui/src/~components/MuiPopover.tsx
+++ b/packages/mui/src/~components/MuiPopover.tsx
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { PopoverPaper } from "@mui/material/Popover";
+import {
+	forwardRef,
+	useMergedRefs,
+} from "@stratakit/foundations/secret-internals";
+
+import type { PopoverOwnerState } from "@mui/material/Popover";
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+/** Returns a callback ref that sets a fallback value for `ariaLabelledByElements` using `ownerState.anchorEl`. */
+export function useFallbackLabel(
+	props: Pick<
+		MuiPopoverPaperSlotProps,
+		"aria-label" | "aria-labelledby" | "ownerState"
+	>,
+) {
+	const {
+		"aria-label": ariaLabel,
+		"aria-labelledby": ariaLabelledBy,
+		ownerState = {},
+	} = props;
+
+	return React.useCallback(
+		(element?: HTMLElement) => {
+			if (!element || !(ownerState.anchorEl instanceof HTMLElement)) return;
+			if (
+				ariaLabel ||
+				ariaLabelledBy ||
+				element.ariaLabel ||
+				element.ariaLabelledByElements?.length
+			) {
+				return;
+			}
+
+			// Use the trigger button as the fallback accessible name for the popover.
+			element.ariaLabelledByElements = [ownerState.anchorEl];
+		},
+		[ownerState.anchorEl, ariaLabel, ariaLabelledBy],
+	);
+}
+
+// ----------------------------------------------------------------------------
+
+interface MuiPopoverPaperSlotProps extends BaseProps {
+	ownerState?: Pick<PopoverOwnerState, "anchorEl">;
+}
+
+const MuiPopoverPaperSlot = forwardRef<"div", MuiPopoverPaperSlotProps>(
+	(props, forwardedRef) => {
+		return (
+			<PopoverPaper
+				{...props}
+				ref={useMergedRefs(forwardedRef, useFallbackLabel(props))}
+			/>
+		);
+	},
+);
+DEV: MuiPopoverPaperSlot.displayName = "MuiPopoverPaperSlot";
+
+// ----------------------------------------------------------------------------
+
+export { MuiPopoverPaperSlot };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -30,6 +30,7 @@ import { MuiDivider } from "./~components/MuiDivider.js";
 import { MuiIconButton } from "./~components/MuiIconButton.js";
 import { MuiInputLabel } from "./~components/MuiInputLabel.js";
 import { MuiMenuListSlot } from "./~components/MuiMenu.js";
+import { MuiPopoverPaperSlot } from "./~components/MuiPopover.js";
 import { MuiSnackbar } from "./~components/MuiSnackbar.js";
 import { MuiStepIcon } from "./~components/MuiStepper.js";
 import {
@@ -412,7 +413,12 @@ function createTheme() {
 				defaultProps: {
 					component: Role.div,
 					disableScrollLock: true,
-					slotProps: { paper: { role: "dialog" } },
+					slots: {
+						paper: MuiPopoverPaperSlot,
+					},
+					slotProps: {
+						paper: { role: "dialog" },
+					},
 				},
 			},
 			MuiRadio: {

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -29,6 +29,7 @@ import {
 import { MuiDivider } from "./~components/MuiDivider.js";
 import { MuiIconButton } from "./~components/MuiIconButton.js";
 import { MuiInputLabel } from "./~components/MuiInputLabel.js";
+import { MuiMenuListSlot } from "./~components/MuiMenu.js";
 import { MuiSnackbar } from "./~components/MuiSnackbar.js";
 import { MuiStepIcon } from "./~components/MuiStepper.js";
 import {
@@ -374,6 +375,9 @@ function createTheme() {
 			MuiMenu: {
 				defaultProps: {
 					component: Role.div,
+					slots: {
+						list: MuiMenuListSlot,
+					},
 					slotProps: {
 						paper: {
 							role: "presentation", // Removes role="dialog"


### PR DESCRIPTION
### Changes

This PR implements a fallback mechanism for automatically labelling the `Menu` and `Popover` components using the trigger element.

- `Menu`: [`list`](https://mui.com/material-ui/api/menu/#Menu-css-MuiMenu-list) slot is automatically labelled by the element passed into the `anchorEl` prop.
- `Paper`: [`paper`](https://mui.com/material-ui/api/popover/#Popover-css-MuiPopover-paper) slot is automatically labelled by the element passed into the `anchorEl` prop.

This only takes effect when when an existing label (e.g. `aria-label` or `aria-labelledby`) is not already set.

---

As a result, the basic usage is simplified:
- For the Menu,  `slotProps.list["aria-labelledby"]` does not need to be set in most cases, and the trigger button does not need a generated `id`. There are still some cases where explicit labelling is useful, such as in the selectable Menu (#1471).
- For the Popover, it would still be more appropriate to label it using a heading inside the Popover, so I've kept the existing documentation.

---

#### Implementation details/findings:

- [`ariaLabelledByElements`](https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaLabelledByElements) property is used, because it doesn't require an `id` to be set on the `<button>`.
- A callback `ref` is used because React doesn't support `ariaLabelledByElements` directly as a prop.
- `slots.list`/`slots.paper` has access to `ownerState` and is preferred over the functional form of `slotProps.list`/`slotProps.paper` to avoid issues with merging. (see [thread](https://github.com/iTwin/stratakit/pull/1492#discussion_r3303877013))

### Testing

Confirmed that all `Menu` and `Popover` examples continue to have their accessible names unchanged.
- The examples that were updated correctly use the fallback.
- The examples that still set explicitly `aria-labelledby` take priority over the fallback.

Tested in:
- VoiceOver on macOS 26.0 with Edge and Safari.
- NVDA 2026.1 with Edge and Firefox.
  - Note: NVDA is inconsistent; similar to the findings in https://github.com/iTwin/stratakit/pull/1464#issuecomment-4392187810.