### PR TITLE
disallow `underline` prop in `Link`

### DIFF
--- a/.changeset/bright-radios-warn.md
+++ b/.changeset/bright-radios-warn.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Improved styling for static `Link`.

--- a/.changeset/heavy-rice-fail.md
+++ b/.changeset/heavy-rice-fail.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Removed support for `underline` line from `Link`.

--- a/.changeset/heavy-rice-fail.md
+++ b/.changeset/heavy-rice-fail.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Removed support for `underline` line from `Link`.
+Removed support for `underline` prop from `Link`.

--- a/apps/website/src/content/docs/components/mui/Link.md
+++ b/apps/website/src/content/docs/components/mui/Link.md
@@ -8,6 +8,11 @@ links:
 
 ::example{src="mui/Link.default"}
 
+## StrataKit MUI modifications
+
+- Restyled using StrataKit's visual language.
+- The `underline` prop is not supported. Links are always underlined.
+
 ## Use cases
 
 Make sure the **Link** is suitable for your use case. There may be other, more appropriate components available.

--- a/examples/mui/Breadcrumbs.default.tsx
+++ b/examples/mui/Breadcrumbs.default.tsx
@@ -5,16 +5,15 @@
 
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Link from "@mui/material/Link";
-import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
 		<Breadcrumbs aria-label="breadcrumb">
 			<Link href="/">Home</Link>
 			<Link href="#packages">Packages</Link>
-			<Typography render={<a />} aria-current="true" color="text.primary">
+			<Link aria-current="true" color="textSecondary">
 				@stratakit/mui
-			</Typography>
+			</Link>
 		</Breadcrumbs>
 	);
 };

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -286,6 +286,13 @@ declare module "@mui/material/InputBase" {
 	}
 }
 
+declare module "@mui/material/Link" {
+	interface LinkOwnProps {
+		/** @deprecated DO NOT USE */
+		underline?: "none" | "hover" | "always";
+	}
+}
+
 declare module "@mui/material/ListItemButton" {
 	interface ListItemButtonOwnProps {
 		LinkComponent?: never;

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -21,6 +21,7 @@
 @import "./~components/MuiForm.css";
 @import "./~components/MuiIconButton.css";
 @import "./~components/MuiInput.css";
+@import "./~components/MuiLink.css";
 @import "./~components/MuiList.css";
 @import "./~components/MuiMenu.css";
 @import "./~components/MuiPagination.css";
@@ -44,17 +45,6 @@
 .MuiBackdrop-root {
 	&:where(:not(.MuiBackdrop-invisible)) {
 		background-color: oklch(from var(--stratakit-color-bg-elevation-overlay) l c h / 0.8);
-	}
-}
-
-.MuiLink-root {
-	font-weight: 500;
-	text-decoration-color: currentColor;
-	text-underline-offset: var(--stratakit-space-x05);
-	transition: text-underline-offset 150ms ease-out;
-
-	&:where(:hover, :focus-visible) {
-		text-underline-offset: var(--stratakit-space-x1);
 	}
 }
 

--- a/packages/mui/src/~components/MuiLink.css
+++ b/packages/mui/src/~components/MuiLink.css
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiLink-root {
+	font-weight: 500;
+	text-decoration-color: currentColor;
+	text-underline-offset: var(--stratakit-space-x05);
+	transition: text-underline-offset 150ms ease-out;
+
+	&:where(:hover, :focus-visible) {
+		text-underline-offset: var(--stratakit-space-x1);
+	}
+}

--- a/packages/mui/src/~components/MuiLink.css
+++ b/packages/mui/src/~components/MuiLink.css
@@ -6,6 +6,7 @@
 .MuiLink-root {
 	font-weight: 500;
 	text-decoration-color: currentColor;
+	text-decoration-line: underline;
 	text-underline-offset: var(--stratakit-space-x05);
 	transition: text-underline-offset 150ms ease-out;
 

--- a/packages/mui/src/~components/MuiLink.css
+++ b/packages/mui/src/~components/MuiLink.css
@@ -9,6 +9,10 @@
 	text-underline-offset: var(--stratakit-space-x05);
 	transition: text-underline-offset 150ms ease-out;
 
+	&:where(a:not(:any-link)) {
+		text-decoration-line: none; /* Remove underline from static anchors */
+	}
+
 	&:where(:hover, :focus-visible) {
 		text-underline-offset: var(--stratakit-space-x1);
 	}


### PR DESCRIPTION
### Changes

Three commits best reviewed separately.
1. Moved CSS into separate file.
2. Improved styling for `<Link>` without `href`. (from [#1488]( https://github.com/iTwin/stratakit/pull/1488#discussion_r3285047464))
3. Removed support for `underline` prop. Links should always be underlined.
    - Marked as `@deprecated` in types (unfortunately can't remove the prop altogether).

### Testing

Confirmed `Link` appearance and behavior is correct (including for the static `Link` in the Breacrumbs example).

Confirmed `underline` prop shows the deprecation note in IDE.