### PR TITLE
`Card` cleanup

### DIFF
--- a/.changeset/tough-beans-heal.md
+++ b/.changeset/tough-beans-heal.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `Card` ignoring the `role` prop.

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -69,10 +69,6 @@
 	}
 }
 
-.MuiCardActionArea-focusHighlight {
-	display: none;
-}
-
 .MuiCardActions-root {
 	padding: var(--stratakit-space-x4);
 }

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -27,7 +27,6 @@ const MuiCardContext = React.createContext<
 
 const MuiCard = forwardRef<"article", BaseProps<"article">>(
 	(props, forwardedRef) => {
-		const { role, ...rest } = props;
 		const [actionAreaElement, setActionAreaElement] = React.useState<
 			HTMLElement | undefined | null
 		>(undefined);
@@ -53,7 +52,7 @@ const MuiCard = forwardRef<"article", BaseProps<"article">>(
 			>
 				<Role
 					render={<article />}
-					{...rest}
+					{...props}
 					data-_sk-actionable={actionAreaElement ? "" : undefined}
 					onClick={useEventHandlers(props.onClick, handleActionAreaClick)}
 					ref={forwardedRef as React.Ref<HTMLDivElement>}
@@ -68,13 +67,11 @@ DEV: MuiCard.displayName = "MuiCard";
 
 const MuiCardActionArea = forwardRef<"button", BaseProps<"button">>(
 	(props, forwardedRef) => {
-		const { role, ...rest } = props;
-
 		const context = React.useContext(MuiCardContext);
 
 		return (
 			<MuiButtonBase
-				{...rest}
+				{...props}
 				ref={useMergedRefs(context?.setActionAreaElement, forwardedRef)}
 			/>
 		);

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -253,7 +253,12 @@ function createTheme() {
 				},
 			},
 			MuiCard: { defaultProps: { component: MuiCard } },
-			MuiCardActionArea: { defaultProps: { component: MuiCardActionArea } },
+			MuiCardActionArea: {
+				defaultProps: {
+					component: MuiCardActionArea,
+					slots: { focusHighlight: Nothing },
+				},
+			},
 			MuiCardContent: { defaultProps: { component: Role.div } },
 			MuiCardHeader: {
 				defaultProps: {


### PR DESCRIPTION
### Changes

two small changes to `Card` and `CardActionArea`:

- removed `focusHighlight` element
- fixed `role` prop being ignored

### Testing

N/A