### PR TITLE
disable scroll lock for non-modal popups

### DIFF
--- a/.changeset/frank-pens-dance.md
+++ b/.changeset/frank-pens-dance.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Disabled scroll lock for `Popover`, `Menu` and `Select` components so that the page can still be scrolled when the popup is open.

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -13,6 +13,7 @@ links:
 - Restyled using StrataKit's visual language.
 - Removed [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) semantics from the [`paper`](https://mui.com/material-ui/api/menu/#Menu-css-MuiMenu-paper) slot.
 - Includes full `forced-colors` support.
+- `disableScrollLock` is used to prevent scroll locking when the menu is open.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Popover.md
+++ b/apps/website/src/content/docs/components/mui/Popover.md
@@ -11,6 +11,7 @@ links:
 ## StrataKit MUI modifications
 
 - Added [`role="dialog"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) to the `paper` slot.
+- `disableScrollLock` is used to prevent scroll locking when the popover is open.
 
 ## ✅ Do
 

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -402,6 +402,7 @@ function createTheme() {
 			MuiPopover: {
 				defaultProps: {
 					component: Role.div,
+					disableScrollLock: true,
 					slotProps: { paper: { role: "dialog" } },
 				},
 			},


### PR DESCRIPTION
### Changes

Changed Popover's [`disableScrollLock`](https://mui.com/material-ui/api/popover/#popover-prop-disableScrollLock) to true, to prevent scroll locking. This is inherited by Menu and Select as well.

Since non-modal components don't make the rest of the page inert, there is no strong reason to lock scrolling. 

### Testing

Verified that:
- Non-modal popups (Autocomplete, Menu, Popover, Select) don't lock scroll.
- Modal components (Dialog, Drawer) continue to lock scroll.