### PR TITLE
Prevent `FormControlLabel` from stretching unnecessarily

### DIFF
--- a/.changeset/slimy-pets-hide.md
+++ b/.changeset/slimy-pets-hide.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Prevented `FormControlLabel` from stretching unnecessarily.

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -27,6 +27,7 @@
 .MuiFormGroup-root {
 	/* Accounts for the increased tap target of the checkbox/radio */
 	row-gap: var(--stratakit-space-x1);
+	align-self: start;
 }
 
 .MuiFormHelperText-root {


### PR DESCRIPTION
### Changes

Extracted from #1491 discussed in https://github.com/iTwin/stratakit/pull/1491#discussion_r3290110733.

@mayank99 mentioned:
> Cross-linking https://github.com/iTwin/stratakit/issues/601 and https://github.com/iTwin/stratakit/pull/798 where we've discussed similar concerns.

- Change the labels so they don't stretch to the extreme.  Discussed this with @LadyMoonanBentley.  Pink background applied to make the touch target area obvious.

| Before | What I originally planned | What @LadyMoonanBentley and I landed on |
| -- | -- | -- |
| <img width="717" height="303" alt="Screenshot 2026-05-22 at 11 20 43 AM" src="https://github.com/user-attachments/assets/3675a00a-1aba-4989-8152-49f5917db38d" /> | <img width="717" height="303" alt="Screenshot 2026-05-22 at 11 20 53 AM" src="https://github.com/user-attachments/assets/f0a1f1ba-d4d8-4eb0-ba01-f89798cfad98" /> | <img width="717" height="303" alt="Screenshot 2026-05-22 at 11 21 53 AM" src="https://github.com/user-attachments/assets/bfdbd53a-ddd3-4308-ad6e-23cc2194119c" /> |

### Testing

- Applied pink background so I could see all areas this effects (`Checkbox`, `Radio`, `Switch`).
