### PR TITLE
use `slots` instead of `slotProps` in `Accordion`

### DIFF
--- a/.changeset/loose-adults-tell.md
+++ b/.changeset/loose-adults-tell.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `Accordion` to use `slots.root` instead of `slotProps.root` for setting the default value of the `square` prop.

--- a/apps/website/src/content/docs/components/mui/Accordion.md
+++ b/apps/website/src/content/docs/components/mui/Accordion.md
@@ -32,7 +32,7 @@ Make sure the **Accordion** is suitable for your use case. There may be other, m
 - Added [responsive design](#responsive-design) that reorients the marker placement based on container width.
 - Added `markerPlacement` prop to override responsive design and force the [marker placement](#marker-placement).
 - The default `disableGutters` is now `"true"`.
-- The `slotProps.root.square` prop defaults to true except when `variant="outlined"`.
+- The default value of the `root` slot's [`square`](https://mui.com/material-ui/api/paper/#paper-prop-square) prop defaults to true except when `variant="outlined"`.
 - You are not required to attribute `<AccordionSummary>` with `aria-controls`.
 - Removed [`role="region"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/region_role) semantics. The **Accordion** no longer creates a region landmark.
 - Includes full `forced-colors` support.

--- a/packages/mui/src/~components/MuiAccordion.css
+++ b/packages/mui/src/~components/MuiAccordion.css
@@ -10,6 +10,7 @@
 	background-color: transparent;
 	border-color: var(--stratakit-color-border-neutral-muted);
 	border-radius: var(--_MuiAccordion-border-radius);
+	overflow-anchor: none; /* Prevent scroll jump with exclusive accordions */
 
 	&:where(.MuiPaper-rounded) {
 		--_MuiAccordion-border-radius: 8px;

--- a/packages/mui/src/~components/MuiAccordion.tsx
+++ b/packages/mui/src/~components/MuiAccordion.tsx
@@ -4,10 +4,33 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
+import Paper from "@mui/material/Paper";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 
+import type { AccordionOwnerState } from "@mui/material/Accordion";
 import type { AccordionSummaryOwnProps } from "@mui/material/AccordionSummary";
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+interface MuiAccordionRootSlotProps extends BaseProps {
+	ownerState?: AccordionOwnerState;
+}
+
+const MuiAccordionRootSlot = forwardRef<"div", MuiAccordionRootSlotProps>(
+	(props, forwardedRef) => {
+		const { square, variant } = props.ownerState || {};
+
+		return (
+			<Paper
+				{...props}
+				square={square ?? variant !== "outlined"} // Disable rounded corners on non-outlined variants
+				ref={forwardedRef}
+			/>
+		);
+	},
+);
+DEV: MuiAccordionRootSlot.displayName = "MuiAccordionRootSlot";
 
 // ----------------------------------------------------------------------------
 
@@ -33,4 +56,4 @@ DEV: MuiAccordionSummary.displayName = "MuiAccordionSummary";
 
 // ----------------------------------------------------------------------------
 
-export { MuiAccordionSummary };
+export { MuiAccordionRootSlot, MuiAccordionSummary };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -9,7 +9,10 @@ import OutlinedInput from "@mui/material/OutlinedInput";
 import StepConnector from "@mui/material/StepConnector";
 import { createTheme as createMuiTheme } from "@mui/material/styles";
 import cx from "classnames";
-import { MuiAccordionSummary } from "./~components/MuiAccordionSummary.js";
+import {
+	MuiAccordionRootSlot,
+	MuiAccordionSummary,
+} from "./~components/MuiAccordion.js";
 import { MuiAlert, MuiAlertTitle } from "./~components/MuiAlert.js";
 import { MuiAutocomplete } from "./~components/MuiAutocomplete.js";
 import { MuiAvatarGroup } from "./~components/MuiAvatarGroup.js";
@@ -120,12 +123,10 @@ function createTheme() {
 				defaultProps: {
 					component: Role.div,
 					disableGutters: true,
+					slots: {
+						root: MuiAccordionRootSlot,
+					},
 					slotProps: {
-						root({ variant, square }) {
-							return {
-								square: square ?? (variant !== "outlined" ? true : undefined), // Disable rounded corners on non-outlined variants
-							};
-						},
 						region: {
 							role: undefined,
 							"aria-labelledby": undefined,


### PR DESCRIPTION
### Changes

This replaces the Accordion's handling of `slotProps.root.square` (from #1454 and #1479) with `slots.root` in order to avoid issues with merging of `slotProps` as described in https://github.com/iTwin/stratakit/pull/1492#discussion_r3304468275.

Had to also add missing `overflow-anchor: none` which was lost after overriding the slot. See https://github.com/iTwin/stratakit/pull/1498#issuecomment-4555132319.

### Testing

Confirmed that existing behavior is unchanged, _and_ that additionally passing `slotProps.root` does not break the `square` logic.