### PR TITLE
add fallback support for `CardActionArea` wrapping the title

### DIFF
--- a/.changeset/easy-ads-agree.md
+++ b/.changeset/easy-ads-agree.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added fallback handling for when `CardActionArea` is rendered as an ancestor of the `CardHeader` title.

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -21,9 +21,6 @@ const MuiCardContext = React.createContext<
 	| {
 			actionAreaElement?: HTMLElement | null;
 			setActionAreaElement: (element?: HTMLElement | null) => void;
-
-			titleElement?: HTMLElement | null;
-			setTitleElement: (element?: HTMLElement | null) => void;
 	  }
 	| undefined
 >(undefined);
@@ -33,9 +30,6 @@ const MuiCardContext = React.createContext<
 const MuiCard = forwardRef<"article", BaseProps<"article">>(
 	(props, forwardedRef) => {
 		const [actionAreaElement, setActionAreaElement] = React.useState<
-			HTMLElement | undefined | null
-		>(undefined);
-		const [titleElement, setTitleElement] = React.useState<
 			HTMLElement | undefined | null
 		>(undefined);
 
@@ -56,12 +50,7 @@ const MuiCard = forwardRef<"article", BaseProps<"article">>(
 
 		return (
 			<MuiCardContext.Provider
-				value={{
-					actionAreaElement,
-					setActionAreaElement,
-					titleElement,
-					setTitleElement,
-				}}
+				value={{ actionAreaElement, setActionAreaElement }}
 			>
 				<Role
 					render={<article />}
@@ -81,28 +70,24 @@ DEV: MuiCard.displayName = "MuiCard";
 const MuiCardHeaderTitle = forwardRef<"h2", BaseProps<"h2">>(
 	(props, forwardedRef) => {
 		const cardContext = React.useContext(MuiCardContext);
-		const { registerActionAreaTitle } =
-			React.useContext(MuiCardActionAreaContext) ?? {};
-		const isInsideActionArea = Boolean(registerActionAreaTitle);
+		const cardActionAreaContext = React.useContext(MuiCardActionAreaContext);
 
 		const { children, ...rest } = props;
-
-		React.useInsertionEffect(() => {
-			return registerActionAreaTitle?.();
-		}, [registerActionAreaTitle]);
 
 		return (
 			<Role.h2
 				{...rest}
-				ref={useMergedRefs(cardContext?.setTitleElement, forwardedRef)}
+				ref={useMergedRefs(
+					cardActionAreaContext?.setTitleElement,
+					forwardedRef,
+				)}
 			>
 				{(() => {
-					// If CardActionArea is an ancestor of the title, then we portal the title text into the CardActionArea's button element.
-					if (isInsideActionArea && cardContext?.actionAreaElement) {
-						return ReactDOM.createPortal(
-							children,
-							cardContext.actionAreaElement,
-						);
+					// If CardActionArea is an ancestor of the title, then we portal the title content into the CardActionArea's button element.
+					if (cardActionAreaContext) {
+						return cardContext?.actionAreaElement
+							? ReactDOM.createPortal(children, cardContext.actionAreaElement)
+							: null;
 					}
 					return children;
 				})()}
@@ -115,47 +100,31 @@ DEV: MuiCardHeaderTitle.displayName = "MuiCardHeaderTitle";
 // ----------------------------------------------------------------------------
 
 const MuiCardActionAreaContext = React.createContext<
-	{ registerActionAreaTitle: () => () => void } | undefined
+	{ setTitleElement: (element?: HTMLElement | null) => void } | undefined
 >(undefined);
 
 const MuiCardActionArea = forwardRef<"button", BaseProps<"button">>(
 	(props, forwardedRef) => {
-		const cardContext = React.useContext(MuiCardContext);
-
 		const { children, ...rest } = props;
 
-		const [containsTitle, setContainsTitle] = React.useState<
-			boolean | undefined
+		// This gets populated by a descendant CardHeaderTitle
+		const [titleElement, setTitleElement] = React.useState<
+			HTMLElement | undefined | null
 		>(undefined);
 
-		React.useInsertionEffect(() => {
-			// Set it to false if it isn't already set (by CardHeaderTitle)
-			setContainsTitle((containsTitle) => containsTitle ?? false);
-		}, []);
-
-		const registerActionAreaTitle = React.useCallback(() => {
-			setContainsTitle(true);
-			return () => setContainsTitle(false);
-		}, []);
-
 		return (
-			<MuiCardActionAreaContext.Provider value={{ registerActionAreaTitle }}>
+			<MuiCardActionAreaContext.Provider value={{ setTitleElement }}>
 				{(() => {
-					if (containsTitle === undefined) {
-						return children;
-					}
-
 					// If the CardActionArea is rendered as an ancestor of the title, then we portal the button element into the title element.
 					// This helps avoids potential accessibility issues (e.g. nested buttons, such as when using CardHeader's `action` prop).
-					if (containsTitle) {
+					if (titleElement) {
 						return (
 							<>
 								{children}
-								{cardContext?.titleElement &&
-									ReactDOM.createPortal(
-										<MuiCardActionAreaButton {...rest} ref={forwardedRef} />,
-										cardContext.titleElement,
-									)}
+								{ReactDOM.createPortal(
+									<MuiCardActionAreaButton {...rest} ref={forwardedRef} />,
+									titleElement,
+								)}
 							</>
 						);
 					}

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -4,14 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import { Role } from "@ariakit/react/role";
 import {
-	type BaseProps,
 	forwardRef,
 	useEventHandlers,
 	useMergedRefs,
 } from "@stratakit/foundations/secret-internals";
 import { MuiButtonBase } from "./MuiButtonBase.js";
+
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
 // ----------------------------------------------------------------------------
 
@@ -19,6 +21,9 @@ const MuiCardContext = React.createContext<
 	| {
 			actionAreaElement?: HTMLElement | null;
 			setActionAreaElement: (element?: HTMLElement | null) => void;
+
+			titleElement?: HTMLElement | null;
+			setTitleElement: (element?: HTMLElement | null) => void;
 	  }
 	| undefined
 >(undefined);
@@ -28,6 +33,9 @@ const MuiCardContext = React.createContext<
 const MuiCard = forwardRef<"article", BaseProps<"article">>(
 	(props, forwardedRef) => {
 		const [actionAreaElement, setActionAreaElement] = React.useState<
+			HTMLElement | undefined | null
+		>(undefined);
+		const [titleElement, setTitleElement] = React.useState<
 			HTMLElement | undefined | null
 		>(undefined);
 
@@ -48,7 +56,12 @@ const MuiCard = forwardRef<"article", BaseProps<"article">>(
 
 		return (
 			<MuiCardContext.Provider
-				value={{ actionAreaElement, setActionAreaElement }}
+				value={{
+					actionAreaElement,
+					setActionAreaElement,
+					titleElement,
+					setTitleElement,
+				}}
 			>
 				<Role
 					render={<article />}
@@ -65,19 +78,113 @@ DEV: MuiCard.displayName = "MuiCard";
 
 // ----------------------------------------------------------------------------
 
-const MuiCardActionArea = forwardRef<"button", BaseProps<"button">>(
+const MuiCardHeaderTitle = forwardRef<"h2", BaseProps<"h2">>(
 	(props, forwardedRef) => {
-		const context = React.useContext(MuiCardContext);
+		const cardContext = React.useContext(MuiCardContext);
+		const { registerActionAreaTitle } =
+			React.useContext(MuiCardActionAreaContext) ?? {};
+		const isInsideActionArea = Boolean(registerActionAreaTitle);
+
+		const { children, ...rest } = props;
+
+		React.useInsertionEffect(() => {
+			return registerActionAreaTitle?.();
+		}, [registerActionAreaTitle]);
 
 		return (
-			<MuiButtonBase
-				{...props}
-				ref={useMergedRefs(context?.setActionAreaElement, forwardedRef)}
-			/>
+			<Role.h2
+				{...rest}
+				ref={useMergedRefs(cardContext?.setTitleElement, forwardedRef)}
+			>
+				{(() => {
+					// If CardActionArea is an ancestor of the title, then we portal the title text into the CardActionArea's button element.
+					if (isInsideActionArea && cardContext?.actionAreaElement) {
+						return ReactDOM.createPortal(
+							children,
+							cardContext.actionAreaElement,
+						);
+					}
+					return children;
+				})()}
+			</Role.h2>
+		);
+	},
+);
+DEV: MuiCardHeaderTitle.displayName = "MuiCardHeaderTitle";
+
+// ----------------------------------------------------------------------------
+
+const MuiCardActionAreaContext = React.createContext<
+	{ registerActionAreaTitle: () => () => void } | undefined
+>(undefined);
+
+const MuiCardActionArea = forwardRef<"button", BaseProps<"button">>(
+	(props, forwardedRef) => {
+		const cardContext = React.useContext(MuiCardContext);
+
+		const { children, ...rest } = props;
+
+		const [containsTitle, setContainsTitle] = React.useState<
+			boolean | undefined
+		>(undefined);
+
+		React.useInsertionEffect(() => {
+			// Set it to false if it isn't already set (by CardHeaderTitle)
+			setContainsTitle((containsTitle) => containsTitle ?? false);
+		}, []);
+
+		const registerActionAreaTitle = React.useCallback(() => {
+			setContainsTitle(true);
+			return () => setContainsTitle(false);
+		}, []);
+
+		return (
+			<MuiCardActionAreaContext.Provider value={{ registerActionAreaTitle }}>
+				{(() => {
+					if (containsTitle === undefined) {
+						return children;
+					}
+
+					// If the CardActionArea is rendered as an ancestor of the title, then we portal the button element into the title element.
+					// This helps avoids potential accessibility issues (e.g. nested buttons, such as when using CardHeader's `action` prop).
+					if (containsTitle) {
+						return (
+							<>
+								{children}
+								{cardContext?.titleElement &&
+									ReactDOM.createPortal(
+										<MuiCardActionAreaButton {...rest} ref={forwardedRef} />,
+										cardContext.titleElement,
+									)}
+							</>
+						);
+					}
+
+					return (
+						<MuiCardActionAreaButton {...rest} ref={forwardedRef}>
+							{children}
+						</MuiCardActionAreaButton>
+					);
+				})()}
+			</MuiCardActionAreaContext.Provider>
 		);
 	},
 );
 DEV: MuiCardActionArea.displayName = "MuiCardActionArea";
+
+const MuiCardActionAreaButton = forwardRef<"button", BaseProps<"button">>(
+	(props, forwardedRef) => {
+		const cardContext = React.useContext(MuiCardContext);
+
+		return (
+			<MuiButtonBase
+				{...props}
+				ref={useMergedRefs(cardContext?.setActionAreaElement, forwardedRef)}
+			/>
+		);
+	},
+);
+DEV: MuiCardActionAreaButton.displayName = "MuiCardActionAreaButton";
 
 // ----------------------------------------------------------------------------
 
@@ -138,4 +245,4 @@ DEV: MuiCardMedia.displayName = "MuiCardMedia";
 
 // ----------------------------------------------------------------------------
 
-export { MuiCard, MuiCardActionArea, MuiCardMedia };
+export { MuiCard, MuiCardActionArea, MuiCardHeaderTitle, MuiCardMedia };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -27,6 +27,7 @@ import { MuiButtonBase } from "./~components/MuiButtonBase.js";
 import {
 	MuiCard,
 	MuiCardActionArea,
+	MuiCardHeaderTitle,
 	MuiCardMedia,
 } from "./~components/MuiCard.js";
 import {
@@ -277,7 +278,7 @@ function createTheme() {
 					slotProps: {
 						title: {
 							// biome-ignore lint/suspicious/noExplicitAny: MUI's CardHeader.title.component is hardcoded to "span"
-							component: Role.h2 as any,
+							component: MuiCardHeaderTitle as any,
 						},
 					},
 				},


### PR DESCRIPTION
### Changes

This addresses https://github.com/iTwin/stratakit/pull/1289#discussion_r3138868859, making the `CardActionArea` support more cases and preventing invalid a11y patterns (e.g. long accessible name or nested interactive elements).

In short, when the `CardActionArea` is rendered as an ancestor of `CardHeader`'s `title`, this change ensures that the actual button is still placed _inside_ the title.

This is achieved by first detecting the nesting pattern using React Context and then using two portals:
1. The CardActionArea's `<button>` is portaled into the title element (`<h2>`).
2. The title content (text node) is portaled into the portaled `<button>`.

**Note:** This is only a _fallback/safeguard_ mechanism; the docs will continue to recommend the approach from https://github.com/iTwin/stratakit/pull/1274, where `CardActionArea` is manually rendered inside the title.

### Testing

Verified that both of these patterns produce the same markup (actionArea remains inside the h2):

```jsx
<Card>
  <CardHeader
    title={<CardActionArea>…</CardActionArea>}
    action={<button>…</button>}
  />
</Card>
```

```jsx
<Card>
  <CardActionArea>
    <CardHeader title={…} action={<button>…</button>} />
  </CardActionArea>
</Card>
```

(previously the second pattern would lead to nested buttons)