### PR TITLE
Use portal context in the `Dialog` component

### DIFF
--- a/.changeset/eleven-rules-cheer.md
+++ b/.changeset/eleven-rules-cheer.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated the default [`container`](https://mui.com/material-ui/api/modal/#modal-prop-container) prop of the `Dialog` component to use the portal context, which defaults to [`portalContainer`](https://stratakit.bentley.com/docs/reference/foundations/Root/#Root.Root.portalContainer).

--- a/.changeset/funny-singers-repeat.md
+++ b/.changeset/funny-singers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `Dialog` component to create a portal context, which enables nested elements to be portalled into the [`container`](https://mui.com/material-ui/api/dialog/#Dialog-css-MuiDialog-container) of the `Dialog`.

--- a/apps/test-app/app/mui/Dialog.showcase.tsx
+++ b/apps/test-app/app/mui/Dialog.showcase.tsx
@@ -2,8 +2,15 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
+import DialogNested_ from "examples/mui/Dialog._nested.tsx";
 import DialogDefault from "examples/mui/Dialog.default.tsx";
 
 export default function DialogExamples() {
-	return <DialogDefault />;
+	return (
+		<>
+			<DialogDefault />
+			<DialogNested_ />
+		</>
+	);
 }

--- a/apps/website/src/content/docs/components/mui/Dialog.md
+++ b/apps/website/src/content/docs/components/mui/Dialog.md
@@ -11,4 +11,4 @@ links:
 ## StrataKit MUI modifications
 
 - Restyled using StrataKit's visual language.
-- The default [`container`](https://mui.com/material-ui/api/modal/#modal-prop-container) is now the [root portal container](/components/root/#portal-container).
+- The default [`container`](https://mui.com/material-ui/api/modal/#modal-prop-container) now resolves from StrataKit's portal context, which defaults to [`portalContainer`](https://stratakit.bentley.com/docs/components/root/#portal-container).

--- a/examples/mui/Dialog._nested.tsx
+++ b/examples/mui/Dialog._nested.tsx
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+
+export default () => {
+	const [open, setOpen] = React.useState(false);
+	const [discardOpen, setDiscardOpen] = React.useState(false);
+
+	const handleClose = () => {
+		setDiscardOpen(true);
+	};
+
+	return (
+		<>
+			<Button onClick={() => setOpen(true)}>Settings</Button>
+			<Dialog open={open} onClose={handleClose}>
+				<DialogTitle>Settings</DialogTitle>
+				<DialogContent>
+					<ColorSchemeSelect />
+				</DialogContent>
+				<DialogActions>
+					<Button
+						onClick={() => {
+							setDiscardOpen(true);
+						}}
+					>
+						Discard
+					</Button>
+					<DiscardDialog
+						open={discardOpen}
+						onClose={() => setDiscardOpen(false)}
+						onDiscard={() => {
+							setDiscardOpen(false);
+							setOpen(false);
+						}}
+					/>
+					<Button
+						onClick={() => {
+							setOpen(false);
+						}}
+						color="primary"
+					>
+						Apply
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</>
+	);
+};
+
+interface DiscardDialogProps {
+	open: boolean;
+	onClose: () => void;
+	onDiscard: () => void;
+}
+
+function DiscardDialog(props: DiscardDialogProps) {
+	const { open, onClose, onDiscard } = props;
+	return (
+		<Dialog open={open} onClose={onClose}>
+			<DialogTitle>Discard changes</DialogTitle>
+			<DialogContent>
+				<DialogContentText>
+					Are you sure you want to discard your changes?
+				</DialogContentText>
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onClose}>Cancel</Button>
+				<Button onClick={onDiscard} color="primary">
+					Yes
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}
+
+function ColorSchemeSelect() {
+	const labelId = React.useId();
+	const label = "Color scheme";
+
+	return (
+		<FormControl>
+			<InputLabel id={labelId}>{label}</InputLabel>
+			<Select labelId={labelId} label={label} defaultValue="light">
+				<MenuItem value="auto">Auto</MenuItem>
+				<MenuItem value="light">Light</MenuItem>
+				<MenuItem value="dark">Dark</MenuItem>
+			</Select>
+		</FormControl>
+	);
+}

--- a/packages/mui/src/~components/MuiDialog.tsx
+++ b/packages/mui/src/~components/MuiDialog.tsx
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { PortalContext } from "@ariakit/react/portal";
+import { Role } from "@ariakit/react/role";
+import Modal from "@mui/material/Modal";
+import { forwardRef } from "@stratakit/foundations/secret-internals";
+
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+const MuiDialogRootSlot = forwardRef<"div", React.ComponentProps<typeof Modal>>(
+	(props, forwardedRef) => {
+		const container = React.useContext(PortalContext);
+		return <Modal container={container} {...props} ref={forwardedRef} />;
+	},
+);
+DEV: MuiDialogRootSlot.displayName = "MuiDialogRootSlot";
+
+// ----------------------------------------------------------------------------
+
+const MuiDialogPaper = forwardRef<"div", BaseProps<"div">>(
+	(props, forwardedRef) => {
+		const [containerElement, setContainerElement] =
+			React.useState<HTMLDivElement | null>(null);
+		return (
+			<PortalContext.Provider value={containerElement}>
+				<Role {...props} ref={forwardedRef}>
+					{props.children}
+					{/* Render in a container to avoid `aria-hidden` focus warning. */}
+					<div ref={setContainerElement} />
+				</Role>
+			</PortalContext.Provider>
+		);
+	},
+);
+DEV: MuiDialogPaper.displayName = "MuiDialogPaper";
+
+// ----------------------------------------------------------------------------
+
+export { MuiDialogPaper, MuiDialogRootSlot };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -36,6 +36,7 @@ import {
 	MuiChipDeleteIcon,
 	MuiChipLabel,
 } from "./~components/MuiChip.js";
+import { MuiDialogPaper, MuiDialogRootSlot } from "./~components/MuiDialog.js";
 import { MuiDivider } from "./~components/MuiDivider.js";
 import { MuiIconButton } from "./~components/MuiIconButton.js";
 import { MuiInputLabel } from "./~components/MuiInputLabel.js";
@@ -335,7 +336,18 @@ function createTheme(args: CreateThemeArgs) {
 				},
 			},
 			MuiContainer: { defaultProps: { component: Role.div } },
-			MuiDialog: { defaultProps: { component: Role.div } },
+			MuiDialog: {
+				defaultProps: {
+					slots: {
+						root: MuiDialogRootSlot,
+					},
+					slotProps: {
+						paper: {
+							component: MuiDialogPaper,
+						},
+					},
+				},
+			},
 			MuiDialogContentText: {
 				defaultProps: {
 					component: Role.p,


### PR DESCRIPTION
_Fixes part of #1402_
_Continuation of #1513_

### Changes

Updated the MUI `Dialog` component to use the portal context:
- The [`container`](https://mui.com/material-ui/api/modal/#modal-prop-container) prop will now use the  [`PortalContext`](https://github.com/iTwin/stratakit/blob/86a8c6a6b4167daf67da72f7d414e9c3e9247406/packages/foundations/src/Root.tsx#L267) by default.
- The [container element](https://mui.com/material-ui/api/dialog/#Dialog-css-MuiDialog-container) of the `Dialog` will be used as a portal context, which enables nested elements to be portalled into the dialog container.

The current approach simply sets the default `container` prop by overriding the `root` slot (which uses the `Modal` component), this allows to support all existing features of the `Dialog`. One thing to keep in mind: MUI applies `aria-hidden` attributes to all siblings of a portalled `Modal`.

---

Noticed an issue unrelated to this PR:
- `FormControl` label used in `Dialog._nested.tsx` example is truncated unnecessarily.

### Testing

Added a new (internal) example which tests nested dialogs and a `Select` in a `Dialog` (`Select` portalling needs to be fixed separately).

http://stratakit.bentley.com/1506/mui#dialog
 
