### PR TITLE
fix `Autocomplete` options size

### DIFF
--- a/.changeset/hungry-jokes-rhyme.md
+++ b/.changeset/hungry-jokes-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `Autocomplete` options size when `size="small"`.

--- a/packages/mui/src/~components/MuiMenu.css
+++ b/packages/mui/src/~components/MuiMenu.css
@@ -54,7 +54,8 @@
 	--_MuiMenuItem-color: var(--✨color-text--default);
 	--_MuiMenuItem-height: var(--✨size--medium);
 
-	:where(.MuiMenu-list.MuiList-dense) & {
+	:where(.MuiMenu-list.MuiList-dense) &,
+	&:where([data-_sk-dense]) {
 		@apply --typography("body-sm");
 		--_MuiMenuItem-height: var(--✨size--small);
 	}

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -176,6 +176,7 @@ function createTheme() {
 							key={key}
 							{...props}
 							className={cx("MuiMenuItem-root", props.className)}
+							data-_sk-dense={ownerState.size === "small" ? "" : undefined}
 						>
 							{ownerState.getOptionLabel(option)}
 						</li>


### PR DESCRIPTION
### Changes

_Follow-up to https://github.com/iTwin/stratakit/pull/1379 and https://github.com/iTwin/stratakit/pull/1403._

This reduces the size of `Autocomplete` options when `size="small"` is set.

`Autocomplete` does not use `Menu` or `MenuItem` directly, so this required a new data attribute to be targeted in CSS.

### Testing

| Before | After |
| --- | --- |
| <img width="191" height="140" alt="image" src="https://github.com/user-attachments/assets/3c402b6a-b703-4e47-9c47-c5a59ffd7415" /> | <img width="196" height="131" alt="image" src="https://github.com/user-attachments/assets/3fcc4075-e312-4322-8b83-59e891ab90f0" /> |