### PR TITLE
fix `InputLabel` small size

### DIFF
--- a/.changeset/chubby-schools-allow.md
+++ b/.changeset/chubby-schools-allow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `InputLabel` styles for `size="small"`.

--- a/examples/mui/Select.sizes.tsx
+++ b/examples/mui/Select.sizes.tsx
@@ -24,7 +24,9 @@ const SmallSelect = () => {
 	const label = "Favorite small animal:";
 	return (
 		<FormControl>
-			<InputLabel id={id}>{label}</InputLabel>
+			<InputLabel id={id} size="small">
+				{label}
+			</InputLabel>
 			<Select labelId={id} label={label} defaultValue={1} size="small">
 				<MenuItem value={1}>Mouse</MenuItem>
 				<MenuItem value={2}>Worm</MenuItem>

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -74,10 +74,14 @@
 }
 
 .MuiFormLabel-root {
-	font-size: var(--stratakit-font-size-14);
+	@apply --typography("body-md");
 	color: var(--stratakit-color-text-neutral-secondary);
 	position: relative; /* Disable floating label */
 	transform: none; /* Undo inset positioning */
+
+	&:where(.MuiInputLabel-root.MuiInputLabel-sizeSmall) {
+		@apply --typography("body-sm");
+	}
 
 	&:where(.Mui-disabled) {
 		color: var(--stratakit-color-text-neutral-disabled);


### PR DESCRIPTION
### Changes

_Follow-up to https://github.com/iTwin/stratakit/pull/1139_.

This correctly handles the styles for `size="small"` in `InputLabel`. (Previously it was unconditionally using `"body-md"`)

This prop is automatically set by _some_ higher-level components, such as `TextField`.

### Testing

| Before | After |
| --- | --- |
| <img width="380" height="76" alt="image" src="https://github.com/user-attachments/assets/47d2481d-8542-47e3-8ae9-9cbfcdc0b058" /> | <img width="390" height="72" alt="image" src="https://github.com/user-attachments/assets/d5e522cf-b7ae-4885-a0cd-1fd290e09913" /> |
| <img width="181" height="63" alt="image" src="https://github.com/user-attachments/assets/6da4f385-f126-4b11-a52f-67ede21c8f1d" /> | <img width="185" height="65" alt="image" src="https://github.com/user-attachments/assets/aba6b875-453c-4b72-ab67-090730843a58" /> |

[Deploy preview](https://stratakit.bentley.com/1508/mui)