### PR TITLE
add `:target` styling to docs

### DIFF
--- a/apps/website/src/styles/overrides.css
+++ b/apps/website/src/styles/overrides.css
@@ -270,3 +270,14 @@ starlight-menu-button button {
 	text-indent: 0;
 	font-variant: tabular-nums;
 }
+
+.sl-heading-wrapper:has(:target) {
+	:target {
+		outline: 2px solid var(--stratakit-color-border-neutral-faded);
+		outline-offset: 4px;
+	}
+
+	.sl-anchor-link {
+		opacity: 1;
+	}
+}


### PR DESCRIPTION
### Changes

This improves the experience of deep linking to docs sections, by adding [`:target`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:target) styling to the headings. The added styling makes it clear which heading is linked to (especially useful when there are multiple sections visible).

### Testing

Confirmed that the outline is visible when directly visiting an in-page anchor link.

<img width="312" height="116" alt="screenshot showing a neutral outline around a heading" src="https://github.com/user-attachments/assets/deb46453-b874-48c0-b16b-55e6797b79b2" />

([Preview](https://stratakit.bentley.com/1509/docs/components/navigationrail/#comprehensive))