### PR TITLE
update `CardContent` color

### DIFF
--- a/.changeset/swift-friends-juggle.md
+++ b/.changeset/swift-friends-juggle.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+`CardContent` will now use `--stratakit-color-text-neutral-secondary` for its descendants.

--- a/examples/mui/Card.actions.tsx
+++ b/examples/mui/Card.actions.tsx
@@ -28,7 +28,7 @@ export default () => {
 			/>
 			<CardHeader title="Stadium" />
 			<CardContent>
-				<Typography variant="body2" color="text.secondary">
+				<Typography variant="body2">
 					Stadium is a place for outdoor sports, concerts, or other events and
 					activities.
 				</Typography>

--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -34,7 +34,7 @@ export default () => {
 				}
 			/>
 			<CardContent>
-				<Typography variant="body2" color="text.secondary">
+				<Typography variant="body2">
 					Stadium is a place for outdoor sports, concerts, or other events and
 					activities.
 				</Typography>

--- a/examples/mui/Card.menu.tsx
+++ b/examples/mui/Card.menu.tsx
@@ -38,7 +38,7 @@ export default () => {
 				action={<ActionsMenu />}
 			/>
 			<CardContent>
-				<Typography variant="body2" color="text.secondary">
+				<Typography variant="body2">
 					Stadium is a place for outdoor sports, concerts, or other events and
 					activities.
 				</Typography>

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -51,6 +51,8 @@
 }
 
 .MuiCardContent-root {
+	color: var(--stratakit-color-text-neutral-secondary);
+
 	&:where(:has(+ .MuiCardActions-root)) {
 		padding-block-end: 0;
 	}


### PR DESCRIPTION
### Changes

This makes `CardContent` use `color-text-neutral-secondary` (overriding the default inherited color which is `color-text-neutral-primary`).

#### Context

Following #1505, I saw that `Typography` in `Card` examples was using `color="text.secondary"`. This form of usage is attempting to directly access the underlying tokens and is not supported in MUI v9. Instead of changing it to use the `sx` prop (which is supported but not recommended) or `color="textSecondary"`, I made it the default for `CardContent`, so that it doesn't need to be manually set. This is very similar to how `AccordionDetails` does it ([related thread](https://github.com/iTwin/stratakit/pull/1454#discussion_r3170514359)).

### Testing

| Before | After |
| --- | --- |
| <img width="375" height="282" alt="screenshot" src="https://github.com/user-attachments/assets/f8f95ece-eb85-412e-abc8-6cb607a2fb67" /> | <img width="366" height="281" alt="screenshot" src="https://github.com/user-attachments/assets/a5ddfcab-8199-4b57-a922-dd0a20b6845f" /> |