### PR TITLE
update `FormGroup` spacing

### DIFF
--- a/.changeset/funny-llamas-leave.md
+++ b/.changeset/funny-llamas-leave.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated spacing for `RadioGroup` and `FormGroup`.

--- a/apps/test-app/app/mui/RadioGroup.showcase.tsx
+++ b/apps/test-app/app/mui/RadioGroup.showcase.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import RadioGroupDefault from "examples/mui/RadioGroup.default.tsx";
+import RadioGroupDefaultValue from "examples/mui/RadioGroup.defaultValue.tsx";
 import RadioGroupError from "examples/mui/RadioGroup.error.tsx";
 import { createKnob } from "~/~utils.tsx";
 
@@ -10,6 +11,7 @@ export default function RadioGroupExamples() {
 	return (
 		<>
 			<RadioGroupDefault />
+			<RadioGroupDefaultValue />
 			<RadioGroupError />
 		</>
 	);
@@ -20,6 +22,13 @@ export const knobs = {
 		props: {
 			MuiFormControl: {
 				disabled: true,
+			},
+		},
+	}),
+	row: createKnob({
+		props: {
+			MuiFormGroup: {
+				row: true,
 			},
 		},
 	}),

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -24,9 +24,15 @@
 	@apply --typography("body-md");
 }
 
+.MuiFormLabel-root {
+	&:where(legend) {
+		margin-block-end: var(--stratakit-space-x1); /* legend does not support gap */
+	}
+}
+
 .MuiFormGroup-root {
-	/* Accounts for the increased tap target of the checkbox/radio */
 	row-gap: var(--stratakit-space-x1);
+	column-gap: var(--stratakit-space-x2);
 }
 
 .MuiFormHelperText-root {


### PR DESCRIPTION
### Changes

Updates to `FormGroup` and `FormLabel`:

- Added `column-gap` to support horizontal layout ([`row` prop](https://mui.com/material-ui/api/form-group/#form-group-prop-row)).
  - Uses larger `column-gap` values. (see [comment](https://github.com/iTwin/stratakit/pull/1511#discussion_r3336749889))
- Added margin to `<legend>` (does not participate in flex layout).

### Testing

Updated `RadioGroup.showcase`:
- Added knob for `row` prop.
- Added missing `RadioGroup.defaultValue` example.

| Before | After |
| --- | --- |
| <img width="200" height="126" alt="image" src="https://github.com/user-attachments/assets/77873ed4-80ab-45e8-920e-3a1e2ed6aedb" /> | <img width="203" height="134" alt="image" src="https://github.com/user-attachments/assets/8356e149-ffa7-4b55-a1b6-60245beef492" /> |
| <img width="197" height="73" alt="image" src="https://github.com/user-attachments/assets/8d21c7c1-6d26-4de3-8c4a-bc7d063e9cab" /> | <img width="225" height="85" alt="image" src="https://github.com/user-attachments/assets/dc0f36d2-9928-42cb-82b5-0ac08ab94dac" /> |

[Deploy preview](http://stratakit.bentley.com/1511/mui#radiogroup)