### PR TITLE
fix `Slider` cursor

### DIFF
--- a/packages/mui/src/~components/MuiSlider.css
+++ b/packages/mui/src/~components/MuiSlider.css
@@ -114,6 +114,10 @@
 	box-shadow: none;
 	cursor: grab;
 
+	&:where(.Mui-active) {
+		cursor: grabbing;
+	}
+
 	&:where(.Mui-disabled) {
 		background-color: var(--stratakit-color-icon-neutral-disabled);
 		border-color: var(--stratakit-color-icon-neutral-disabled);


### PR DESCRIPTION
### Changes

_Follow-up to https://github.com/iTwin/stratakit/pull/1476 (unreleased)_.

This fixes the cursor in Firefox and Safari, so that it consistently changes from `grab` to `grabbing` when the thumb is pressed and dragged.

`cursor: grabbing` is now intentionally set in two places:
- `.MuiSlider-root:has(.MuiSlider-thumb.Mui-active)`
- `.MuiSlider-thumb.Mui-active`

### Testing

Tested working in Chrome, Firefox and Safari.

https://github.com/user-attachments/assets/06e5c911-8427-48ce-90b4-320c831c1a47

Scenarios covered:
- clicking directly on the rail
- clicking on the thumb
- moving the mouse away from the thumb during drag
  - This even works when the mouse leaves the browser window, thanks to pointer capture.