### PR TITLE
Fix `Alert` icon shrinking issue

### DIFF
--- a/.changeset/eight-poets-enter.md
+++ b/.changeset/eight-poets-enter.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `Alert` icon shrinking issue.

--- a/packages/mui/src/~components/MuiAlert.css
+++ b/packages/mui/src/~components/MuiAlert.css
@@ -31,6 +31,7 @@
 	align-items: center;
 	font-size: inherit;
 	block-size: 1lh;
+	flex-shrink: 0;
 
 	padding: 0;
 	opacity: 1; /* Stock MUI reduces the icon opacity for some reason. */


### PR DESCRIPTION
### Changes

- Fixes `Alert` icon shrinking issue.

| Before | After |
| -- | -- |
| <img width="859" height="418" alt="IMG_4450" src="https://github.com/user-attachments/assets/ff1a848a-0a32-4014-9c15-b61fe48519c7" /> | <img width="863" height="410" alt="IMG_4451" src="https://github.com/user-attachments/assets/59d57edb-9cb5-490a-8b99-30f68d021697" /> |


### Testing

- Tested on iOS.