### PR TITLE
Improved animations for `Accordion`

### DIFF
--- a/.changeset/witty-cats-heal.md
+++ b/.changeset/witty-cats-heal.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Improved animations for `Accordion`.

--- a/packages/mui/src/~components/MuiAccordion.css
+++ b/packages/mui/src/~components/MuiAccordion.css
@@ -78,6 +78,19 @@
 .MuiAccordionSummary-expandIconWrapper {
 	color: var(--_MuiAccordion-expand-icon-color);
 	order: var(--_MuiAccordion-expand-icon-order, -1);
+
+	@supports (rotate: if(else: -0.5turn)) {
+		transform: none;
+		transition: rotate 150ms ease-in-out;
+
+		:where(.MuiAccordion-root.Mui-expanded) & {
+			rotate: if(style(--_MuiAccordion-expand-icon-order: 0): 0.5turn; else: -0.5turn);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
 }
 
 .MuiAccordionDetails-root {
@@ -90,4 +103,10 @@
 	color: var(--stratakit-color-text-neutral-secondary);
 	padding: var(--_MuiAccordion-padding);
 	padding-inline-start: var(--_MuiAccordion-details-indent, var(--✨indent));
+}
+
+.MuiCollapse-root {
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
 }


### PR DESCRIPTION
### Changes

- Removes animations if `reduced-motion` is active.
- Change the direction of the expand icon when in the start position.  Now the expand arrow always rotates in the direction of the label.

| Before | After |
| -- | -- |
| <img alt="accordion-before" src="https://github.com/user-attachments/assets/5d72e659-b8e7-4c20-a58b-8bd05426841d" /> | <img alt="animation-after" src="https://github.com/user-attachments/assets/b7b8807a-b785-4f08-99b1-9cd69886d582" /> |

### Testing

- Tested with left & right aligned expand icon.
- Tested in Chrome Canary (supported), and Safari (not supported, uses fallback).