### PR TITLE
fix `IconButton` edge prop

### DIFF
--- a/.changeset/sixty-paths-occur.md
+++ b/.changeset/sixty-paths-occur.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `edge` prop for `IconButton`.

--- a/packages/mui/src/~components/MuiIconButton.css
+++ b/packages/mui/src/~components/MuiIconButton.css
@@ -12,6 +12,14 @@
 	min-inline-size: var(--_MuiIconButton-size);
 	padding: var(--_MuiIconButton-padding);
 
+	&:where(.MuiIconButton-edgeStart) {
+		margin-inline-start: calc(var(--_MuiIconButton-margin-negative) * -1);
+	}
+
+	&:where(.MuiIconButton-edgeEnd) {
+		margin-inline-end: calc(var(--_MuiIconButton-margin-negative) * -1);
+	}
+
 	@media (any-hover: hover) {
 		&:where(:hover) {
 			--_MuiIconButton-icon-color: var(--stratakit-color-icon-neutral-primary);
@@ -21,16 +29,19 @@
 	&:where(.MuiIconButton-sizeSmall) {
 		--_MuiIconButton-size: var(--stratakit-size-control-field-height-small);
 		--_MuiIconButton-padding: var(--stratakit-space-x05);
+		--_MuiIconButton-margin-negative: var(--stratakit-space-x1);
 	}
 
 	&:where(.MuiIconButton-sizeMedium) {
 		--_MuiIconButton-size: var(--stratakit-size-control-field-height-medium);
 		--_MuiIconButton-padding: var(--stratakit-space-x05);
+		--_MuiIconButton-margin-negative: var(--stratakit-space-x2);
 	}
 
 	&:where(.MuiIconButton-sizeLarge) {
 		--_MuiIconButton-size: var(--stratakit-size-control-field-height-large);
 		--_MuiIconButton-padding: var(--stratakit-space-x1);
+		--_MuiIconButton-margin-negative: var(--stratakit-space-x3);
 	}
 
 	&:where(.MuiIconButton-colorPrimary) {


### PR DESCRIPTION
### Changes

IconButton has an [`edge`](https://mui.com/material-ui/api/icon-button/#icon-button-prop-edge) prop which is similar to the legacy "ghost aligner" concept. This prop was previously using strange hardcoded values (e.g. `-3px`).

This PR updates the negative margin values to use the most appropriate StrataKit spacing tokens, based on the button's size.

### Testing

Tested by temporarily adding `edge="start"` and `edge="end"` to an existing `<IconButton>`.