### PR TITLE
change default `Alert` severity

### DIFF
--- a/.changeset/smart-drinks-post.md
+++ b/.changeset/smart-drinks-post.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Updated the default `severity` of `Alert` to a newly added `"none"` value.

--- a/apps/website/src/content/docs/components/mui/Alert.md
+++ b/apps/website/src/content/docs/components/mui/Alert.md
@@ -12,4 +12,5 @@ links:
 
 - Restyled using StrataKit's visual language.
 - The `"standard"` variant has been removed. The default variant is now `"outlined"`.
+- The default severity is now a new `"none"` value instead of `"success"`.
 - The **Alert** will no longer create a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) by default. It now uses [`role="group"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role) instead of [`role="alert"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role).

--- a/examples/mui/Alert._permutations.tsx
+++ b/examples/mui/Alert._permutations.tsx
@@ -9,6 +9,7 @@ import Alert from "@mui/material/Alert";
 export default () => {
 	return (["outlined", "filled"] as const).map((variant) => (
 		<React.Fragment key={variant}>
+			<Alert>This is the default Alert.</Alert>
 			<Alert severity="success" variant={variant}>
 				This is a success Alert.
 			</Alert>

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -8,6 +8,7 @@
 // See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
 
 import type { RoleProps } from "@ariakit/react/role";
+import type { AlertProps } from "@mui/material/Alert";
 import type { BadgeProps } from "@mui/material/Badge";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type { CommonProps } from "@mui/material/OverridableComponent";
@@ -62,13 +63,24 @@ declare module "@mui/material/Alert" {
 		standard: false;
 	}
 
+	interface AlertPropsColorOverrides {
+		none: true;
+	}
+
 	interface AlertOwnProps {
 		/**
 		 * The default variant with `@stratakit/mui` is `"outlined"`.
 		 *
 		 * @default 'outlined'
 		 */
-		variant?: "filled" | "outlined";
+		variant?: AlertProps["variant"];
+
+		/**
+		 * The default severity with `@stratakit/mui` is `"none"`.
+		 *
+		 * @default 'none'
+		 */
+		severity?: AlertProps["severity"];
 	}
 }
 

--- a/packages/mui/src/~components/MuiAlert.css
+++ b/packages/mui/src/~components/MuiAlert.css
@@ -37,6 +37,10 @@
 	opacity: 1; /* Stock MUI reduces the icon opacity for some reason. */
 	margin-inline-end: var(--stratakit-space-x2);
 
+	&:where(:empty) {
+		display: none;
+	}
+
 	:where(.MuiAlert-root.MuiAlert-colorSuccess) & {
 		color: var(--stratakit-color-icon-positive-base);
 	}

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -160,6 +160,7 @@ function createTheme(args: CreateThemeArgs) {
 				defaultProps: {
 					component: MuiAlert,
 					variant: "outlined",
+					severity: "none",
 					iconMapping: {
 						error: <ErrorIcon />,
 						info: <InfoIcon />,


### PR DESCRIPTION
### Changes

This addresses https://github.com/iTwin/stratakit/pull/1388#issuecomment-4348279801, changing the Alert's default [`severity`](https://mui.com/material-ui/api/alert/#alert-prop-severity) from `"success"` to a new `"none"` value.

Because this severity does not come with a default icon, the icon's wrapper element needed to be hidden to remove extra space.

#### Bikeshed

I would have liked to use `"neutral"` as the name for the new value for consistency with the legacy `Banner`, but the prop name `severity` does not imply color or tone, so the value needs to be somewhat generic too. I also tried to use `undefined`, but it seems to require a string. In any case, I'm not expecting most consumers to pass this value manually.

### Testing

Tested IDE autocomplete experience to ensure `"none"` shows up correctly and can be passed explicitly.

Added a demo to the `Alert._permutations` example. [Deploy preview](http://stratakit.bentley.com/1540/mui#alert)

<img width="219" height="169" alt="screenshot" src="https://github.com/user-attachments/assets/22231792-0c9e-412d-98a1-13635ea8d21e" />

Updated docs to mention this breaking change under MUI modifications. [Docs preview](http://stratakit.bentley.com/1540/docs/components/alert)