### PR TITLE
Bump `astro` and `@astrojs/starlight`

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -53,14 +53,14 @@
 		}
 	},
 	"dependencies": {
-		"@astrojs/starlight": "^0.39.3",
+		"@astrojs/starlight": "^0.40.0",
 		"@mui/material": "catalog:",
 		"@stratakit/bricks": "workspace:*",
 		"@stratakit/foundations": "workspace:*",
 		"@stratakit/icons": "workspace:*",
 		"@stratakit/mui": "workspace:*",
 		"@stratakit/structures": "workspace:*",
-		"astro": "^6.4.3",
+		"astro": "^6.4.5",
 		"examples": "workspace:*",
 		"react": "catalog:",
 		"react-dom": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,8 +198,8 @@ importers:
   apps/website:
     dependencies:
       "@astrojs/starlight":
-        specifier: ^0.39.3
-        version: 0.39.3(astro@6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))(typescript@6.0.3)
+        specifier: ^0.40.0
+        version: 0.40.0(astro@6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))(typescript@6.0.3)
       "@mui/material":
         specifier: "catalog:"
         version: 9.0.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -219,8 +219,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/structures
       astro:
-        specifier: ^6.4.3
-        version: 6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)
+        specifier: ^6.4.5
+        version: 6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)
       examples:
         specifier: workspace:*
         version: link:../../examples
@@ -571,32 +571,24 @@ packages:
         integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==,
       }
 
-  "@astrojs/internal-helpers@0.9.1":
-    resolution:
-      {
-        integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==,
-      }
-
-  "@astrojs/markdown-remark@7.1.2":
-    resolution:
-      {
-        integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==,
-      }
-
   "@astrojs/markdown-remark@7.2.0":
     resolution:
       {
         integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==,
       }
 
-  "@astrojs/mdx@5.0.6":
+  "@astrojs/mdx@6.0.3":
     resolution:
       {
-        integrity: sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==,
+        integrity: sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw==,
       }
     engines: { node: ">=22.12.0" }
     peerDependencies:
-      astro: ^6.0.0
+      "@astrojs/markdown-satteri": 0.3.0
+      astro: ^6.4.0
+    peerDependenciesMeta:
+      "@astrojs/markdown-satteri":
+        optional: true
 
   "@astrojs/prism@4.0.2":
     resolution:
@@ -611,13 +603,17 @@ packages:
         integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==,
       }
 
-  "@astrojs/starlight@0.39.3":
+  "@astrojs/starlight@0.40.0":
     resolution:
       {
-        integrity: sha512-uvAweA2DwhmLgFVfBT9NqG38Ey14k1ck3+y78XNJbceT1pMdzxCCX69RoBajb1QzTJviufsXzSc1xswgRxJfig==,
+        integrity: sha512-H1NBIXx4Xw6YzKMsoMkazYxFgnTTj6pD4IReUGWj1fqw82AOAgj+WnZLpTDWRExf3b9ZM7Popbl583i4IvDNVQ==,
       }
     peerDependencies:
-      astro: ^6.0.0
+      "@astrojs/markdown-satteri": ^0.2.0
+      astro: ^6.4.5
+    peerDependenciesMeta:
+      "@astrojs/markdown-satteri":
+        optional: true
 
   "@astrojs/telemetry@3.3.2":
     resolution:
@@ -1533,28 +1529,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@expressive-code/core@0.42.0":
+  "@expressive-code/core@0.43.1":
     resolution:
       {
-        integrity: sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw==,
+        integrity: sha512-H4rUJXKyS6y2q9Ig9bIp3dFhWhkZQIeH/jRGl3DROlslrGvfD4OC9qzmvKEFExm+/DtdvvHMQ8/Olmrcfxp+wQ==,
       }
 
-  "@expressive-code/plugin-frames@0.42.0":
+  "@expressive-code/plugin-frames@0.43.1":
     resolution:
       {
-        integrity: sha512-XtkPm+941Uta7Y+81Acv+OA/20F1NJmJhCX6UYGKpqEIGqplNh3PTOhcURp6tcruhlzJcWcvpWy6Oigz3SrjqA==,
+        integrity: sha512-tENfLw2UDeq5h749tTLvUtQYvgjIiQc6W7PBCR5xQ4yuE/QftManKJfUQjwJo6RRsAimVQDN4alhFTJ3aq1Khg==,
       }
 
-  "@expressive-code/plugin-shiki@0.42.0":
+  "@expressive-code/plugin-shiki@0.43.1":
     resolution:
       {
-        integrity: sha512-PMKey/kLmewttAHQezL+Y5Fx3vVssfDi3+FJOYQQS2mXP3tQspFELtKKAfsXfmSXdToZYgwoO69HJndqfE+09g==,
+        integrity: sha512-NdceinYEROXODNgB/ix+7oCdIg+nGyok+E+p2lU9YlWd1xKshXdXpmmptKfkuU27MJ5jjnfhMCI78YYBGi9GtQ==,
       }
 
-  "@expressive-code/plugin-text-markers@0.42.0":
+  "@expressive-code/plugin-text-markers@0.43.1":
     resolution:
       {
-        integrity: sha512-l59lUx8fq1v5g6SpmbDjiU0+7IdfbiWnAyRmtTVSpfhyq+nZMN4UcmYyu2b9Mynhzt7Gr+O+cXyEPDNb2AVWVQ==,
+        integrity: sha512-JWf8wdbZSNoGY4TFv3lmt3/NNDaCP7iYL6rRYD05g8YYjKL62hKUHLl5+B47+v0+bqbuMhXDN7qz2wywFUvMkg==,
       }
 
   "@floating-ui/core@1.7.5":
@@ -2653,18 +2649,18 @@ packages:
       }
     hasBin: true
 
-  astro-expressive-code@0.42.0:
+  astro-expressive-code@0.43.1:
     resolution:
       {
-        integrity: sha512-aiTePi2Cn0mJPYWZSzP1GcxCinX9mNtJyCCshVVPSg1yRwM7ADvFJOx0FnS440M9t65hp8JH//dc2qr22Bm4ag==,
+        integrity: sha512-xddgwQxFRwpnnAnU7kSfrO82SsOAq7sQrYpXxVcrN9k/0aqNlTH2+mLrOMm1wXm6jdFKepst3hd8/qWojwuunw==,
       }
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@6.4.3:
+  astro@6.4.5:
     resolution:
       {
-        integrity: sha512-heArIk8zLcxuoj1WgBH2zGdAD8zKSU1mEcBvS6hYMEHRPlbtvB+4Y8ri9Z27hzeryvGaFgrH32zjghEfV2y07g==,
+        integrity: sha512-0R7WLD1+WD/mTPcZxyKtcF0CztQi9ahFRtGM7oChJhxjNbr4lSBenxi+mk91k5bPTaUEoZ6edg1fDo2qP8bCwg==,
       }
     engines: { node: ">=22.12.0", npm: ">=9.6.5", pnpm: ">=7.1.0" }
     hasBin: true
@@ -3284,10 +3280,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  expressive-code@0.42.0:
+  expressive-code@0.43.1:
     resolution:
       {
-        integrity: sha512-V5DtJLEKuj4wf9O6IRtPtRObkMVy2ggR+S0MdjrTw6m58krZnDioyhW1si3Y04c5YPeooP4nd85Yq9NwEVHS4g==,
+        integrity: sha512-JdOzanoU825iNvslmk6Kg8Ro61eSHmDK2Zz7BynOxObVrpIXZNzrIZOwQO2uDQcGsjSYShL/8vTrXgeWYnq3NA==,
       }
 
   exsolve@1.0.8:
@@ -4879,10 +4875,10 @@ packages:
         integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==,
       }
 
-  rehype-expressive-code@0.42.0:
+  rehype-expressive-code@0.43.1:
     resolution:
       {
-        integrity: sha512-8rp/1YMEVVSYbtz+bFBx+uSx3vA4i4T8RwRm5Q/IWbucQnnQqQ0hDqtmKOr8tv+59Cik6cu5aH3WPo0I7csuTA==,
+        integrity: sha512-CUOGQVlUcSMSXZgpcq9xL6B+dZqnI3w1R6EZj932XpGgj2Hmy7H6oMqa9W/Z7X2HOILWLWhqu1b9kuYcD+nd6w==,
       }
 
   rehype-format@5.0.1:
@@ -5776,36 +5772,6 @@ snapshots:
       smol-toml: 1.6.1
       unified: 11.0.5
 
-  "@astrojs/internal-helpers@0.9.1":
-    dependencies:
-      picomatch: 4.0.4
-
-  "@astrojs/markdown-remark@7.1.2":
-    dependencies:
-      "@astrojs/internal-helpers": 0.9.1
-      "@astrojs/prism": 4.0.2
-      github-slugger: 2.0.0
-      hast-util-from-html: 2.0.3
-      hast-util-to-text: 4.0.2
-      js-yaml: 4.2.0
-      mdast-util-definitions: 6.0.0
-      rehype-raw: 7.0.0
-      rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.1.0
-      smol-toml: 1.6.1
-      unified: 11.0.5
-      unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.1.0
-      unist-util-visit-parents: 6.0.2
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   "@astrojs/markdown-remark@7.2.0":
     dependencies:
       "@astrojs/internal-helpers": 0.10.0
@@ -5828,12 +5794,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@5.0.6(astro@6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))":
+  "@astrojs/mdx@6.0.3(astro@6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))":
     dependencies:
-      "@astrojs/markdown-remark": 7.1.2
+      "@astrojs/internal-helpers": 0.10.0
+      "@astrojs/markdown-remark": 7.2.0
       "@mdx-js/mdx": 3.1.1
       acorn: 8.16.0
-      astro: 6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)
+      astro: 6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5857,17 +5824,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  "@astrojs/starlight@0.39.3(astro@6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))(typescript@6.0.3)":
+  "@astrojs/starlight@0.40.0(astro@6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))(typescript@6.0.3)":
     dependencies:
       "@astrojs/markdown-remark": 7.2.0
-      "@astrojs/mdx": 5.0.6(astro@6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))
+      "@astrojs/mdx": 6.0.3(astro@6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))
       "@astrojs/sitemap": 3.7.3
       "@pagefind/default-ui": 1.5.2
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)
-      astro-expressive-code: 0.42.0(astro@6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))
+      astro: 6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)
+      astro-expressive-code: 0.43.1(astro@6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -6390,7 +6357,7 @@ snapshots:
   "@esbuild/win32-x64@0.28.0":
     optional: true
 
-  "@expressive-code/core@0.42.0":
+  "@expressive-code/core@0.43.1":
     dependencies:
       "@ctrl/tinycolor": 4.2.0
       hast-util-select: 6.0.4
@@ -6402,18 +6369,18 @@ snapshots:
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
-  "@expressive-code/plugin-frames@0.42.0":
+  "@expressive-code/plugin-frames@0.43.1":
     dependencies:
-      "@expressive-code/core": 0.42.0
+      "@expressive-code/core": 0.43.1
 
-  "@expressive-code/plugin-shiki@0.42.0":
+  "@expressive-code/plugin-shiki@0.43.1":
     dependencies:
-      "@expressive-code/core": 0.42.0
+      "@expressive-code/core": 0.43.1
       shiki: 4.1.0
 
-  "@expressive-code/plugin-text-markers@0.42.0":
+  "@expressive-code/plugin-text-markers@0.43.1":
     dependencies:
-      "@expressive-code/core": 0.42.0
+      "@expressive-code/core": 0.43.1
 
   "@floating-ui/core@1.7.5":
     dependencies:
@@ -7028,12 +6995,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.42.0(astro@6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)):
+  astro-expressive-code@0.43.1(astro@6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)):
     dependencies:
-      astro: 6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)
-      rehype-expressive-code: 0.42.0
+      astro: 6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4)
+      rehype-expressive-code: 0.43.1
 
-  astro@6.4.3(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4):
+  astro@6.4.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.22.4):
     dependencies:
       "@astrojs/compiler": 4.0.0
       "@astrojs/internal-helpers": 0.10.0
@@ -7481,12 +7448,12 @@ snapshots:
 
   exit-hook@2.2.1: {}
 
-  expressive-code@0.42.0:
+  expressive-code@0.43.1:
     dependencies:
-      "@expressive-code/core": 0.42.0
-      "@expressive-code/plugin-frames": 0.42.0
-      "@expressive-code/plugin-shiki": 0.42.0
-      "@expressive-code/plugin-text-markers": 0.42.0
+      "@expressive-code/core": 0.43.1
+      "@expressive-code/plugin-frames": 0.43.1
+      "@expressive-code/plugin-shiki": 0.43.1
+      "@expressive-code/plugin-text-markers": 0.43.1
 
   exsolve@1.0.8: {}
 
@@ -8704,9 +8671,9 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  rehype-expressive-code@0.42.0:
+  rehype-expressive-code@0.43.1:
     dependencies:
-      expressive-code: 0.42.0
+      expressive-code: 0.43.1
 
   rehype-format@5.0.1:
     dependencies:


### PR DESCRIPTION
### Changes

This PR fixes incorrect table markup generation of `.mdx` files introduced in #1524 by bumping `@astrojs/starlight` to a version that officially supports v6.4 of `astro`: https://github.com/withastro/starlight/releases/tag/%40astrojs%2Fstarlight%400.40.0

### Testing

- [Docs](https://stratakit.bentley.com/1542/docs/getting-started/migration-from-legacy-stratakit/#use-mui-components)
