### PR TITLE
Fix `aspect-ratio` issue

### DIFF
--- a/.changeset/itchy-webs-write.md
+++ b/.changeset/itchy-webs-write.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed aspect ratio issue present in some versions of Safari.

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -49,6 +49,7 @@
 			content: "";
 			display: inline-block;
 			block-size: 1lh;
+			inline-size: 1lh;
 			aspect-ratio: 1;
 			vertical-align: top;
 		}

--- a/packages/mui/src/~components/MuiStepper.css
+++ b/packages/mui/src/~components/MuiStepper.css
@@ -33,6 +33,7 @@
 	place-items: center;
 
 	block-size: 1.5rem;
+	inline-size: 1.5rem;
 	aspect-ratio: 1;
 	border-radius: 50%;
 

--- a/packages/mui/src/~components/MuiSwitch.css
+++ b/packages/mui/src/~components/MuiSwitch.css
@@ -51,6 +51,7 @@
 
 	aspect-ratio: 1;
 	block-size: var(--_MuiSwitch-height);
+	inline-size: var(--_MuiSwitch-height);
 	inset: unset;
 	padding: var(--_MuiSwitch-padding);
 	transform: var(--_MuiSwitch-thumb-position-off);


### PR DESCRIPTION
### Changes

@mayank99 discovered an issue with the `Switch` present in https://github.com/iTwin/stratakit/labels/safari 26.0.1:
<img width="101" height="131" alt="image" src="https://github.com/user-attachments/assets/2f6e604b-9f5c-40c9-9307-9228f3aad49d" />

@mayank99 found that `aspect-ratio` & `block-size` alone were not enough, and adding `inline-size` fixed the problem.

This PR ensures both `block-size` & `inline-size` are **both** applied to all MUI stylesheets where `aspect-ratio` is used.

### Testing

I am unable to reproduce the bug.