### PR TITLE
Remove `aria-hidden` from inline `Badge`

### DIFF
--- a/.changeset/cold-readers-exist.md
+++ b/.changeset/cold-readers-exist.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Removed `aria-hidden` from inline `Badge` when used with `@mui/material@^9.1.0`.

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -22,31 +22,25 @@ const MuiBadgeContext = React.createContext<{ inline?: boolean } | undefined>(
 
 type BadgeProps = React.ComponentProps<typeof Badge>;
 
-interface MuiBadgeRootProps
-	extends BaseProps<"span">,
-		Pick<BadgeProps, "inline"> {}
-
-const MuiBadgeRoot = forwardRef<"span", MuiBadgeRootProps>(
-	(props, forwardedRef) => {
-		const { inline, ...rest } = props;
-		return (
-			<MuiBadgeContext.Provider value={{ inline }}>
-				<Role.span
-					{...rest}
-					data-_sk-inline={inline ? "" : undefined}
-					ref={forwardedRef}
-				/>
-			</MuiBadgeContext.Provider>
-		);
-	},
-);
-DEV: MuiBadgeRoot.displayName = "MuiBadgeRoot";
-
-// ----------------------------------------------------------------------------
-
 interface MuiBadgeProps extends BaseProps<"span">, Pick<BadgeProps, "inline"> {}
 
 const MuiBadge = forwardRef<"span", MuiBadgeProps>((props, forwardedRef) => {
+	const { inline, ...rest } = props;
+	return (
+		<MuiBadgeContext.Provider value={{ inline }}>
+			<Role.span
+				{...rest}
+				data-_sk-inline={inline ? "" : undefined}
+				ref={forwardedRef}
+			/>
+		</MuiBadgeContext.Provider>
+	);
+});
+DEV: MuiBadge.displayName = "MuiBadge";
+
+// ----------------------------------------------------------------------------
+
+const MuiBadgeBadge = forwardRef<"span", BaseProps>((props, forwardedRef) => {
 	const { inline } = useSafeContext(MuiBadgeContext);
 	return (
 		<Role.span
@@ -56,7 +50,8 @@ const MuiBadge = forwardRef<"span", MuiBadgeProps>((props, forwardedRef) => {
 		/>
 	);
 });
-DEV: MuiBadge.displayName = "MuiBadge";
+DEV: MuiBadgeBadge.displayName = "MuiBadgeBadge";
 
 // ----------------------------------------------------------------------------
-export { MuiBadge, MuiBadgeRoot };
+
+export { MuiBadge, MuiBadgeBadge };

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -2,27 +2,56 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
+import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import {
-	type BaseProps,
 	forwardRef,
+	useSafeContext,
 } from "@stratakit/foundations/secret-internals";
 
 import type Badge from "@mui/material/Badge";
+import type { BaseProps } from "@stratakit/foundations/secret-internals";
+
+// ----------------------------------------------------------------------------
+
+const MuiBadgeContext = React.createContext<{ inline?: boolean } | undefined>(
+	undefined,
+);
 
 // ----------------------------------------------------------------------------
 
 type BadgeProps = React.ComponentProps<typeof Badge>;
 
+interface MuiBadgeRootProps
+	extends BaseProps<"span">,
+		Pick<BadgeProps, "inline"> {}
+
+const MuiBadgeRoot = forwardRef<"span", MuiBadgeRootProps>(
+	(props, forwardedRef) => {
+		const { inline, ...rest } = props;
+		return (
+			<MuiBadgeContext.Provider value={{ inline }}>
+				<Role.span
+					{...rest}
+					data-_sk-inline={inline ? "" : undefined}
+					ref={forwardedRef}
+				/>
+			</MuiBadgeContext.Provider>
+		);
+	},
+);
+DEV: MuiBadgeRoot.displayName = "MuiBadgeRoot";
+
+// ----------------------------------------------------------------------------
+
 interface MuiBadgeProps extends BaseProps<"span">, Pick<BadgeProps, "inline"> {}
 
 const MuiBadge = forwardRef<"span", MuiBadgeProps>((props, forwardedRef) => {
-	const { inline, ...rest } = props;
+	const { inline } = useSafeContext(MuiBadgeContext);
 	return (
 		<Role.span
-			{...rest}
-			data-_sk-inline={inline ? "" : undefined}
+			{...props}
+			aria-hidden={inline ? undefined : props["aria-hidden"]}
 			ref={forwardedRef}
 		/>
 	);
@@ -30,5 +59,4 @@ const MuiBadge = forwardRef<"span", MuiBadgeProps>((props, forwardedRef) => {
 DEV: MuiBadge.displayName = "MuiBadge";
 
 // ----------------------------------------------------------------------------
-
-export { MuiBadge };
+export { MuiBadge, MuiBadgeRoot };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -21,7 +21,7 @@ import {
 	MuiAutocompleteClearIndicator,
 } from "./~components/MuiAutocomplete.js";
 import { MuiAvatarGroup } from "./~components/MuiAvatarGroup.js";
-import { MuiBadge } from "./~components/MuiBadge.js";
+import { MuiBadge, MuiBadgeRoot } from "./~components/MuiBadge.js";
 import { MuiBottomNavigationAction } from "./~components/MuiBottomNavigation.js";
 import { MuiButtonBase } from "./~components/MuiButtonBase.js";
 import {
@@ -237,8 +237,9 @@ function createTheme(args: CreateThemeArgs) {
 			MuiBackdrop: { defaultProps: { component: Role.div } },
 			MuiBadge: {
 				defaultProps: {
-					component: MuiBadge,
+					component: MuiBadgeRoot,
 					color: "secondary",
+					slotProps: { badge: { component: MuiBadge } },
 				},
 			},
 			MuiBottomNavigation: { defaultProps: { component: Role.div } },

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -21,7 +21,7 @@ import {
 	MuiAutocompleteClearIndicator,
 } from "./~components/MuiAutocomplete.js";
 import { MuiAvatarGroup } from "./~components/MuiAvatarGroup.js";
-import { MuiBadge, MuiBadgeRoot } from "./~components/MuiBadge.js";
+import { MuiBadge, MuiBadgeBadge } from "./~components/MuiBadge.js";
 import { MuiBottomNavigationAction } from "./~components/MuiBottomNavigation.js";
 import { MuiButtonBase } from "./~components/MuiButtonBase.js";
 import {
@@ -237,9 +237,9 @@ function createTheme(args: CreateThemeArgs) {
 			MuiBackdrop: { defaultProps: { component: Role.div } },
 			MuiBadge: {
 				defaultProps: {
-					component: MuiBadgeRoot,
+					component: MuiBadge,
 					color: "secondary",
-					slotProps: { badge: { component: MuiBadge } },
+					slotProps: { badge: { component: MuiBadgeBadge } },
 				},
 			},
 			MuiBottomNavigation: { defaultProps: { component: Role.div } },


### PR DESCRIPTION
### Changes

This PR removes `aria-hidden` attribute from the `badge` slot of `Badge` component, which is introduced with [MUI 9.1.0](https://github.com/mui/material-ui/releases)

I've not updated the MUI version due to regression `https://github.com/mui/material-ui/issues/48636`

Additionally, current solution doesn't handle use-case where consumer explicitly sets the `aria-hidden` prop via the `slotProps.badge` prop (wasn't sure if it's a valid use case, and is worth the additional complication). For that we need owner state, which is overridden when functional `slotProps` form is used (might be worth reporting upstream). Overriding the `badge` slot itself is tricky as well, due to [extensive styling](https://github.com/mui/material-ui/blob/0f9b43f4e001102e9aa94f10c3882e15277908a5/packages/mui-material/src/Badge/Badge.js#L52). For now easiest solution would be to override the `root` slot and pass needed information via the context.

### Testing
 
| Before | After |
| --- | --- |
| <img width="1066" height="390" alt="Screenshot 2026-06-11 at 11 26 56" src="https://github.com/user-attachments/assets/5bbd6f5d-8595-48b3-8c6d-801b98785f49" /> | <img width="1043" height="519" alt="Screenshot 2026-06-11 at 15 00 30" src="https://github.com/user-attachments/assets/2c3f557b-00c8-4732-98c3-433356b9a897" /> |


