### PR TITLE
`Typography`: require `render` prop for headings

### DIFF
--- a/.changeset/slick-wasps-wonder.md
+++ b/.changeset/slick-wasps-wonder.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Updated types for `Typography` so that `render` prop is required for heading-like variants.

--- a/apps/test-app/app/mui/Typography.showcase.tsx
+++ b/apps/test-app/app/mui/Typography.showcase.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import TypographyMuiVariants_ from "examples/mui/Typography._mui-variants.tsx";
 import TypographyColors from "examples/mui/Typography.colors.tsx";
 import TypographyDefault from "examples/mui/Typography.default.tsx";
 import TypographyHeading from "examples/mui/Typography.heading.tsx";
@@ -14,6 +15,7 @@ export default function TypographyExamples() {
 			<TypographyDefault />
 			<TypographyHeading />
 			<TypographyVariants />
+			<TypographyMuiVariants_ />
 			<TypographyColors />
 		</>
 	);

--- a/apps/test-app/app/mui/mui.tsx
+++ b/apps/test-app/app/mui/mui.tsx
@@ -135,7 +135,7 @@ export default function Page() {
 				tabIndex={-1}
 				id={React.use(SkipLinkContext)?.id}
 			>
-				<Typography variant="h4" render={<h1 />} className={styles.h1}>
+				<Typography variant="headline-lg" render={<h1 />} className={styles.h1}>
 					StrataKit MUI theme
 				</Typography>
 

--- a/apps/test-app/app/~examples.tsx
+++ b/apps/test-app/app/~examples.tsx
@@ -54,7 +54,7 @@ export function ExamplesShowcase(props: ExamplesShowcaseProps) {
 		>
 			<hgroup className={styles.exampleHeader}>
 				<Typography
-					variant="h5"
+					variant="headline-md"
 					render={<h2 />}
 					id={id}
 					className={styles.exampleTitle}
@@ -122,7 +122,12 @@ export function KnobControlEntrypoint(
 					},
 				}}
 			>
-				<Typography variant="body2" render={<h2 />} id={headingId} gutterBottom>
+				<Typography
+					variant="body-md"
+					render={<h2 />}
+					id={headingId}
+					gutterBottom
+				>
 					Knobs
 				</Typography>
 				<FormGroup>

--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -14,34 +14,14 @@ links:
 - The typography scale has been adjusted to better align with StrataKit's more compact visual language.
 - Several new [`variant`s](#variants) have been added.
 - The default `variant` is now `"inherit"` instead of `"body1"`.
-- A warning will be logged during development if a heading variant is used without explicitly setting the `render` prop.
+- The `render` prop is required to be set for all heading variants.
 - The `"secondary"` color value has been removed. A `"textTertiary"` color value has been added.
 
 ## Examples
 
-### Heading
-
-Heading `variant`s of the **Typography** will render the respective [`<h1>` to `<h6>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) heading elements. You should use the `render` prop to override the rendered element and maintain proper [heading structure](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/) in your application. When the `render` prop is not set, StrataKit will log a warning during development.
-
-::example{src="mui/Typography.heading"}
-
-:::caution[Grabbing attention]
-
-You may want a statement to _stand out_. This statement might regard a special offer, or perhaps a warning. Standalone statements are _not_ headings, since they do not introduce a new section of content.
-
-In these cases, combine a larger `variant` with the `render` prop to set a generic `<span>` or `<div>` element:
-
-```jsx
-<Typography variant="h6" render={<span />}>
-	This change cannot be undone.
-</Typography>
-```
-
-:::
-
 ### Variants
 
-All of the stock MUI **Typography** `variant`s are available, with sizing adjusted to fit StrataKit's more compact visual language. Additionally, the following custom `variant`s are available:
+The following custom **Typography** `variant`s are available:
 
 - `"display-lg"` / `"display-md"` / `"display-sm"`
 - `"headline-lg"` / `"headline-md"` / `"headline-sm"`
@@ -51,6 +31,28 @@ All of the stock MUI **Typography** `variant`s are available, with sizing adjust
 - `"mono-sm"`
 
 ::example{src="mui/Typography.variants" min-height="600px"}
+
+All of the stock MUI **Typography** `variant`s are also available for backwards compatibility, but not recommended for use.
+
+### Heading
+
+StrataKit decouples the visual presentation of **Typography** from its semantic meaning. Any visual `variant` can be rendered as any HTML element using the `render` prop. This allows for maximum flexibility without compromising accessibility.
+
+When using a heading `variant`, the `render` prop should typically be set to a heading element ([`<h1>` to `<h6>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)). Be sure to pick the most appropriate heading element required to maintain proper [heading structure](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/) in your application.
+
+::example{src="mui/Typography.heading"}
+
+:::caution[Grabbing attention]
+
+You may want a statement to _stand out_. This statement might regard a special offer, or perhaps a warning. Standalone statements are _not_ headings, since they do not introduce a new section of content. Do _not_ use a semantic heading element in these cases. Instead, set the `render` prop to a generic element (`<p>` or `<span>` or `<div>`):
+
+```jsx
+<Typography variant="subtitle-lg" render={<p />}>
+	This change cannot be undone.
+</Typography>
+```
+
+:::
 
 ### Colors
 
@@ -73,7 +75,7 @@ The following color are available for the `color` prop:
 ## ✅ Do
 
 - Use the `variant` prop of the **Typography** component to affect the visual presentation of the text.
-- Use the `render` prop to set the most semantically appropriate element. This is especially important for heading variants.
+- Use the `render` prop to set the most semantically appropriate element. This is required for heading variants.
 
 ## 🚫 Don't
 

--- a/apps/website/src/content/docs/guides/structure.md
+++ b/apps/website/src/content/docs/guides/structure.md
@@ -154,20 +154,20 @@ The heading elements (`<h1>` to `<h6>`) are numbered according to section depth.
 
 Headings, and a logical application of heading levels, are indispensable for describing the relationships of belonging that make up the document’s structure. Landmarks and headings together expose the information topology to different users, their assistive software, and agents.
 
-If you are applying a suitable heading level but need control over the element’s styling, use the [**Typography**](/components/typography) component and set the level using the `render` prop:
+The [**Typography**](/components/typography) component allows you to control the heading level using the `render` prop, with the `variant` prop controlling the visual presentation.
 
 ```jsx
-<Typography variant="h4" render={<h2 />}>
-	This must render as an `h2`, but looks smaller, like an `h4`.
+<Typography variant="subtitle-sm" render={<h2 />}>
+	This small subtitle will render as an `h2`.
 </Typography>
 ```
 
 :::caution[False headings]
 
-Just because some text appears large or **bold** does not make it a heading. A heading must introduce a section (or subsection) of thematically distinct content. For large (or otherwise attention grabbing) text, not intended as a heading, use a [**Typography**](/components/typography) heading `variant` but change the underlying element using the `render` prop:
+Just because some text appears large or **bold** does not make it a heading. A heading must introduce a section (or subsection) of thematically distinct content. For large (or otherwise attention grabbing) text not intended as a heading, change the underlying element to a non-heading element (e.g. `<p>`) using the `render` prop:
 
 ```jsx
-<Typography variant="h4" render={<span />}>
+<Typography variant="subtitle-lg" render={<p />}>
 	This change cannot be undone.
 </Typography>
 ```

--- a/examples/mui/AppBar.default.tsx
+++ b/examples/mui/AppBar.default.tsx
@@ -19,7 +19,7 @@ export default () => {
 				<IconButton size="large" edge="start" aria-label="menu">
 					<Icon href={`${svgMenu}#icon-large`} size="large" />
 				</IconButton>
-				<Typography variant="h6" render={<div />} sx={{ flexGrow: 1 }}>
+				<Typography variant="headline-sm" render={<div />} sx={{ flexGrow: 1 }}>
 					News
 				</Typography>
 				<Button variant="text">Login</Button>

--- a/examples/mui/Card.actions.tsx
+++ b/examples/mui/Card.actions.tsx
@@ -28,7 +28,7 @@ export default () => {
 			/>
 			<CardHeader title="Stadium" />
 			<CardContent>
-				<Typography variant="body2">
+				<Typography>
 					Stadium is a place for outdoor sports, concerts, or other events and
 					activities.
 				</Typography>

--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -34,7 +34,7 @@ export default () => {
 				}
 			/>
 			<CardContent>
-				<Typography variant="body2">
+				<Typography>
 					Stadium is a place for outdoor sports, concerts, or other events and
 					activities.
 				</Typography>

--- a/examples/mui/Card.menu.tsx
+++ b/examples/mui/Card.menu.tsx
@@ -38,7 +38,7 @@ export default () => {
 				action={<ActionsMenu />}
 			/>
 			<CardContent>
-				<Typography variant="body2">
+				<Typography>
 					Stadium is a place for outdoor sports, concerts, or other events and
 					activities.
 				</Typography>

--- a/examples/mui/Typography._mui-variants.tsx
+++ b/examples/mui/Typography._mui-variants.tsx
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
+export default () => {
+	return (
+		<Stack spacing={1}>
+			<Typography variant="body1">Body1</Typography>
+			<Typography variant="body2">Body2</Typography>
+			<Typography variant="button">Button</Typography>
+			<Typography variant="caption">Caption</Typography>
+			<Typography variant="h1" render={<div />}>
+				H1
+			</Typography>
+			<Typography variant="h2" render={<div />}>
+				H2
+			</Typography>
+			<Typography variant="h3" render={<div />}>
+				H3
+			</Typography>
+			<Typography variant="h4" render={<div />}>
+				H4
+			</Typography>
+			<Typography variant="h5" render={<div />}>
+				H5
+			</Typography>
+			<Typography variant="h6" render={<div />}>
+				H6
+			</Typography>
+			<Typography variant="inherit">inherit</Typography>
+			<Typography variant="overline">overline</Typography>
+			<Typography variant="subtitle1" render={<div />}>
+				subtitle1
+			</Typography>
+			<Typography variant="subtitle2" render={<div />}>
+				subtitle2
+			</Typography>
+		</Stack>
+	);
+};

--- a/examples/mui/Typography.variants.tsx
+++ b/examples/mui/Typography.variants.tsx
@@ -9,53 +9,40 @@ import Typography from "@mui/material/Typography";
 export default () => {
 	return (
 		<Stack spacing={1}>
-			<Typography variant="display-lg">display-lg</Typography>
-			<Typography variant="display-md">display-md</Typography>
-			<Typography variant="display-sm">display-sm</Typography>
-			<Typography variant="headline-lg">headline-lg</Typography>
-			<Typography variant="headline-md">headline-md</Typography>
-			<Typography variant="headline-sm">headline-sm</Typography>
+			<Typography variant="display-lg" render={<div />}>
+				display-lg
+			</Typography>
+			<Typography variant="display-md" render={<div />}>
+				display-md
+			</Typography>
+			<Typography variant="display-sm" render={<div />}>
+				display-sm
+			</Typography>
+			<Typography variant="headline-lg" render={<div />}>
+				headline-lg
+			</Typography>
+			<Typography variant="headline-md" render={<div />}>
+				headline-md
+			</Typography>
+			<Typography variant="headline-sm" render={<div />}>
+				headline-sm
+			</Typography>
 			<Typography variant="body-lg">body-lg</Typography>
 			<Typography variant="body-md">body-md</Typography>
 			<Typography variant="body-sm">body-sm</Typography>
-			<Typography variant="subtitle-lg">subtitle-lg</Typography>
-			<Typography variant="subtitle-md">subtitle-md</Typography>
-			<Typography variant="subtitle-sm">subtitle-sm</Typography>
+			<Typography variant="subtitle-lg" render={<div />}>
+				subtitle-lg
+			</Typography>
+			<Typography variant="subtitle-md" render={<div />}>
+				subtitle-md
+			</Typography>
+			<Typography variant="subtitle-sm" render={<div />}>
+				subtitle-sm
+			</Typography>
 			<Typography variant="caption-lg">caption-lg</Typography>
 			<Typography variant="caption-md">caption-md</Typography>
 			<Typography variant="caption-sm">caption-sm</Typography>
 			<Typography variant="mono-sm">mono-sm</Typography>
-
-			<Typography variant="body1">Body1</Typography>
-			<Typography variant="body2">Body2</Typography>
-			<Typography variant="button">Button</Typography>
-			<Typography variant="caption">Caption</Typography>
-			<Typography variant="h1" render={<div />}>
-				H1
-			</Typography>
-			<Typography variant="h2" render={<div />}>
-				H2
-			</Typography>
-			<Typography variant="h3" render={<div />}>
-				H3
-			</Typography>
-			<Typography variant="h4" render={<div />}>
-				H4
-			</Typography>
-			<Typography variant="h5" render={<div />}>
-				H5
-			</Typography>
-			<Typography variant="h6" render={<div />}>
-				H6
-			</Typography>
-			<Typography variant="inherit">inherit</Typography>
-			<Typography variant="overline">overline</Typography>
-			<Typography variant="subtitle1" render={<div />}>
-				subtitle1
-			</Typography>
-			<Typography variant="subtitle2" render={<div />}>
-				subtitle2
-			</Typography>
 		</Stack>
 	);
 };

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -11,7 +11,11 @@ import type { RoleProps } from "@ariakit/react/role";
 import type { AlertProps } from "@mui/material/Alert";
 import type { BadgeProps } from "@mui/material/Badge";
 import type { IconButtonProps } from "@mui/material/IconButton";
-import type { CommonProps } from "@mui/material/OverridableComponent";
+import type {
+	CommonProps,
+	DefaultComponentProps,
+	OverridableTypeMap,
+} from "@mui/material/OverridableComponent";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";
@@ -20,7 +24,10 @@ import type {
 	TextFieldVariants,
 } from "@mui/material/TextField";
 import type { TooltipProps } from "@mui/material/Tooltip";
-import type { TypographyProps } from "@mui/material/Typography";
+import type {
+	TypographyProps,
+	TypographyTypeMap,
+} from "@mui/material/Typography";
 import type * as React from "react";
 
 declare module "@mui/material/OverridableComponent" {
@@ -40,6 +47,15 @@ declare module "@mui/material/OverridableComponent" {
 
 		/** @deprecated Use `render` prop instead. */
 		component?: React.ElementType;
+	}
+
+	interface OverridableComponent<TypeMap extends OverridableTypeMap> {
+		// biome-ignore lint/style/useShorthandFunctionType: Interface with call signature is necessary when merging.
+		(
+			props:
+				| DefaultComponentProps<TypeMap>
+				| TypographyOverridableComponentProps<TypeMap>,
+		): React.JSX.Element | null;
 	}
 }
 
@@ -460,6 +476,52 @@ declare module "@mui/material/Tooltip" {
 	}
 }
 
+// These headings variants are declared separately from TypographyPropsVariantOverrides,
+// so that we can force the `render` prop to be required for these variants.
+type TypographyHeadingVariantProps = {
+	variant:
+		| "display-lg"
+		| "display-md"
+		| "display-sm"
+		| "headline-lg"
+		| "headline-md"
+		| "headline-sm"
+		| "subtitle-lg"
+		| "subtitle-md"
+		| "subtitle-sm"
+		| "h1"
+		| "h2"
+		| "h3"
+		| "h4"
+		| "h5"
+		| "h6"
+		| "subtitle1"
+		| "subtitle2";
+	/**
+	 * When using a heading-like `variant`, the `render` prop must be manually set to the most semantically appropriate element.
+	 *
+	 * Pick the most appropriate heading element ([`<h1>` to `<h6>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements))
+	 * required to maintain proper [heading structure](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/) in your application.
+	 *
+	 * @example
+	 * ```tsx
+	 * render={<h2 />}>
+	 * ```
+	 *
+	 * Do not use heading elements when you simply want to grab attention with large variants.
+	 */
+	render: NonNullable<RoleProps["render"]>;
+};
+
+type TypographyOverridableComponentProps<TypeMap extends OverridableTypeMap> =
+	TypeMap extends TypographyTypeMap
+		? Omit<
+				DefaultComponentProps<TypeMap>,
+				keyof TypographyHeadingVariantProps
+			> &
+				TypographyHeadingVariantProps
+		: never;
+
 declare module "@mui/material/Typography" {
 	interface TypographyPropsColorOverrides {
 		secondary: false;
@@ -467,22 +529,24 @@ declare module "@mui/material/Typography" {
 	}
 
 	interface TypographyPropsVariantOverrides {
-		"display-lg": true;
-		"display-md": true;
-		"display-sm": true;
-		"headline-lg": true;
-		"headline-md": true;
-		"headline-sm": true;
+		// Additional custom variants (non-heading).
 		"body-lg": true;
 		"body-md": true;
 		"body-sm": true;
-		"subtitle-lg": true;
-		"subtitle-md": true;
-		"subtitle-sm": true;
 		"caption-lg": true;
 		"caption-md": true;
 		"caption-sm": true;
 		"mono-sm": true;
+
+		// Stock MUI heading variants are removed here and re-added above, with the `render` prop required.
+		h1: false;
+		h2: false;
+		h3: false;
+		h4: false;
+		h5: false;
+		h6: false;
+		subtitle1: false;
+		subtitle2: false;
 	}
 
 	interface TypographyOwnProps {

--- a/packages/mui/src/~components/MuiTypography.tsx
+++ b/packages/mui/src/~components/MuiTypography.tsx
@@ -6,7 +6,6 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 
-import type { TypographyOwnProps } from "@mui/material/Typography";
 import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
 // ----------------------------------------------------------------------------
@@ -26,7 +25,7 @@ const variantMapping = {
 	button: "span",
 	caption: "span",
 	overline: "span",
-} satisfies TypographyOwnProps["variantMapping"];
+};
 
 const muiVariants = Object.keys(
 	variantMapping,


### PR DESCRIPTION
### Changes

_Follow-up to #1433._

This PR updates the types of the `Typography` component to require the `render` prop when using a heading (or heading-like) `variant`. No runtime changes.

This applies to both stock MUI and custom StrataKit variants:
- Stock: `"h1"`, `"h2"`, `"h3"`, `"h4"`, `"h5"`, `"h6"`, `"subtitle1"`, `"subtitle2"`
- Custom: `"display-*"` / `"headline-*"` / `"subtitle-*"`

The implementation in `types.d.ts` was a bit tricky. Normally, discriminated unions should be enough, but MUI's variant overrides logic was interfering with it. The fix was to take control of it at a higher level, where the `props` are defined through [`OverridableComponent`](https://github.com/mui/material-ui/blob/a8f042ac06d63aad13e1029ba2bac1521d267707/packages/mui-material/src/OverridableComponent/index.ts#L10). Here, we narrow the `OverridableComponent` instance by [`TypographyTypeMap`](https://github.com/mui/material-ui/blob/a8f042ac06d63aad13e1029ba2bac1521d267707/packages/mui-material/src/Typography/Typography.d.ts#L98). Once found, we remove the heading variants from the default path and re-add it with the `render` prop required. We also remove the stock MUI heading variants in `TypographyPropsVariantOverrides` to make it use the same code path as the custom variants.

### Testing

Confirmed that TypeScript flags any heading variant used without `render`, for both custom and stock variants.

<details>
<summary>IDE experience</summary>

https://github.com/user-attachments/assets/17ff5993-74b8-4a83-9013-7fe5887ebf77


https://github.com/user-attachments/assets/7ae248ae-f8f6-4908-93c5-a89e7f2d4787



</details>

Removed all instances of stock MUI variants in the test-app. Added a private example (hidden from docs) to showcase MUI variants.

### Documentation

- Updated several parts of documentation to more clearly explain that the `render` prop needs to be used for heading variants.
- Removed all instances of stock MUI variants, replacing them with custom StrataKit variants.
- Added custom JSDocs for `render` prop in `Typography`.
