### PR TITLE
update default `Card` variant

### DIFF
--- a/.changeset/cozy-places-wave.md
+++ b/.changeset/cozy-places-wave.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Changed the default `variant` of `Card` to `"outlined"`.

--- a/apps/website/src/content/docs/components/mui/Card.md
+++ b/apps/website/src/content/docs/components/mui/Card.md
@@ -27,6 +27,7 @@ Make sure the **Card** is suitable for your use case. There may be other, more a
 - `Card` is rendered as an [`<article>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article) element by default. This programmatically indicates the bounds of the **Card’s** contents.
 - `CardHeader`'s `title` is rendered as an `<h2>` by default.
 - `CardActionArea` has been redesigned to no longer wrap the entire card content. Instead, it should be used in the **Card's** title.
+- `Card` defaults to `variant="outlined"`.
 
 ## Examples
 

--- a/examples/mui/Card.actions.tsx
+++ b/examples/mui/Card.actions.tsx
@@ -15,7 +15,7 @@ import styles from "./Card.actions.module.css";
 
 export default () => {
 	return (
-		<Card className={styles.card} variant="outlined">
+		<Card className={styles.card}>
 			<CardMedia
 				className={styles.media}
 				render={

--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -14,7 +14,7 @@ import styles from "./Card.default.module.css";
 
 export default () => {
 	return (
-		<Card className={styles.card} variant="outlined">
+		<Card className={styles.card}>
 			<CardMedia
 				className={styles.media}
 				render={

--- a/examples/mui/Card.menu.tsx
+++ b/examples/mui/Card.menu.tsx
@@ -21,7 +21,7 @@ import styles from "./Card.menu.module.css";
 
 export default () => {
 	return (
-		<Card className={styles.card} variant="outlined">
+		<Card className={styles.card}>
 			<CardMedia
 				className={styles.media}
 				render={

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -181,6 +181,17 @@ declare module "@mui/material/BottomNavigationAction" {
 	}
 }
 
+declare module "@mui/material/Card" {
+	interface CardOwnProps {
+		/**
+		 * The default variant with `@stratakit/mui` is `"outlined"`.
+		 *
+		 * @default 'outlined'
+		 */
+		variant?: "outlined" | "elevation";
+	}
+}
+
 declare module "@mui/material/CardActionArea" {
 	interface CardActionAreaOwnProps {
 		LinkComponent?: never;

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -274,7 +274,12 @@ function createTheme(args: CreateThemeArgs) {
 					disableRipple: true, // ButtonGroup overrides Button's disableRipple so we need to set it here as well
 				},
 			},
-			MuiCard: { defaultProps: { component: MuiCard } },
+			MuiCard: {
+				defaultProps: {
+					component: MuiCard,
+					variant: "outlined",
+				},
+			},
 			MuiCardActionArea: {
 				defaultProps: {
 					component: MuiCardActionArea,


### PR DESCRIPTION
### Changes

Changed the default value of `Card`'s `variant` prop to `"outlined"`.

The previous default `"elevation"` leads to a barely visible card (without borders), at least in the default configuration of the `elevation` prop.

#### Future

In the future, it would make sense to properly support both, in a way that `"elevation"` Cards have a background+shadow, and `"outlined"` Cards only have a border. The same applies to other `Paper` components, such as `Accordion`.

### Testing

Removed explicit `variant="outlined"` from examples and verified visuals are unchanged.