### PR TITLE
`Typography`: change default element of stock heading variants

### DIFF
--- a/.changeset/shy-worlds-say.md
+++ b/.changeset/shy-worlds-say.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Changed the stock heading and subtitle variants of the `Typography` component to render as `<h2>` elements by default, except for the `"h1"` variant which still renders as `<h1>`. For all of these variants, the `render` prop is now required.

--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -15,6 +15,7 @@ links:
 - Several new [`variant`s](#variants) have been added.
 - The default `variant` is now `"inherit"` instead of `"body1"`.
 - The `render` prop is required to be set for all heading variants.
+- The stock MUI heading and subtitle `variant`s all map to `<h2>` elements by default, except for the `"h1"` variant which still maps to `<h1>`. In all these cases, the `render` prop is required.
 - The `"secondary"` color value has been removed. A `"textTertiary"` color value has been added.
 
 ## Examples

--- a/packages/mui/src/~components/MuiTypography.tsx
+++ b/packages/mui/src/~components/MuiTypography.tsx
@@ -13,12 +13,12 @@ import type { BaseProps } from "@stratakit/foundations/secret-internals";
 const variantMapping = {
 	h1: "h1",
 	h2: "h2",
-	h3: "h3",
-	h4: "h4",
-	h5: "h5",
-	h6: "h6",
-	subtitle1: "h6",
-	subtitle2: "h6",
+	h3: "h2",
+	h4: "h2",
+	h5: "h2",
+	h6: "h2",
+	subtitle1: "h2",
+	subtitle2: "h2",
 	body1: "p",
 	body2: "p",
 	inherit: "p",
@@ -65,4 +65,4 @@ DEV: MuiTypography.displayName = "MuiTypography";
 
 // ----------------------------------------------------------------------------
 
-export { MuiTypography };
+export { MuiTypography, variantMapping };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -49,7 +49,7 @@ import {
 } from "./~components/MuiTable.js";
 import { MuiTabs } from "./~components/MuiTabs.js";
 import { MuiToggleButton } from "./~components/MuiToggleButton.js";
-import { MuiTypography } from "./~components/MuiTypography.js";
+import { MuiTypography, variantMapping } from "./~components/MuiTypography.js";
 import {
 	ArrowDownIcon,
 	CaretsUpDownIcon,
@@ -554,6 +554,7 @@ function createTheme(args: CreateThemeArgs) {
 			MuiTypography: {
 				defaultProps: {
 					variant: "inherit",
+					variantMapping,
 					component: MuiTypography,
 				},
 				variants: [


### PR DESCRIPTION
### Changes

_Follow-up to #1547_

This is a change to the runtime logic of `Typography`. (#1547 was only changing types)

The default rendered element and the variant mapping of stock heading variants has been changed to use the safer `<h2>` default, except for `variant="h1"` which still renders `<h1>`.

This is a fallback mechanism for cases where the rendered element is not overridden by the consumer.

Default rendered element for affected variants:

| variant | Before | After |
| --- | --- | --- |
| `"h1"` | `<h1>` | `<h1>` |
| `"h2"` | `<h2>` | `<h2>` |
| `"h3"` | `<h3>` | `<h2>` |
| `"h4"` | `<h4>` | `<h2>` |
| `"h5"` | `<h5>` | `<h2>` |
| `"h6"` | `<h6>` | `<h2>` |
| `"subtitle1"` | `<h6>` | `<h2>` |
| `"subtitle2"` | `<h6>` | `<h2>` |

### Testing

Temporarily removed `variant={<div />}` from the `Typography._mui-variants` example and confirmed that `<h2>` is rendered.