### PR TITLE
set explicit font-size in `ErrorRegion`

### DIFF
--- a/.changeset/purple-parts-rest.md
+++ b/.changeset/purple-parts-rest.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fixed font-size for inherited typographical elements inside `ErrorRegion.Item` actions.

--- a/packages/structures/src/ErrorRegion.css
+++ b/packages/structures/src/ErrorRegion.css
@@ -6,6 +6,7 @@
 	--✨padding: var(--stratakit-space-x1);
 
 	@layer base {
+		@apply --typography("body-sm");
 		position: relative;
 		z-index: 1;
 	}


### PR DESCRIPTION
### Changes

This fixes a longstanding issue in `ErrorRegion`, where typographical elements (such as `Typography` and `Link` components) were using the global `"body-md"` font-size, instead of `"body-sm"` like the rest of `ErrorRegion`.

This started happening after the root font-size was increased to `0.875rem` when switching the `Root` import from `@stratakit/foundations` to `@stratakit/mui`.

Related: https://github.com/iTwin/stratakit/discussions/1405

### Testing

| Before | After |
| --- | --- |
| <img width="396" height="194" alt="image" src="https://github.com/user-attachments/assets/934710a3-8137-421e-ae9e-a727671ae44d" /> | <img width="397" height="188" alt="image" src="https://github.com/user-attachments/assets/1ee0fc76-a1be-42cc-a28b-426be7a9a66b" /> |
