### PR TITLE
Update esbuild to fix GHSA-gv7w-rqvm-qjhr

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ catalogs:
       specifier: ^19.2.3
       version: 19.2.3
     esbuild:
-      specifier: ^0.28.1
+      specifier: ">=0.28.1"
       version: 0.28.1
     react:
       specifier: ^19.2.7
@@ -1070,15 +1070,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/aix-ppc64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [aix]
-
   "@esbuild/aix-ppc64@0.28.1":
     resolution:
       {
@@ -1092,15 +1083,6 @@ packages:
     resolution:
       {
         integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1124,15 +1106,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-arm@0.28.0":
-    resolution:
-      {
-        integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
-    os: [android]
-
   "@esbuild/android-arm@0.28.1":
     resolution:
       {
@@ -1146,15 +1119,6 @@ packages:
     resolution:
       {
         integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [android]
-
-  "@esbuild/android-x64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1178,15 +1142,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-arm64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [darwin]
-
   "@esbuild/darwin-arm64@0.28.1":
     resolution:
       {
@@ -1200,15 +1155,6 @@ packages:
     resolution:
       {
         integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1232,15 +1178,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-arm64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [freebsd]
-
   "@esbuild/freebsd-arm64@0.28.1":
     resolution:
       {
@@ -1254,15 +1191,6 @@ packages:
     resolution:
       {
         integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1286,15 +1214,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [linux]
-
   "@esbuild/linux-arm64@0.28.1":
     resolution:
       {
@@ -1308,15 +1227,6 @@ packages:
     resolution:
       {
         integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.28.0":
-    resolution:
-      {
-        integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
@@ -1340,15 +1250,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.28.0":
-    resolution:
-      {
-        integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [linux]
-
   "@esbuild/linux-ia32@0.28.1":
     resolution:
       {
@@ -1362,15 +1263,6 @@ packages:
     resolution:
       {
         integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
-      }
-    engines: { node: ">=18" }
-    cpu: [loong64]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==,
       }
     engines: { node: ">=18" }
     cpu: [loong64]
@@ -1394,15 +1286,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.28.0":
-    resolution:
-      {
-        integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [mips64el]
-    os: [linux]
-
   "@esbuild/linux-mips64el@0.28.1":
     resolution:
       {
@@ -1416,15 +1299,6 @@ packages:
     resolution:
       {
         integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
@@ -1448,15 +1322,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [riscv64]
-    os: [linux]
-
   "@esbuild/linux-riscv64@0.28.1":
     resolution:
       {
@@ -1470,15 +1335,6 @@ packages:
     resolution:
       {
         integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [s390x]
-    os: [linux]
-
-  "@esbuild/linux-s390x@0.28.0":
-    resolution:
-      {
-        integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==,
       }
     engines: { node: ">=18" }
     cpu: [s390x]
@@ -1502,15 +1358,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/linux-x64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [linux]
-
   "@esbuild/linux-x64@0.28.1":
     resolution:
       {
@@ -1524,15 +1371,6 @@ packages:
     resolution:
       {
         integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [netbsd]
-
-  "@esbuild/netbsd-arm64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1556,15 +1394,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [netbsd]
-
   "@esbuild/netbsd-x64@0.28.1":
     resolution:
       {
@@ -1578,15 +1407,6 @@ packages:
     resolution:
       {
         integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-arm64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1610,15 +1430,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [openbsd]
-
   "@esbuild/openbsd-x64@0.28.1":
     resolution:
       {
@@ -1632,15 +1443,6 @@ packages:
     resolution:
       {
         integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openharmony]
-
-  "@esbuild/openharmony-arm64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1664,15 +1466,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/sunos-x64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [sunos]
-
   "@esbuild/sunos-x64@0.28.1":
     resolution:
       {
@@ -1686,15 +1479,6 @@ packages:
     resolution:
       {
         integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [win32]
-
-  "@esbuild/win32-arm64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1718,15 +1502,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.28.0":
-    resolution:
-      {
-        integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [win32]
-
   "@esbuild/win32-ia32@0.28.1":
     resolution:
       {
@@ -1740,15 +1515,6 @@ packages:
     resolution:
       {
         integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.28.0":
-    resolution:
-      {
-        integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -3420,14 +3186,6 @@ packages:
     resolution:
       {
         integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
-      }
-    engines: { node: ">=18" }
-    hasBin: true
-
-  esbuild@0.28.0:
-    resolution:
-      {
-        integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -6446,16 +6204,10 @@ snapshots:
   "@esbuild/aix-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/aix-ppc64@0.28.0":
-    optional: true
-
   "@esbuild/aix-ppc64@0.28.1":
     optional: true
 
   "@esbuild/android-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/android-arm64@0.28.0":
     optional: true
 
   "@esbuild/android-arm64@0.28.1":
@@ -6464,16 +6216,10 @@ snapshots:
   "@esbuild/android-arm@0.27.7":
     optional: true
 
-  "@esbuild/android-arm@0.28.0":
-    optional: true
-
   "@esbuild/android-arm@0.28.1":
     optional: true
 
   "@esbuild/android-x64@0.27.7":
-    optional: true
-
-  "@esbuild/android-x64@0.28.0":
     optional: true
 
   "@esbuild/android-x64@0.28.1":
@@ -6482,16 +6228,10 @@ snapshots:
   "@esbuild/darwin-arm64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-arm64@0.28.0":
-    optional: true
-
   "@esbuild/darwin-arm64@0.28.1":
     optional: true
 
   "@esbuild/darwin-x64@0.27.7":
-    optional: true
-
-  "@esbuild/darwin-x64@0.28.0":
     optional: true
 
   "@esbuild/darwin-x64@0.28.1":
@@ -6500,16 +6240,10 @@ snapshots:
   "@esbuild/freebsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.28.0":
-    optional: true
-
   "@esbuild/freebsd-arm64@0.28.1":
     optional: true
 
   "@esbuild/freebsd-x64@0.27.7":
-    optional: true
-
-  "@esbuild/freebsd-x64@0.28.0":
     optional: true
 
   "@esbuild/freebsd-x64@0.28.1":
@@ -6518,16 +6252,10 @@ snapshots:
   "@esbuild/linux-arm64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm64@0.28.0":
-    optional: true
-
   "@esbuild/linux-arm64@0.28.1":
     optional: true
 
   "@esbuild/linux-arm@0.27.7":
-    optional: true
-
-  "@esbuild/linux-arm@0.28.0":
     optional: true
 
   "@esbuild/linux-arm@0.28.1":
@@ -6536,16 +6264,10 @@ snapshots:
   "@esbuild/linux-ia32@0.27.7":
     optional: true
 
-  "@esbuild/linux-ia32@0.28.0":
-    optional: true
-
   "@esbuild/linux-ia32@0.28.1":
     optional: true
 
   "@esbuild/linux-loong64@0.27.7":
-    optional: true
-
-  "@esbuild/linux-loong64@0.28.0":
     optional: true
 
   "@esbuild/linux-loong64@0.28.1":
@@ -6554,16 +6276,10 @@ snapshots:
   "@esbuild/linux-mips64el@0.27.7":
     optional: true
 
-  "@esbuild/linux-mips64el@0.28.0":
-    optional: true
-
   "@esbuild/linux-mips64el@0.28.1":
     optional: true
 
   "@esbuild/linux-ppc64@0.27.7":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.28.0":
     optional: true
 
   "@esbuild/linux-ppc64@0.28.1":
@@ -6572,16 +6288,10 @@ snapshots:
   "@esbuild/linux-riscv64@0.27.7":
     optional: true
 
-  "@esbuild/linux-riscv64@0.28.0":
-    optional: true
-
   "@esbuild/linux-riscv64@0.28.1":
     optional: true
 
   "@esbuild/linux-s390x@0.27.7":
-    optional: true
-
-  "@esbuild/linux-s390x@0.28.0":
     optional: true
 
   "@esbuild/linux-s390x@0.28.1":
@@ -6590,16 +6300,10 @@ snapshots:
   "@esbuild/linux-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-x64@0.28.0":
-    optional: true
-
   "@esbuild/linux-x64@0.28.1":
     optional: true
 
   "@esbuild/netbsd-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.28.0":
     optional: true
 
   "@esbuild/netbsd-arm64@0.28.1":
@@ -6608,16 +6312,10 @@ snapshots:
   "@esbuild/netbsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/netbsd-x64@0.28.0":
-    optional: true
-
   "@esbuild/netbsd-x64@0.28.1":
     optional: true
 
   "@esbuild/openbsd-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.28.0":
     optional: true
 
   "@esbuild/openbsd-arm64@0.28.1":
@@ -6626,16 +6324,10 @@ snapshots:
   "@esbuild/openbsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/openbsd-x64@0.28.0":
-    optional: true
-
   "@esbuild/openbsd-x64@0.28.1":
     optional: true
 
   "@esbuild/openharmony-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.28.0":
     optional: true
 
   "@esbuild/openharmony-arm64@0.28.1":
@@ -6644,16 +6336,10 @@ snapshots:
   "@esbuild/sunos-x64@0.27.7":
     optional: true
 
-  "@esbuild/sunos-x64@0.28.0":
-    optional: true
-
   "@esbuild/sunos-x64@0.28.1":
     optional: true
 
   "@esbuild/win32-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/win32-arm64@0.28.0":
     optional: true
 
   "@esbuild/win32-arm64@0.28.1":
@@ -6662,16 +6348,10 @@ snapshots:
   "@esbuild/win32-ia32@0.27.7":
     optional: true
 
-  "@esbuild/win32-ia32@0.28.0":
-    optional: true
-
   "@esbuild/win32-ia32@0.28.1":
     optional: true
 
   "@esbuild/win32-x64@0.27.7":
-    optional: true
-
-  "@esbuild/win32-x64@0.28.0":
     optional: true
 
   "@esbuild/win32-x64@0.28.1":
@@ -7693,35 +7373,6 @@ snapshots:
       "@esbuild/win32-arm64": 0.27.7
       "@esbuild/win32-ia32": 0.27.7
       "@esbuild/win32-x64": 0.27.7
-
-  esbuild@0.28.0:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.28.0
-      "@esbuild/android-arm": 0.28.0
-      "@esbuild/android-arm64": 0.28.0
-      "@esbuild/android-x64": 0.28.0
-      "@esbuild/darwin-arm64": 0.28.0
-      "@esbuild/darwin-x64": 0.28.0
-      "@esbuild/freebsd-arm64": 0.28.0
-      "@esbuild/freebsd-x64": 0.28.0
-      "@esbuild/linux-arm": 0.28.0
-      "@esbuild/linux-arm64": 0.28.0
-      "@esbuild/linux-ia32": 0.28.0
-      "@esbuild/linux-loong64": 0.28.0
-      "@esbuild/linux-mips64el": 0.28.0
-      "@esbuild/linux-ppc64": 0.28.0
-      "@esbuild/linux-riscv64": 0.28.0
-      "@esbuild/linux-s390x": 0.28.0
-      "@esbuild/linux-x64": 0.28.0
-      "@esbuild/netbsd-arm64": 0.28.0
-      "@esbuild/netbsd-x64": 0.28.0
-      "@esbuild/openbsd-arm64": 0.28.0
-      "@esbuild/openbsd-x64": 0.28.0
-      "@esbuild/openharmony-arm64": 0.28.0
-      "@esbuild/sunos-x64": 0.28.0
-      "@esbuild/win32-arm64": 0.28.0
-      "@esbuild/win32-ia32": 0.28.0
-      "@esbuild/win32-x64": 0.28.0
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -9328,7 +8979,7 @@ snapshots:
 
   tsx@4.22.4:
     dependencies:
-      esbuild: 0.28.0
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^19.2.3
       version: 19.2.3
     esbuild:
-      specifier: ^0.28.0
-      version: 0.28.0
+      specifier: ^0.28.1
+      version: 0.28.1
     react:
       specifier: ^19.2.7
       version: 19.2.7
@@ -175,7 +175,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
         specifier: "catalog:"
-        version: 0.28.0
+        version: 0.28.1
       lightningcss:
         specifier: 1.30.1
         version: 1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce)
@@ -352,7 +352,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
         specifier: "catalog:"
-        version: 0.28.0
+        version: 0.28.1
       react:
         specifier: "catalog:"
         version: 19.2.7
@@ -386,7 +386,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
         specifier: "catalog:"
-        version: 0.28.0
+        version: 0.28.1
       lightningcss:
         specifier: 1.30.1
         version: 1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce)
@@ -440,7 +440,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
         specifier: "catalog:"
-        version: 0.28.0
+        version: 0.28.1
       react:
         specifier: "catalog:"
         version: 19.2.7
@@ -483,7 +483,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
         specifier: "catalog:"
-        version: 0.28.0
+        version: 0.28.1
       react:
         specifier: "catalog:"
         version: 19.2.7
@@ -1079,6 +1079,15 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  "@esbuild/aix-ppc64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
   "@esbuild/android-arm64@0.27.7":
     resolution:
       {
@@ -1092,6 +1101,15 @@ packages:
     resolution:
       {
         integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1115,6 +1133,15 @@ packages:
     cpu: [arm]
     os: [android]
 
+  "@esbuild/android-arm@0.28.1":
+    resolution:
+      {
+        integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
   "@esbuild/android-x64@0.27.7":
     resolution:
       {
@@ -1128,6 +1155,15 @@ packages:
     resolution:
       {
         integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/android-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1151,6 +1187,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  "@esbuild/darwin-arm64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@esbuild/darwin-x64@0.27.7":
     resolution:
       {
@@ -1164,6 +1209,15 @@ packages:
     resolution:
       {
         integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1187,6 +1241,15 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  "@esbuild/freebsd-arm64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
   "@esbuild/freebsd-x64@0.27.7":
     resolution:
       {
@@ -1200,6 +1263,15 @@ packages:
     resolution:
       {
         integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1223,6 +1295,15 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@esbuild/linux-arm64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
   "@esbuild/linux-arm@0.27.7":
     resolution:
       {
@@ -1236,6 +1317,15 @@ packages:
     resolution:
       {
         integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.28.1":
+    resolution:
+      {
+        integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
@@ -1259,6 +1349,15 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  "@esbuild/linux-ia32@0.28.1":
+    resolution:
+      {
+        integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
   "@esbuild/linux-loong64@0.27.7":
     resolution:
       {
@@ -1272,6 +1371,15 @@ packages:
     resolution:
       {
         integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==,
       }
     engines: { node: ">=18" }
     cpu: [loong64]
@@ -1295,6 +1403,15 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  "@esbuild/linux-mips64el@0.28.1":
+    resolution:
+      {
+        integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
   "@esbuild/linux-ppc64@0.27.7":
     resolution:
       {
@@ -1308,6 +1425,15 @@ packages:
     resolution:
       {
         integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
@@ -1331,6 +1457,15 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  "@esbuild/linux-riscv64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
   "@esbuild/linux-s390x@0.27.7":
     resolution:
       {
@@ -1344,6 +1479,15 @@ packages:
     resolution:
       {
         integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.28.1":
+    resolution:
+      {
+        integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==,
       }
     engines: { node: ">=18" }
     cpu: [s390x]
@@ -1367,6 +1511,15 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  "@esbuild/linux-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
   "@esbuild/netbsd-arm64@0.27.7":
     resolution:
       {
@@ -1380,6 +1533,15 @@ packages:
     resolution:
       {
         integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-arm64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1403,6 +1565,15 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  "@esbuild/netbsd-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
   "@esbuild/openbsd-arm64@0.27.7":
     resolution:
       {
@@ -1416,6 +1587,15 @@ packages:
     resolution:
       {
         integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-arm64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1439,6 +1619,15 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  "@esbuild/openbsd-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [openbsd]
+
   "@esbuild/openharmony-arm64@0.27.7":
     resolution:
       {
@@ -1452,6 +1641,15 @@ packages:
     resolution:
       {
         integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@esbuild/openharmony-arm64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1475,6 +1673,15 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  "@esbuild/sunos-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
   "@esbuild/win32-arm64@0.27.7":
     resolution:
       {
@@ -1488,6 +1695,15 @@ packages:
     resolution:
       {
         integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-arm64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1511,6 +1727,15 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  "@esbuild/win32-ia32@0.28.1":
+    resolution:
+      {
+        integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
   "@esbuild/win32-x64@0.27.7":
     resolution:
       {
@@ -1524,6 +1749,15 @@ packages:
     resolution:
       {
         integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -3194,6 +3428,14 @@ packages:
     resolution:
       {
         integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution:
+      {
+        integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -6207,10 +6449,16 @@ snapshots:
   "@esbuild/aix-ppc64@0.28.0":
     optional: true
 
+  "@esbuild/aix-ppc64@0.28.1":
+    optional: true
+
   "@esbuild/android-arm64@0.27.7":
     optional: true
 
   "@esbuild/android-arm64@0.28.0":
+    optional: true
+
+  "@esbuild/android-arm64@0.28.1":
     optional: true
 
   "@esbuild/android-arm@0.27.7":
@@ -6219,10 +6467,16 @@ snapshots:
   "@esbuild/android-arm@0.28.0":
     optional: true
 
+  "@esbuild/android-arm@0.28.1":
+    optional: true
+
   "@esbuild/android-x64@0.27.7":
     optional: true
 
   "@esbuild/android-x64@0.28.0":
+    optional: true
+
+  "@esbuild/android-x64@0.28.1":
     optional: true
 
   "@esbuild/darwin-arm64@0.27.7":
@@ -6231,10 +6485,16 @@ snapshots:
   "@esbuild/darwin-arm64@0.28.0":
     optional: true
 
+  "@esbuild/darwin-arm64@0.28.1":
+    optional: true
+
   "@esbuild/darwin-x64@0.27.7":
     optional: true
 
   "@esbuild/darwin-x64@0.28.0":
+    optional: true
+
+  "@esbuild/darwin-x64@0.28.1":
     optional: true
 
   "@esbuild/freebsd-arm64@0.27.7":
@@ -6243,10 +6503,16 @@ snapshots:
   "@esbuild/freebsd-arm64@0.28.0":
     optional: true
 
+  "@esbuild/freebsd-arm64@0.28.1":
+    optional: true
+
   "@esbuild/freebsd-x64@0.27.7":
     optional: true
 
   "@esbuild/freebsd-x64@0.28.0":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.28.1":
     optional: true
 
   "@esbuild/linux-arm64@0.27.7":
@@ -6255,10 +6521,16 @@ snapshots:
   "@esbuild/linux-arm64@0.28.0":
     optional: true
 
+  "@esbuild/linux-arm64@0.28.1":
+    optional: true
+
   "@esbuild/linux-arm@0.27.7":
     optional: true
 
   "@esbuild/linux-arm@0.28.0":
+    optional: true
+
+  "@esbuild/linux-arm@0.28.1":
     optional: true
 
   "@esbuild/linux-ia32@0.27.7":
@@ -6267,10 +6539,16 @@ snapshots:
   "@esbuild/linux-ia32@0.28.0":
     optional: true
 
+  "@esbuild/linux-ia32@0.28.1":
+    optional: true
+
   "@esbuild/linux-loong64@0.27.7":
     optional: true
 
   "@esbuild/linux-loong64@0.28.0":
+    optional: true
+
+  "@esbuild/linux-loong64@0.28.1":
     optional: true
 
   "@esbuild/linux-mips64el@0.27.7":
@@ -6279,10 +6557,16 @@ snapshots:
   "@esbuild/linux-mips64el@0.28.0":
     optional: true
 
+  "@esbuild/linux-mips64el@0.28.1":
+    optional: true
+
   "@esbuild/linux-ppc64@0.27.7":
     optional: true
 
   "@esbuild/linux-ppc64@0.28.0":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.28.1":
     optional: true
 
   "@esbuild/linux-riscv64@0.27.7":
@@ -6291,10 +6575,16 @@ snapshots:
   "@esbuild/linux-riscv64@0.28.0":
     optional: true
 
+  "@esbuild/linux-riscv64@0.28.1":
+    optional: true
+
   "@esbuild/linux-s390x@0.27.7":
     optional: true
 
   "@esbuild/linux-s390x@0.28.0":
+    optional: true
+
+  "@esbuild/linux-s390x@0.28.1":
     optional: true
 
   "@esbuild/linux-x64@0.27.7":
@@ -6303,10 +6593,16 @@ snapshots:
   "@esbuild/linux-x64@0.28.0":
     optional: true
 
+  "@esbuild/linux-x64@0.28.1":
+    optional: true
+
   "@esbuild/netbsd-arm64@0.27.7":
     optional: true
 
   "@esbuild/netbsd-arm64@0.28.0":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.28.1":
     optional: true
 
   "@esbuild/netbsd-x64@0.27.7":
@@ -6315,10 +6611,16 @@ snapshots:
   "@esbuild/netbsd-x64@0.28.0":
     optional: true
 
+  "@esbuild/netbsd-x64@0.28.1":
+    optional: true
+
   "@esbuild/openbsd-arm64@0.27.7":
     optional: true
 
   "@esbuild/openbsd-arm64@0.28.0":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.28.1":
     optional: true
 
   "@esbuild/openbsd-x64@0.27.7":
@@ -6327,10 +6629,16 @@ snapshots:
   "@esbuild/openbsd-x64@0.28.0":
     optional: true
 
+  "@esbuild/openbsd-x64@0.28.1":
+    optional: true
+
   "@esbuild/openharmony-arm64@0.27.7":
     optional: true
 
   "@esbuild/openharmony-arm64@0.28.0":
+    optional: true
+
+  "@esbuild/openharmony-arm64@0.28.1":
     optional: true
 
   "@esbuild/sunos-x64@0.27.7":
@@ -6339,10 +6647,16 @@ snapshots:
   "@esbuild/sunos-x64@0.28.0":
     optional: true
 
+  "@esbuild/sunos-x64@0.28.1":
+    optional: true
+
   "@esbuild/win32-arm64@0.27.7":
     optional: true
 
   "@esbuild/win32-arm64@0.28.0":
+    optional: true
+
+  "@esbuild/win32-arm64@0.28.1":
     optional: true
 
   "@esbuild/win32-ia32@0.27.7":
@@ -6351,10 +6665,16 @@ snapshots:
   "@esbuild/win32-ia32@0.28.0":
     optional: true
 
+  "@esbuild/win32-ia32@0.28.1":
+    optional: true
+
   "@esbuild/win32-x64@0.27.7":
     optional: true
 
   "@esbuild/win32-x64@0.28.0":
+    optional: true
+
+  "@esbuild/win32-x64@0.28.1":
     optional: true
 
   "@expressive-code/core@0.43.1":
@@ -7402,6 +7722,35 @@ snapshots:
       "@esbuild/win32-arm64": 0.28.0
       "@esbuild/win32-ia32": 0.28.0
       "@esbuild/win32-x64": 0.28.0
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.28.1
+      "@esbuild/android-arm": 0.28.1
+      "@esbuild/android-arm64": 0.28.1
+      "@esbuild/android-x64": 0.28.1
+      "@esbuild/darwin-arm64": 0.28.1
+      "@esbuild/darwin-x64": 0.28.1
+      "@esbuild/freebsd-arm64": 0.28.1
+      "@esbuild/freebsd-x64": 0.28.1
+      "@esbuild/linux-arm": 0.28.1
+      "@esbuild/linux-arm64": 0.28.1
+      "@esbuild/linux-ia32": 0.28.1
+      "@esbuild/linux-loong64": 0.28.1
+      "@esbuild/linux-mips64el": 0.28.1
+      "@esbuild/linux-ppc64": 0.28.1
+      "@esbuild/linux-riscv64": 0.28.1
+      "@esbuild/linux-s390x": 0.28.1
+      "@esbuild/linux-x64": 0.28.1
+      "@esbuild/netbsd-arm64": 0.28.1
+      "@esbuild/netbsd-x64": 0.28.1
+      "@esbuild/openbsd-arm64": 0.28.1
+      "@esbuild/openbsd-x64": 0.28.1
+      "@esbuild/openharmony-arm64": 0.28.1
+      "@esbuild/sunos-x64": 0.28.1
+      "@esbuild/win32-arm64": 0.28.1
+      "@esbuild/win32-ia32": 0.28.1
+      "@esbuild/win32-x64": 0.28.1
 
   escalade@3.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ catalogs:
     "@types/react-dom":
       specifier: ^19.2.3
       version: 19.2.3
-    esbuild:
-      specifier: ">=0.28.1"
-      version: 0.28.1
     react:
       specifier: ^19.2.7
       version: 19.2.7
@@ -39,6 +36,7 @@ catalogs:
 
 overrides:
   brace-expansion@<5.0.0: ^5.0.6
+  esbuild: ^0.28.1
   lightningcss: 1.30.1
 
 patchedDependencies:
@@ -174,7 +172,7 @@ importers:
         specifier: "catalog:"
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
-        specifier: "catalog:"
+        specifier: ^0.28.1
         version: 0.28.1
       lightningcss:
         specifier: 1.30.1
@@ -351,7 +349,7 @@ importers:
         specifier: "catalog:"
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
-        specifier: "catalog:"
+        specifier: ^0.28.1
         version: 0.28.1
       react:
         specifier: "catalog:"
@@ -385,7 +383,7 @@ importers:
         specifier: "catalog:"
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
-        specifier: "catalog:"
+        specifier: ^0.28.1
         version: 0.28.1
       lightningcss:
         specifier: 1.30.1
@@ -439,7 +437,7 @@ importers:
         specifier: "catalog:"
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
-        specifier: "catalog:"
+        specifier: ^0.28.1
         version: 0.28.1
       react:
         specifier: "catalog:"
@@ -482,7 +480,7 @@ importers:
         specifier: "catalog:"
         version: 19.2.3(@types/react@19.2.16)
       esbuild:
-        specifier: "catalog:"
+        specifier: ^0.28.1
         version: 0.28.1
       react:
         specifier: "catalog:"
@@ -1061,15 +1059,6 @@ packages:
         integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==,
       }
 
-  "@esbuild/aix-ppc64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [aix]
-
   "@esbuild/aix-ppc64@0.28.1":
     resolution:
       {
@@ -1079,15 +1068,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [android]
-
   "@esbuild/android-arm64@0.28.1":
     resolution:
       {
@@ -1095,15 +1075,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm@0.27.7":
-    resolution:
-      {
-        integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
     os: [android]
 
   "@esbuild/android-arm@0.28.1":
@@ -1115,15 +1086,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [android]
-
   "@esbuild/android-x64@0.28.1":
     resolution:
       {
@@ -1133,15 +1095,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [darwin]
-
   "@esbuild/darwin-arm64@0.28.1":
     resolution:
       {
@@ -1149,15 +1102,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [darwin]
 
   "@esbuild/darwin-x64@0.28.1":
@@ -1169,15 +1113,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [freebsd]
-
   "@esbuild/freebsd-arm64@0.28.1":
     resolution:
       {
@@ -1185,15 +1120,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [freebsd]
 
   "@esbuild/freebsd-x64@0.28.1":
@@ -1205,15 +1131,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [linux]
-
   "@esbuild/linux-arm64@0.28.1":
     resolution:
       {
@@ -1221,15 +1138,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.27.7":
-    resolution:
-      {
-        integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
     os: [linux]
 
   "@esbuild/linux-arm@0.28.1":
@@ -1241,15 +1149,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.27.7":
-    resolution:
-      {
-        integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [linux]
-
   "@esbuild/linux-ia32@0.28.1":
     resolution:
       {
@@ -1257,15 +1156,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
-      }
-    engines: { node: ">=18" }
-    cpu: [loong64]
     os: [linux]
 
   "@esbuild/linux-loong64@0.28.1":
@@ -1277,15 +1167,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.27.7":
-    resolution:
-      {
-        integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [mips64el]
-    os: [linux]
-
   "@esbuild/linux-mips64el@0.28.1":
     resolution:
       {
@@ -1293,15 +1174,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
     os: [linux]
 
   "@esbuild/linux-ppc64@0.28.1":
@@ -1313,15 +1185,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [riscv64]
-    os: [linux]
-
   "@esbuild/linux-riscv64@0.28.1":
     resolution:
       {
@@ -1329,15 +1192,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
-    os: [linux]
-
-  "@esbuild/linux-s390x@0.27.7":
-    resolution:
-      {
-        integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [s390x]
     os: [linux]
 
   "@esbuild/linux-s390x@0.28.1":
@@ -1349,15 +1203,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [linux]
-
   "@esbuild/linux-x64@0.28.1":
     resolution:
       {
@@ -1367,15 +1212,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [netbsd]
-
   "@esbuild/netbsd-arm64@0.28.1":
     resolution:
       {
@@ -1383,15 +1219,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [netbsd]
-
-  "@esbuild/netbsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [netbsd]
 
   "@esbuild/netbsd-x64@0.28.1":
@@ -1403,15 +1230,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openbsd]
-
   "@esbuild/openbsd-arm64@0.28.1":
     resolution:
       {
@@ -1419,15 +1237,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [openbsd]
 
   "@esbuild/openbsd-x64@0.28.1":
@@ -1439,15 +1248,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openharmony]
-
   "@esbuild/openharmony-arm64@0.28.1":
     resolution:
       {
@@ -1456,15 +1256,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
-
-  "@esbuild/sunos-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [sunos]
 
   "@esbuild/sunos-x64@0.28.1":
     resolution:
@@ -1475,15 +1266,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [win32]
-
   "@esbuild/win32-arm64@0.28.1":
     resolution:
       {
@@ -1493,15 +1275,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.27.7":
-    resolution:
-      {
-        integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [win32]
-
   "@esbuild/win32-ia32@0.28.1":
     resolution:
       {
@@ -1509,15 +1282,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [win32]
 
   "@esbuild/win32-x64@0.28.1":
@@ -3181,14 +2945,6 @@ packages:
       {
         integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
       }
-
-  esbuild@0.27.7:
-    resolution:
-      {
-        integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
-      }
-    engines: { node: ">=18" }
-    hasBin: true
 
   esbuild@0.28.1:
     resolution:
@@ -6201,157 +5957,79 @@ snapshots:
 
   "@emotion/weak-memoize@0.4.0": {}
 
-  "@esbuild/aix-ppc64@0.27.7":
-    optional: true
-
   "@esbuild/aix-ppc64@0.28.1":
-    optional: true
-
-  "@esbuild/android-arm64@0.27.7":
     optional: true
 
   "@esbuild/android-arm64@0.28.1":
     optional: true
 
-  "@esbuild/android-arm@0.27.7":
-    optional: true
-
   "@esbuild/android-arm@0.28.1":
-    optional: true
-
-  "@esbuild/android-x64@0.27.7":
     optional: true
 
   "@esbuild/android-x64@0.28.1":
     optional: true
 
-  "@esbuild/darwin-arm64@0.27.7":
-    optional: true
-
   "@esbuild/darwin-arm64@0.28.1":
-    optional: true
-
-  "@esbuild/darwin-x64@0.27.7":
     optional: true
 
   "@esbuild/darwin-x64@0.28.1":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.27.7":
-    optional: true
-
   "@esbuild/freebsd-arm64@0.28.1":
-    optional: true
-
-  "@esbuild/freebsd-x64@0.27.7":
     optional: true
 
   "@esbuild/freebsd-x64@0.28.1":
     optional: true
 
-  "@esbuild/linux-arm64@0.27.7":
-    optional: true
-
   "@esbuild/linux-arm64@0.28.1":
-    optional: true
-
-  "@esbuild/linux-arm@0.27.7":
     optional: true
 
   "@esbuild/linux-arm@0.28.1":
     optional: true
 
-  "@esbuild/linux-ia32@0.27.7":
-    optional: true
-
   "@esbuild/linux-ia32@0.28.1":
-    optional: true
-
-  "@esbuild/linux-loong64@0.27.7":
     optional: true
 
   "@esbuild/linux-loong64@0.28.1":
     optional: true
 
-  "@esbuild/linux-mips64el@0.27.7":
-    optional: true
-
   "@esbuild/linux-mips64el@0.28.1":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.27.7":
     optional: true
 
   "@esbuild/linux-ppc64@0.28.1":
     optional: true
 
-  "@esbuild/linux-riscv64@0.27.7":
-    optional: true
-
   "@esbuild/linux-riscv64@0.28.1":
-    optional: true
-
-  "@esbuild/linux-s390x@0.27.7":
     optional: true
 
   "@esbuild/linux-s390x@0.28.1":
     optional: true
 
-  "@esbuild/linux-x64@0.27.7":
-    optional: true
-
   "@esbuild/linux-x64@0.28.1":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.27.7":
     optional: true
 
   "@esbuild/netbsd-arm64@0.28.1":
     optional: true
 
-  "@esbuild/netbsd-x64@0.27.7":
-    optional: true
-
   "@esbuild/netbsd-x64@0.28.1":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.27.7":
     optional: true
 
   "@esbuild/openbsd-arm64@0.28.1":
     optional: true
 
-  "@esbuild/openbsd-x64@0.27.7":
-    optional: true
-
   "@esbuild/openbsd-x64@0.28.1":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.27.7":
     optional: true
 
   "@esbuild/openharmony-arm64@0.28.1":
     optional: true
 
-  "@esbuild/sunos-x64@0.27.7":
-    optional: true
-
   "@esbuild/sunos-x64@0.28.1":
-    optional: true
-
-  "@esbuild/win32-arm64@0.27.7":
     optional: true
 
   "@esbuild/win32-arm64@0.28.1":
     optional: true
 
-  "@esbuild/win32-ia32@0.27.7":
-    optional: true
-
   "@esbuild/win32-ia32@0.28.1":
-    optional: true
-
-  "@esbuild/win32-x64@0.27.7":
     optional: true
 
   "@esbuild/win32-x64@0.28.1":
@@ -7020,7 +6698,7 @@ snapshots:
       diff: 8.0.4
       dset: 3.1.4
       es-module-lexer: 2.1.0
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       flattie: 1.1.1
       fontace: 0.4.1
       get-tsconfig: 5.0.0-beta.4
@@ -7344,35 +7022,6 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.27.7
-      "@esbuild/android-arm": 0.27.7
-      "@esbuild/android-arm64": 0.27.7
-      "@esbuild/android-x64": 0.27.7
-      "@esbuild/darwin-arm64": 0.27.7
-      "@esbuild/darwin-x64": 0.27.7
-      "@esbuild/freebsd-arm64": 0.27.7
-      "@esbuild/freebsd-x64": 0.27.7
-      "@esbuild/linux-arm": 0.27.7
-      "@esbuild/linux-arm64": 0.27.7
-      "@esbuild/linux-ia32": 0.27.7
-      "@esbuild/linux-loong64": 0.27.7
-      "@esbuild/linux-mips64el": 0.27.7
-      "@esbuild/linux-ppc64": 0.27.7
-      "@esbuild/linux-riscv64": 0.27.7
-      "@esbuild/linux-s390x": 0.27.7
-      "@esbuild/linux-x64": 0.27.7
-      "@esbuild/netbsd-arm64": 0.27.7
-      "@esbuild/netbsd-x64": 0.27.7
-      "@esbuild/openbsd-arm64": 0.27.7
-      "@esbuild/openbsd-x64": 0.27.7
-      "@esbuild/openharmony-arm64": 0.27.7
-      "@esbuild/sunos-x64": 0.27.7
-      "@esbuild/win32-arm64": 0.27.7
-      "@esbuild/win32-ia32": 0.27.7
-      "@esbuild/win32-x64": 0.27.7
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -9150,7 +8799,7 @@ snapshots:
 
   vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.22.4):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   "@types/node": ^22.19.19
   "@types/react": ^19.2.16
   "@types/react-dom": ^19.2.3
-  esbuild: ">=0.28.1"
+  esbuild: ^0.28.1
   lightningcss: ^1.32.0
   react: ^19.2.7
   react-dom: ^19.2.7
@@ -33,6 +33,7 @@ onlyBuiltDependencies:
 
 overrides:
   brace-expansion@<5.0.0: ^5.0.6
+  esbuild: ^0.28.1
   lightningcss: 1.30.1
 
 patchedDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   "@types/node": ^22.19.19
   "@types/react": ^19.2.16
   "@types/react-dom": ^19.2.3
-  esbuild: ^0.28.1
+  esbuild: ">=0.28.1"
   lightningcss: ^1.32.0
   react: ^19.2.7
   react-dom: ^19.2.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   "@types/node": ^22.19.19
   "@types/react": ^19.2.16
   "@types/react-dom": ^19.2.3
-  esbuild: ^0.28.0
+  esbuild: ^0.28.1
   lightningcss: ^1.32.0
   react: ^19.2.7
   react-dom: ^19.2.7


### PR DESCRIPTION

### Changes

Update esbuild to fix https://github.com/advisories/GHSA-gv7w-rqvm-qjhr that was causing [CI to fail](https://github.com/iTwin/stratakit/actions/runs/27564214204/job/81483861397?pr=1554).

Uses overrides since esbuild is pulled in via vite and vite 7.3.5 is still on "^0.27.0".  Not sure of effort or if we want to upgrade to vite 8 at this point

### Testing

Make sure CI passes on this branch