### PR TITLE
Update documentation for autofixing lint errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ _Before running this command, make sure [Docker](https://www.docker.com/) is run
 
 ### To lint and fix autofixable errors
 
-`pnpm run lint`
+`pnpm run lint --write`
 
 ### To run the docs website
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Update command to autofix. The existing command just reported the errors

### Testing

1. Change the order of imports in a file
1. Run `pnpm run lint`
    - Note that it reports the error but does not fix
1. Run `pnpm run lint --write`
    - Note that the import order is corrected

## To  do
 
- [x] merge after https://github.com/iTwin/stratakit/pull/1555 - rebased to avoid blocking