### PR TITLE
Update import paths for #1565

### DIFF
--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -5,12 +5,15 @@
 
 import { Focusable } from "@ariakit/react/focusable";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/internal-utils/props";
 
 interface AnchorRootProps extends FocusableProps<"a"> {
 	/** @default "neutral" */

--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -10,7 +10,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps, FocusableProps } from "./~utils.props.js";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 interface AnchorRootProps extends FocusableProps<"a"> {
 	/** @default "neutral" */

--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -5,15 +5,12 @@
 
 import { Focusable } from "@ariakit/react/focusable";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 interface AnchorRootProps extends FocusableProps<"a"> {
 	/** @default "neutral" */

--- a/packages/bricks/src/Anchor.tsx
+++ b/packages/bricks/src/Anchor.tsx
@@ -10,7 +10,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type { BaseProps, FocusableProps } from "./~utils.props.js";
 
 interface AnchorRootProps extends FocusableProps<"a"> {
 	/** @default "neutral" */

--- a/packages/bricks/src/Avatar.tsx
+++ b/packages/bricks/src/Avatar.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface AvatarProps extends Omit<BaseProps<"span">, "children"> {
 	/**

--- a/packages/bricks/src/Avatar.tsx
+++ b/packages/bricks/src/Avatar.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface AvatarProps extends Omit<BaseProps<"span">, "children"> {
 	/**

--- a/packages/bricks/src/Avatar.tsx
+++ b/packages/bricks/src/Avatar.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface AvatarProps extends Omit<BaseProps<"span">, "children"> {
 	/**

--- a/packages/bricks/src/Avatar.tsx
+++ b/packages/bricks/src/Avatar.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface AvatarProps extends Omit<BaseProps<"span">, "children"> {
 	/**

--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -5,12 +5,12 @@
 
 import { Role } from "@ariakit/react/role";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface BadgeProps extends Omit<BaseProps<"span">, "children"> {
 	/**

--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -5,12 +5,12 @@
 
 import { Role } from "@ariakit/react/role";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface BadgeProps extends Omit<BaseProps<"span">, "children"> {
 	/**

--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -10,7 +10,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface BadgeProps extends Omit<BaseProps<"span">, "children"> {
 	/**

--- a/packages/bricks/src/Badge.tsx
+++ b/packages/bricks/src/Badge.tsx
@@ -10,7 +10,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface BadgeProps extends Omit<BaseProps<"span">, "children"> {
 	/**

--- a/packages/bricks/src/Button.tsx
+++ b/packages/bricks/src/Button.tsx
@@ -9,7 +9,7 @@ import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { FocusableProps } from "./~utils.props.js";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 interface ButtonProps extends FocusableProps<"button"> {
 	/**

--- a/packages/bricks/src/Button.tsx
+++ b/packages/bricks/src/Button.tsx
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Button as AkButton } from "@ariakit/react/button";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "@stratakit/internal-utils/props";
 
 interface ButtonProps extends FocusableProps<"button"> {
 	/**

--- a/packages/bricks/src/Button.tsx
+++ b/packages/bricks/src/Button.tsx
@@ -9,7 +9,7 @@ import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "./~utils.props.js";
 
 interface ButtonProps extends FocusableProps<"button"> {
 	/**

--- a/packages/bricks/src/Button.tsx
+++ b/packages/bricks/src/Button.tsx
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Button as AkButton } from "@ariakit/react/button";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { FocusableProps } from "@stratakit/foundations/secret-internals";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 interface ButtonProps extends FocusableProps<"button"> {
 	/**

--- a/packages/bricks/src/Checkbox.tsx
+++ b/packages/bricks/src/Checkbox.tsx
@@ -10,7 +10,7 @@ import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
-import type { FocusableProps } from "./~utils.props.js";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 type InputBaseProps = Omit<
 	FocusableProps<"input">,

--- a/packages/bricks/src/Checkbox.tsx
+++ b/packages/bricks/src/Checkbox.tsx
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Checkbox as AkCheckbox } from "@ariakit/react/checkbox";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
-import type { FocusableProps } from "@stratakit/foundations/secret-internals";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 type InputBaseProps = Omit<
 	FocusableProps<"input">,

--- a/packages/bricks/src/Checkbox.tsx
+++ b/packages/bricks/src/Checkbox.tsx
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Checkbox as AkCheckbox } from "@ariakit/react/checkbox";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "@stratakit/internal-utils/props";
 
 type InputBaseProps = Omit<
 	FocusableProps<"input">,

--- a/packages/bricks/src/Checkbox.tsx
+++ b/packages/bricks/src/Checkbox.tsx
@@ -10,7 +10,7 @@ import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "./~utils.props.js";
 
 type InputBaseProps = Omit<
 	FocusableProps<"input">,

--- a/packages/bricks/src/Description.tsx
+++ b/packages/bricks/src/Description.tsx
@@ -3,12 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface DescriptionProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Description.tsx
+++ b/packages/bricks/src/Description.tsx
@@ -3,12 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface DescriptionProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Description.tsx
+++ b/packages/bricks/src/Description.tsx
@@ -8,7 +8,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface DescriptionProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Description.tsx
+++ b/packages/bricks/src/Description.tsx
@@ -8,7 +8,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Text from "./Text.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface DescriptionProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Divider.tsx
+++ b/packages/bricks/src/Divider.tsx
@@ -5,12 +5,12 @@
 
 import { Role } from "@ariakit/react/role";
 import { Separator } from "@ariakit/react/separator";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
 import type { SeparatorProps } from "@ariakit/react/separator";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface DividerProps
 	extends BaseProps<"hr">,

--- a/packages/bricks/src/Divider.tsx
+++ b/packages/bricks/src/Divider.tsx
@@ -5,12 +5,12 @@
 
 import { Role } from "@ariakit/react/role";
 import { Separator } from "@ariakit/react/separator";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
 import type { SeparatorProps } from "@ariakit/react/separator";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface DividerProps
 	extends BaseProps<"hr">,

--- a/packages/bricks/src/Divider.tsx
+++ b/packages/bricks/src/Divider.tsx
@@ -10,7 +10,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
 import type { SeparatorProps } from "@ariakit/react/separator";
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface DividerProps
 	extends BaseProps<"hr">,

--- a/packages/bricks/src/Divider.tsx
+++ b/packages/bricks/src/Divider.tsx
@@ -10,7 +10,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
 import type { SeparatorProps } from "@ariakit/react/separator";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface DividerProps
 	extends BaseProps<"hr">,

--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ariakit/react/collection";
 import { Role } from "@ariakit/react/role";
 import { useStoreState } from "@ariakit/react/store";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Description from "./Description.js";
@@ -18,7 +18,7 @@ import { FieldCollection, FieldControlTypeContext } from "./Field.internal.js";
 import Label from "./Label.js";
 
 import type { CollectionItemProps } from "@ariakit/react/collection";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type {
 	CollectionStoreItem,
 	FieldCollectionStoreItem,

--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -18,7 +18,7 @@ import { FieldCollection, FieldControlTypeContext } from "./Field.internal.js";
 import Label from "./Label.js";
 
 import type { CollectionItemProps } from "@ariakit/react/collection";
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type {
 	CollectionStoreItem,
 	FieldCollectionStoreItem,

--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ariakit/react/collection";
 import { Role } from "@ariakit/react/role";
 import { useStoreState } from "@ariakit/react/store";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import Description from "./Description.js";
@@ -18,7 +18,7 @@ import { FieldCollection, FieldControlTypeContext } from "./Field.internal.js";
 import Label from "./Label.js";
 
 import type { CollectionItemProps } from "@ariakit/react/collection";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 import type {
 	CollectionStoreItem,
 	FieldCollectionStoreItem,

--- a/packages/bricks/src/Field.tsx
+++ b/packages/bricks/src/Field.tsx
@@ -18,7 +18,7 @@ import { FieldCollection, FieldControlTypeContext } from "./Field.internal.js";
 import Label from "./Label.js";
 
 import type { CollectionItemProps } from "@ariakit/react/collection";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 import type {
 	CollectionStoreItem,
 	FieldCollectionStoreItem,

--- a/packages/bricks/src/IconButton.internal.tsx
+++ b/packages/bricks/src/IconButton.internal.tsx
@@ -5,11 +5,11 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 import type Button from "./Button.js";
 
 // ----------------------------------------------------------------------------

--- a/packages/bricks/src/IconButton.internal.tsx
+++ b/packages/bricks/src/IconButton.internal.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 import type Button from "./Button.js";
 
 // ----------------------------------------------------------------------------

--- a/packages/bricks/src/IconButton.internal.tsx
+++ b/packages/bricks/src/IconButton.internal.tsx
@@ -5,11 +5,11 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type Button from "./Button.js";
 
 // ----------------------------------------------------------------------------

--- a/packages/bricks/src/IconButton.internal.tsx
+++ b/packages/bricks/src/IconButton.internal.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useGhostAlignment } from "./~utils.GhostAligner.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type Button from "./Button.js";
 
 // ----------------------------------------------------------------------------

--- a/packages/bricks/src/IconButton.tsx
+++ b/packages/bricks/src/IconButton.tsx
@@ -5,7 +5,8 @@
 
 import * as React from "react";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
+import { useMergedRefs } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { Dot } from "./~utils.Dot.js";
 import { useInit } from "./~utils.useInit.js";
 import Button from "./Button.js";

--- a/packages/bricks/src/IconButton.tsx
+++ b/packages/bricks/src/IconButton.tsx
@@ -5,10 +5,7 @@
 
 import * as React from "react";
 import { Icon } from "@stratakit/foundations";
-import {
-	forwardRef,
-	useMergedRefs,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
 import { Dot } from "./~utils.Dot.js";
 import { useInit } from "./~utils.useInit.js";
 import Button from "./Button.js";

--- a/packages/bricks/src/Kbd.tsx
+++ b/packages/bricks/src/Kbd.tsx
@@ -11,7 +11,7 @@ import { predefinedSymbols } from "./Kbd.internal.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
 import type { RoleProps } from "@ariakit/react/role";
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type { PredefinedSymbol } from "./Kbd.internal.js";
 
 interface KbdProps extends BaseProps<"kbd"> {

--- a/packages/bricks/src/Kbd.tsx
+++ b/packages/bricks/src/Kbd.tsx
@@ -4,13 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef, predefinedSymbols } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
+import { predefinedSymbols } from "./Kbd.internal.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
 import type { RoleProps } from "@ariakit/react/role";
-import type { BaseProps, PredefinedSymbol } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
+import type { PredefinedSymbol } from "./Kbd.internal.js";
 
 interface KbdProps extends BaseProps<"kbd"> {
 	/** @default "solid" */

--- a/packages/bricks/src/Kbd.tsx
+++ b/packages/bricks/src/Kbd.tsx
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { predefinedSymbols } from "./Kbd.internal.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
 import type { RoleProps } from "@ariakit/react/role";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 import type { PredefinedSymbol } from "./Kbd.internal.js";
 
 interface KbdProps extends BaseProps<"kbd"> {

--- a/packages/bricks/src/Kbd.tsx
+++ b/packages/bricks/src/Kbd.tsx
@@ -4,15 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef, predefinedSymbols } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
-import { predefinedSymbols } from "./Kbd.internal.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
 import type { RoleProps } from "@ariakit/react/role";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
-import type { PredefinedSymbol } from "./Kbd.internal.js";
+import type { BaseProps, PredefinedSymbol } from "@stratakit/internal-utils";
 
 interface KbdProps extends BaseProps<"kbd"> {
 	/** @default "solid" */

--- a/packages/bricks/src/Label.tsx
+++ b/packages/bricks/src/Label.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface LabelProps extends BaseProps<"label"> {}
 

--- a/packages/bricks/src/Label.tsx
+++ b/packages/bricks/src/Label.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface LabelProps extends BaseProps<"label"> {}
 

--- a/packages/bricks/src/Label.tsx
+++ b/packages/bricks/src/Label.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface LabelProps extends BaseProps<"label"> {}
 

--- a/packages/bricks/src/Label.tsx
+++ b/packages/bricks/src/Label.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface LabelProps extends BaseProps<"label"> {}
 

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -5,11 +5,11 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface ProgressBarProps extends Omit<BaseProps, "aria-labelledby"> {
 	/**

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface ProgressBarProps extends Omit<BaseProps, "aria-labelledby"> {
 	/**

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface ProgressBarProps extends Omit<BaseProps, "aria-labelledby"> {
 	/**

--- a/packages/bricks/src/Progress.tsx
+++ b/packages/bricks/src/Progress.tsx
@@ -5,11 +5,11 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface ProgressBarProps extends Omit<BaseProps, "aria-labelledby"> {
 	/**

--- a/packages/bricks/src/Radio.tsx
+++ b/packages/bricks/src/Radio.tsx
@@ -10,7 +10,7 @@ import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { RadioProps as AkRadioProps } from "@ariakit/react/radio";
-import type { FocusableProps } from "./~utils.props.js";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 type InputBaseProps = Omit<FocusableProps<"input">, "defaultValue" | "value">;
 

--- a/packages/bricks/src/Radio.tsx
+++ b/packages/bricks/src/Radio.tsx
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Radio as AkRadio } from "@ariakit/react/radio";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { RadioProps as AkRadioProps } from "@ariakit/react/radio";
-import type { FocusableProps } from "@stratakit/foundations/secret-internals";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 type InputBaseProps = Omit<FocusableProps<"input">, "defaultValue" | "value">;
 

--- a/packages/bricks/src/Radio.tsx
+++ b/packages/bricks/src/Radio.tsx
@@ -10,7 +10,7 @@ import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { RadioProps as AkRadioProps } from "@ariakit/react/radio";
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "./~utils.props.js";
 
 type InputBaseProps = Omit<FocusableProps<"input">, "defaultValue" | "value">;
 

--- a/packages/bricks/src/Radio.tsx
+++ b/packages/bricks/src/Radio.tsx
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Radio as AkRadio } from "@ariakit/react/radio";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { RadioProps as AkRadioProps } from "@ariakit/react/radio";
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "@stratakit/internal-utils/props";
 
 type InputBaseProps = Omit<FocusableProps<"input">, "defaultValue" | "value">;
 

--- a/packages/bricks/src/Select.tsx
+++ b/packages/bricks/src/Select.tsx
@@ -11,7 +11,7 @@ import { CaretsUpDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
-import type { BaseProps, FocusableProps } from "./~utils.props.js";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 const supportsHas = isBrowser && CSS?.supports?.("selector(:has(+ *))");
 

--- a/packages/bricks/src/Select.tsx
+++ b/packages/bricks/src/Select.tsx
@@ -5,16 +5,13 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef, isBrowser } from "@stratakit/foundations/secret-internals";
+import { forwardRef, isBrowser } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { CaretsUpDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 const supportsHas = isBrowser && CSS?.supports?.("selector(:has(+ *))");
 

--- a/packages/bricks/src/Select.tsx
+++ b/packages/bricks/src/Select.tsx
@@ -11,7 +11,7 @@ import { CaretsUpDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type { BaseProps, FocusableProps } from "./~utils.props.js";
 
 const supportsHas = isBrowser && CSS?.supports?.("selector(:has(+ *))");
 

--- a/packages/bricks/src/Select.tsx
+++ b/packages/bricks/src/Select.tsx
@@ -5,13 +5,17 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef, isBrowser } from "@stratakit/internal-utils";
+import { isBrowser } from "@stratakit/internal-utils/dom";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { CaretsUpDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/internal-utils/props";
 
 const supportsHas = isBrowser && CSS?.supports?.("selector(:has(+ *))");
 

--- a/packages/bricks/src/Skeleton.tsx
+++ b/packages/bricks/src/Skeleton.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Skeleton.tsx
+++ b/packages/bricks/src/Skeleton.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Skeleton.tsx
+++ b/packages/bricks/src/Skeleton.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Skeleton.tsx
+++ b/packages/bricks/src/Skeleton.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Spinner.tsx
+++ b/packages/bricks/src/Spinner.tsx
@@ -9,7 +9,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface SpinnerProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Spinner.tsx
+++ b/packages/bricks/src/Spinner.tsx
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface SpinnerProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Spinner.tsx
+++ b/packages/bricks/src/Spinner.tsx
@@ -9,7 +9,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface SpinnerProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Spinner.tsx
+++ b/packages/bricks/src/Spinner.tsx
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface SpinnerProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Switch.tsx
+++ b/packages/bricks/src/Switch.tsx
@@ -10,7 +10,7 @@ import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
-import type { FocusableProps } from "./~utils.props.js";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 type InputBaseProps = Omit<
 	FocusableProps<"input">,

--- a/packages/bricks/src/Switch.tsx
+++ b/packages/bricks/src/Switch.tsx
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Checkbox as AkCheckbox } from "@ariakit/react/checkbox";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
-import type { FocusableProps } from "@stratakit/foundations/secret-internals";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 type InputBaseProps = Omit<
 	FocusableProps<"input">,

--- a/packages/bricks/src/Switch.tsx
+++ b/packages/bricks/src/Switch.tsx
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Checkbox as AkCheckbox } from "@ariakit/react/checkbox";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "@stratakit/internal-utils/props";
 
 type InputBaseProps = Omit<
 	FocusableProps<"input">,

--- a/packages/bricks/src/Switch.tsx
+++ b/packages/bricks/src/Switch.tsx
@@ -10,7 +10,7 @@ import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
 import type { CheckboxProps as AkCheckboxProps } from "@ariakit/react/checkbox";
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "./~utils.props.js";
 
 type InputBaseProps = Omit<
 	FocusableProps<"input">,

--- a/packages/bricks/src/Table.tsx
+++ b/packages/bricks/src/Table.tsx
@@ -13,7 +13,7 @@ import {
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Table.tsx
+++ b/packages/bricks/src/Table.tsx
@@ -13,7 +13,7 @@ import {
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Table.tsx
+++ b/packages/bricks/src/Table.tsx
@@ -5,15 +5,12 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import {
-	forwardRef,
-	useMergedRefs,
-	useSafeContext,
-} from "@stratakit/internal-utils";
+import { useMergedRefs, useSafeContext } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Table.tsx
+++ b/packages/bricks/src/Table.tsx
@@ -9,11 +9,11 @@ import {
 	forwardRef,
 	useMergedRefs,
 	useSafeContext,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Text.tsx
+++ b/packages/bricks/src/Text.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface TextProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Text.tsx
+++ b/packages/bricks/src/Text.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface TextProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Text.tsx
+++ b/packages/bricks/src/Text.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface TextProps extends BaseProps {
 	/**

--- a/packages/bricks/src/Text.tsx
+++ b/packages/bricks/src/Text.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface TextProps extends BaseProps {
 	/**

--- a/packages/bricks/src/TextBox.tsx
+++ b/packages/bricks/src/TextBox.tsx
@@ -11,15 +11,12 @@ import {
 	forwardRef,
 	useEventHandlers,
 	useMergedRefs,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/TextBox.tsx
+++ b/packages/bricks/src/TextBox.tsx
@@ -16,7 +16,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
-import type { BaseProps, FocusableProps } from "./~utils.props.js";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/TextBox.tsx
+++ b/packages/bricks/src/TextBox.tsx
@@ -8,15 +8,18 @@ import { Focusable } from "@ariakit/react/focusable";
 import { Role } from "@ariakit/react/role";
 import { Icon } from "@stratakit/foundations";
 import {
-	forwardRef,
 	useEventHandlers,
 	useMergedRefs,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/TextBox.tsx
+++ b/packages/bricks/src/TextBox.tsx
@@ -16,7 +16,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { useFieldControlType } from "./Field.internal.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type { BaseProps, FocusableProps } from "./~utils.props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -16,7 +16,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { TooltipContext } from "./Tooltip.internal.js";
 
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "./~utils.props.js";
 
 interface TooltipProps
 	extends Omit<FocusableProps<"div">, "content">,

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -11,12 +11,12 @@ import {
 	useEventHandlers,
 	usePopoverApi,
 	useStableCallback,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { TooltipContext } from "./Tooltip.internal.js";
 
-import type { FocusableProps } from "@stratakit/foundations/secret-internals";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 interface TooltipProps
 	extends Omit<FocusableProps<"div">, "content">,

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -16,7 +16,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { TooltipContext } from "./Tooltip.internal.js";
 
-import type { FocusableProps } from "./~utils.props.js";
+import type { FocusableProps } from "@stratakit/internal-utils";
 
 interface TooltipProps
 	extends Omit<FocusableProps<"div">, "content">,

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -7,16 +7,16 @@ import * as React from "react";
 import { useStoreState } from "@ariakit/react/store";
 import * as AkTooltip from "@ariakit/react/tooltip";
 import {
-	forwardRef,
 	useEventHandlers,
 	usePopoverApi,
 	useStableCallback,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { TooltipContext } from "./Tooltip.internal.js";
 
-import type { FocusableProps } from "@stratakit/internal-utils";
+import type { FocusableProps } from "@stratakit/internal-utils/props";
 
 interface TooltipProps
 	extends Omit<FocusableProps<"div">, "content">,

--- a/packages/bricks/src/VisuallyHidden.tsx
+++ b/packages/bricks/src/VisuallyHidden.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface VisuallyHiddenProps extends BaseProps<"span"> {}
 

--- a/packages/bricks/src/VisuallyHidden.tsx
+++ b/packages/bricks/src/VisuallyHidden.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface VisuallyHiddenProps extends BaseProps<"span"> {}
 

--- a/packages/bricks/src/VisuallyHidden.tsx
+++ b/packages/bricks/src/VisuallyHidden.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface VisuallyHiddenProps extends BaseProps<"span"> {}
 

--- a/packages/bricks/src/VisuallyHidden.tsx
+++ b/packages/bricks/src/VisuallyHidden.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface VisuallyHiddenProps extends BaseProps<"span"> {}
 

--- a/packages/bricks/src/secret-internals.ts
+++ b/packages/bricks/src/secret-internals.ts
@@ -13,4 +13,5 @@ export {
 export { predefinedSymbols } from "./Kbd.internal.js";
 export { TooltipContext } from "./Tooltip.internal.js";
 
+export type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 export type { PredefinedSymbol } from "./Kbd.internal.js";

--- a/packages/bricks/src/secret-internals.ts
+++ b/packages/bricks/src/secret-internals.ts
@@ -13,5 +13,4 @@ export {
 export { predefinedSymbols } from "./Kbd.internal.js";
 export { TooltipContext } from "./Tooltip.internal.js";
 
-export type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 export type { PredefinedSymbol } from "./Kbd.internal.js";

--- a/packages/bricks/src/~utils.Dot.tsx
+++ b/packages/bricks/src/~utils.Dot.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface DotProps extends BaseProps<"span"> {
 	/**

--- a/packages/bricks/src/~utils.Dot.tsx
+++ b/packages/bricks/src/~utils.Dot.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface DotProps extends BaseProps<"span"> {
 	/**

--- a/packages/bricks/src/~utils.Dot.tsx
+++ b/packages/bricks/src/~utils.Dot.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 interface DotProps extends BaseProps<"span"> {
 	/**

--- a/packages/bricks/src/~utils.Dot.tsx
+++ b/packages/bricks/src/~utils.Dot.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import VisuallyHidden from "./VisuallyHidden.js";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface DotProps extends BaseProps<"span"> {
 	/**

--- a/packages/bricks/src/~utils.icons.tsx
+++ b/packages/bricks/src/~utils.icons.tsx
@@ -5,10 +5,10 @@
 
 import { Role } from "@ariakit/react/role";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/~utils.icons.tsx
+++ b/packages/bricks/src/~utils.icons.tsx
@@ -8,7 +8,7 @@ import { Icon } from "@stratakit/foundations";
 import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 
-import type { BaseProps } from "./~utils.props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/~utils.icons.tsx
+++ b/packages/bricks/src/~utils.icons.tsx
@@ -8,7 +8,7 @@ import { Icon } from "@stratakit/foundations";
 import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~utils.props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/bricks/src/~utils.useInit.tsx
+++ b/packages/bricks/src/~utils.useInit.tsx
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from "react";
-import {
-	RootContext,
-	useSafeContext,
-} from "@stratakit/foundations/secret-internals";
+import { RootContext } from "@stratakit/foundations/secret-internals";
+import { useSafeContext } from "@stratakit/internal-utils";
 import css from "./styles.css.js";
 
 const packageName = "@stratakit/bricks";

--- a/packages/bricks/src/~utils.useInit.tsx
+++ b/packages/bricks/src/~utils.useInit.tsx
@@ -5,7 +5,7 @@
 
 import * as React from "react";
 import { RootContext } from "@stratakit/foundations/secret-internals";
-import { useSafeContext } from "@stratakit/internal-utils";
+import { useSafeContext } from "@stratakit/internal-utils/hooks";
 import css from "./styles.css.js";
 
 const packageName = "@stratakit/bricks";

--- a/packages/foundations/src/Icon.tsx
+++ b/packages/foundations/src/Icon.tsx
@@ -5,13 +5,9 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import {
-	forwardRef,
-	getOwnerDocument,
-	parseDOM,
-	useLatestRef,
-	useSafeContext,
-} from "@stratakit/internal-utils";
+import { getOwnerDocument } from "@stratakit/internal-utils/dom";
+import { useLatestRef, useSafeContext } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import {
 	HtmlSanitizerContext,
@@ -19,7 +15,7 @@ import {
 	useRootNode,
 } from "./Root.internal.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/foundations/src/Icon.tsx
+++ b/packages/foundations/src/Icon.tsx
@@ -5,16 +5,21 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
+import {
+	forwardRef,
+	getOwnerDocument,
+	parseDOM,
+	useLatestRef,
+	useSafeContext,
+} from "@stratakit/internal-utils";
 import cx from "classnames";
-import { useLatestRef, useSafeContext } from "./~hooks.js";
-import { forwardRef, getOwnerDocument } from "./~utils.js";
 import {
 	HtmlSanitizerContext,
 	spriteSheetId,
 	useRootNode,
 } from "./Root.internal.js";
 
-import type { BaseProps } from "./~utils.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/foundations/src/Icon.tsx
+++ b/packages/foundations/src/Icon.tsx
@@ -19,7 +19,7 @@ import {
 	useRootNode,
 } from "./Root.internal.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/foundations/src/Icon.tsx
+++ b/packages/foundations/src/Icon.tsx
@@ -19,7 +19,7 @@ import {
 	useRootNode,
 } from "./Root.internal.js";
 
-import type { BaseProps } from "./~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/foundations/src/Root.internal.tsx
+++ b/packages/foundations/src/Root.internal.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from "react";
-import { useIsClient } from "./~hooks.js";
+import { useIsClient } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/foundations/src/Root.internal.tsx
+++ b/packages/foundations/src/Root.internal.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from "react";
-import { useIsClient } from "@stratakit/internal-utils";
+import { useIsClient } from "@stratakit/internal-utils/hooks";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { PortalContext } from "@ariakit/react/portal";
 import { Role } from "@ariakit/react/role";
-import cx from "classnames";
-import css from "./~styles.css.js";
 import {
 	forwardRef,
 	getOwnerDocument,
@@ -16,7 +14,9 @@ import {
 	identity,
 	isBrowser,
 	isDocument,
-} from "./~utils.js";
+} from "@stratakit/internal-utils";
+import cx from "classnames";
+import css from "./~styles.css.js";
 import {
 	HtmlSanitizerContext,
 	RootContext,
@@ -26,7 +26,7 @@ import {
 } from "./Root.internal.js";
 import { loadStyles } from "./styles.internal.js";
 
-import type { BaseProps } from "./~utils.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 const packageName = "@stratakit/foundations";
 const key = `${packageName}@${__VERSION__}`;

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -26,7 +26,7 @@ import {
 } from "./Root.internal.js";
 import { loadStyles } from "./styles.internal.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~props.js";
 
 const packageName = "@stratakit/foundations";
 const key = `${packageName}@${__VERSION__}`;

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -26,7 +26,7 @@ import {
 } from "./Root.internal.js";
 import { loadStyles } from "./styles.internal.js";
 
-import type { BaseProps } from "./~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 const packageName = "@stratakit/foundations";
 const key = `${packageName}@${__VERSION__}`;

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -7,14 +7,14 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { PortalContext } from "@ariakit/react/portal";
 import { Role } from "@ariakit/react/role";
+import { identity } from "@stratakit/internal-utils/common";
 import {
-	forwardRef,
 	getOwnerDocument,
 	getWindow,
-	identity,
 	isBrowser,
 	isDocument,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/dom";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import css from "./~styles.css.js";
 import {
@@ -26,7 +26,7 @@ import {
 } from "./Root.internal.js";
 import { loadStyles } from "./styles.internal.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 const packageName = "@stratakit/foundations";
 const key = `${packageName}@${__VERSION__}`;

--- a/packages/foundations/src/styles.internal.ts
+++ b/packages/foundations/src/styles.internal.ts
@@ -3,7 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { getOwnerDocument, getWindow, isBrowser } from "./~utils.js";
+import {
+	getOwnerDocument,
+	getWindow,
+	isBrowser,
+} from "@stratakit/internal-utils";
 
 /**
  * A Map of WeakMaps containing information for all stylesheets.

--- a/packages/foundations/src/styles.internal.ts
+++ b/packages/foundations/src/styles.internal.ts
@@ -7,7 +7,7 @@ import {
 	getOwnerDocument,
 	getWindow,
 	isBrowser,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/dom";
 
 /**
  * A Map of WeakMaps containing information for all stylesheets.

--- a/packages/internal-utils/src/index.ts
+++ b/packages/internal-utils/src/index.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+export * from "./hooks.js";
+export * from "./utils.icons.js";
+export * from "./utils.js";

--- a/packages/internal-utils/src/index.ts
+++ b/packages/internal-utils/src/index.ts
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
-export * from "./hooks.js";
-export * from "./utils.icons.js";
-export * from "./utils.js";

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -6,17 +6,14 @@
 import * as React from "react";
 import { ThemeProvider, useColorScheme } from "@mui/material/styles";
 import { Root as StrataKitRoot } from "@stratakit/foundations";
-import {
-	forwardRef,
-	RootContext,
-	useSafeContext,
-} from "@stratakit/foundations/secret-internals";
+import { RootContext } from "@stratakit/foundations/secret-internals";
+import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { createTheme } from "./~createTheme.js";
 import { StyledEngineProvider } from "./Root.internal.js";
 import css from "./styles.css.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -13,7 +13,7 @@ import { createTheme } from "./~createTheme.js";
 import { StyledEngineProvider } from "./Root.internal.js";
 import css from "./styles.css.js";
 
-import type { BaseProps } from "./~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -13,7 +13,7 @@ import { createTheme } from "./~createTheme.js";
 import { StyledEngineProvider } from "./Root.internal.js";
 import css from "./styles.css.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "./~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -7,13 +7,14 @@ import * as React from "react";
 import { ThemeProvider, useColorScheme } from "@mui/material/styles";
 import { Root as StrataKitRoot } from "@stratakit/foundations";
 import { RootContext } from "@stratakit/foundations/secret-internals";
-import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
+import { useSafeContext } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { createTheme } from "./~createTheme.js";
 import { StyledEngineProvider } from "./Root.internal.js";
 import css from "./styles.css.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAccordion.tsx
+++ b/packages/mui/src/~components/MuiAccordion.tsx
@@ -5,11 +5,11 @@
 
 import { Role } from "@ariakit/react/role";
 import Paper from "@mui/material/Paper";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 
 import type { AccordionOwnerState } from "@mui/material/Accordion";
 import type { AccordionSummaryOwnProps } from "@mui/material/AccordionSummary";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAccordion.tsx
+++ b/packages/mui/src/~components/MuiAccordion.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 
 import type { AccordionOwnerState } from "@mui/material/Accordion";
 import type { AccordionSummaryOwnProps } from "@mui/material/AccordionSummary";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAccordion.tsx
+++ b/packages/mui/src/~components/MuiAccordion.tsx
@@ -5,11 +5,11 @@
 
 import { Role } from "@ariakit/react/role";
 import Paper from "@mui/material/Paper";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
 import type { AccordionOwnerState } from "@mui/material/Accordion";
 import type { AccordionSummaryOwnProps } from "@mui/material/AccordionSummary";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAccordion.tsx
+++ b/packages/mui/src/~components/MuiAccordion.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 
 import type { AccordionOwnerState } from "@mui/material/Accordion";
 import type { AccordionSummaryOwnProps } from "@mui/material/AccordionSummary";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAlert.tsx
+++ b/packages/mui/src/~components/MuiAlert.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAlert.tsx
+++ b/packages/mui/src/~components/MuiAlert.tsx
@@ -5,9 +5,10 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
+import { useSafeContext } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAlert.tsx
+++ b/packages/mui/src/~components/MuiAlert.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAlert.tsx
+++ b/packages/mui/src/~components/MuiAlert.tsx
@@ -5,12 +5,9 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import {
-	forwardRef,
-	useSafeContext,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAutocomplete.tsx
+++ b/packages/mui/src/~components/MuiAutocomplete.tsx
@@ -17,7 +17,7 @@ import { MuiInputLabelContext } from "./MuiInputLabel.js";
 
 import type Autocomplete from "@mui/material/Autocomplete";
 import type { Theme } from "@mui/material/styles";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAutocomplete.tsx
+++ b/packages/mui/src/~components/MuiAutocomplete.tsx
@@ -11,13 +11,13 @@ import {
 	forwardRef,
 	useEventHandlers,
 	useMergedRefs,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import { MuiChip, MuiChipDeleteIcon } from "./MuiChip.js";
 import { MuiInputLabelContext } from "./MuiInputLabel.js";
 
 import type Autocomplete from "@mui/material/Autocomplete";
 import type { Theme } from "@mui/material/styles";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAutocomplete.tsx
+++ b/packages/mui/src/~components/MuiAutocomplete.tsx
@@ -17,7 +17,7 @@ import { MuiInputLabelContext } from "./MuiInputLabel.js";
 
 import type Autocomplete from "@mui/material/Autocomplete";
 import type { Theme } from "@mui/material/styles";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAutocomplete.tsx
+++ b/packages/mui/src/~components/MuiAutocomplete.tsx
@@ -8,16 +8,16 @@ import * as ReactDOM from "react-dom";
 import { Role } from "@ariakit/react/role";
 import { ThemeProvider } from "@mui/material/styles";
 import {
-	forwardRef,
 	useEventHandlers,
 	useMergedRefs,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { MuiChip, MuiChipDeleteIcon } from "./MuiChip.js";
 import { MuiInputLabelContext } from "./MuiInputLabel.js";
 
 import type Autocomplete from "@mui/material/Autocomplete";
 import type { Theme } from "@mui/material/styles";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAvatarGroup.tsx
+++ b/packages/mui/src/~components/MuiAvatarGroup.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAvatarGroup.tsx
+++ b/packages/mui/src/~components/MuiAvatarGroup.tsx
@@ -5,9 +5,9 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAvatarGroup.tsx
+++ b/packages/mui/src/~components/MuiAvatarGroup.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiAvatarGroup.tsx
+++ b/packages/mui/src/~components/MuiAvatarGroup.tsx
@@ -5,9 +5,9 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -7,7 +7,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 
 import type Badge from "@mui/material/Badge";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -7,7 +7,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 
 import type Badge from "@mui/material/Badge";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -4,13 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import {
-	forwardRef,
-	useSafeContext,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 
 import type Badge from "@mui/material/Badge";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
+import { useSafeContext } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
 import type Badge from "@mui/material/Badge";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiBottomNavigation.tsx
+++ b/packages/mui/src/~components/MuiBottomNavigation.tsx
@@ -3,10 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiBottomNavigation.tsx
+++ b/packages/mui/src/~components/MuiBottomNavigation.tsx
@@ -6,7 +6,7 @@
 import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiBottomNavigation.tsx
+++ b/packages/mui/src/~components/MuiBottomNavigation.tsx
@@ -3,10 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiBottomNavigation.tsx
+++ b/packages/mui/src/~components/MuiBottomNavigation.tsx
@@ -6,7 +6,7 @@
 import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiButtonBase.tsx
+++ b/packages/mui/src/~components/MuiButtonBase.tsx
@@ -5,13 +5,10 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import {
-	forwardRef,
-	useMergedRefs,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
 
 import type { ButtonOwnProps } from "@mui/material/Button";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiButtonBase.tsx
+++ b/packages/mui/src/~components/MuiButtonBase.tsx
@@ -5,10 +5,11 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
+import { useMergedRefs } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
 import type { ButtonOwnProps } from "@mui/material/Button";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiButtonBase.tsx
+++ b/packages/mui/src/~components/MuiButtonBase.tsx
@@ -8,7 +8,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
 
 import type { ButtonOwnProps } from "@mui/material/Button";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiButtonBase.tsx
+++ b/packages/mui/src/~components/MuiButtonBase.tsx
@@ -8,7 +8,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
 
 import type { ButtonOwnProps } from "@mui/material/Button";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -10,10 +10,10 @@ import {
 	forwardRef,
 	useEventHandlers,
 	useMergedRefs,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiCard.tsx
+++ b/packages/mui/src/~components/MuiCard.tsx
@@ -7,13 +7,13 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Role } from "@ariakit/react/role";
 import {
-	forwardRef,
 	useEventHandlers,
 	useMergedRefs,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiChip.tsx
+++ b/packages/mui/src/~components/MuiChip.tsx
@@ -8,12 +8,12 @@ import { Role } from "@ariakit/react/role";
 import { VisuallyHidden } from "@ariakit/react/visually-hidden";
 import IconButton from "@mui/material/IconButton";
 import { useTheme } from "@mui/material/styles";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import { DismissCircleIcon } from "../Icon.js";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type Chip from "@mui/material/Chip";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiChip.tsx
+++ b/packages/mui/src/~components/MuiChip.tsx
@@ -13,7 +13,7 @@ import { DismissCircleIcon } from "../Icon.js";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type Chip from "@mui/material/Chip";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiChip.tsx
+++ b/packages/mui/src/~components/MuiChip.tsx
@@ -8,12 +8,12 @@ import { Role } from "@ariakit/react/role";
 import { VisuallyHidden } from "@ariakit/react/visually-hidden";
 import IconButton from "@mui/material/IconButton";
 import { useTheme } from "@mui/material/styles";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { DismissCircleIcon } from "../Icon.js";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type Chip from "@mui/material/Chip";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiChip.tsx
+++ b/packages/mui/src/~components/MuiChip.tsx
@@ -13,7 +13,7 @@ import { DismissCircleIcon } from "../Icon.js";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type Chip from "@mui/material/Chip";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiDivider.tsx
+++ b/packages/mui/src/~components/MuiDivider.tsx
@@ -7,7 +7,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 
 import type { DividerOwnProps } from "@mui/material/Divider";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiDivider.tsx
+++ b/packages/mui/src/~components/MuiDivider.tsx
@@ -7,7 +7,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 
 import type { DividerOwnProps } from "@mui/material/Divider";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiDivider.tsx
+++ b/packages/mui/src/~components/MuiDivider.tsx
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
 import type { DividerOwnProps } from "@mui/material/Divider";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiDivider.tsx
+++ b/packages/mui/src/~components/MuiDivider.tsx
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 
 import type { DividerOwnProps } from "@mui/material/Divider";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiIconButton.tsx
+++ b/packages/mui/src/~components/MuiIconButton.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { IconButtonOwnProps } from "@mui/material/IconButton";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiIconButton.tsx
+++ b/packages/mui/src/~components/MuiIconButton.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import Tooltip from "@mui/material/Tooltip";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { IconButtonOwnProps } from "@mui/material/IconButton";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiIconButton.tsx
+++ b/packages/mui/src/~components/MuiIconButton.tsx
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import Tooltip from "@mui/material/Tooltip";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { IconButtonOwnProps } from "@mui/material/IconButton";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiIconButton.tsx
+++ b/packages/mui/src/~components/MuiIconButton.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { IconButtonOwnProps } from "@mui/material/IconButton";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiInputLabel.tsx
+++ b/packages/mui/src/~components/MuiInputLabel.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiInputLabel.tsx
+++ b/packages/mui/src/~components/MuiInputLabel.tsx
@@ -5,9 +5,9 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiInputLabel.tsx
+++ b/packages/mui/src/~components/MuiInputLabel.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiInputLabel.tsx
+++ b/packages/mui/src/~components/MuiInputLabel.tsx
@@ -5,9 +5,9 @@
 
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiMenu.tsx
+++ b/packages/mui/src/~components/MuiMenu.tsx
@@ -4,10 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import MenuList from "@mui/material/MenuList";
-import {
-	forwardRef,
-	useMergedRefs,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
 import { useFallbackLabel } from "./MuiPopover.js";
 
 import type { MenuOwnerState } from "@mui/material/Menu";

--- a/packages/mui/src/~components/MuiMenu.tsx
+++ b/packages/mui/src/~components/MuiMenu.tsx
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import MenuList from "@mui/material/MenuList";
-import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
+import { useMergedRefs } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { useFallbackLabel } from "./MuiPopover.js";
 
 import type { MenuOwnerState } from "@mui/material/Menu";

--- a/packages/mui/src/~components/MuiPopover.tsx
+++ b/packages/mui/src/~components/MuiPopover.tsx
@@ -5,10 +5,11 @@
 
 import * as React from "react";
 import { PopoverPaper } from "@mui/material/Popover";
-import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
+import { useMergedRefs } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
 import type { PopoverOwnerState } from "@mui/material/Popover";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiPopover.tsx
+++ b/packages/mui/src/~components/MuiPopover.tsx
@@ -8,7 +8,7 @@ import { PopoverPaper } from "@mui/material/Popover";
 import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
 
 import type { PopoverOwnerState } from "@mui/material/Popover";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiPopover.tsx
+++ b/packages/mui/src/~components/MuiPopover.tsx
@@ -8,7 +8,7 @@ import { PopoverPaper } from "@mui/material/Popover";
 import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
 
 import type { PopoverOwnerState } from "@mui/material/Popover";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiPopover.tsx
+++ b/packages/mui/src/~components/MuiPopover.tsx
@@ -5,13 +5,10 @@
 
 import * as React from "react";
 import { PopoverPaper } from "@mui/material/Popover";
-import {
-	forwardRef,
-	useMergedRefs,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useMergedRefs } from "@stratakit/internal-utils";
 
 import type { PopoverOwnerState } from "@mui/material/Popover";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiSnackbar.tsx
+++ b/packages/mui/src/~components/MuiSnackbar.tsx
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Portal } from "@ariakit/react/portal";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiSnackbar.tsx
+++ b/packages/mui/src/~components/MuiSnackbar.tsx
@@ -6,7 +6,7 @@
 import { Portal } from "@ariakit/react/portal";
 import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiSnackbar.tsx
+++ b/packages/mui/src/~components/MuiSnackbar.tsx
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Portal } from "@ariakit/react/portal";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiSnackbar.tsx
+++ b/packages/mui/src/~components/MuiSnackbar.tsx
@@ -6,7 +6,7 @@
 import { Portal } from "@ariakit/react/portal";
 import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiStepper.tsx
+++ b/packages/mui/src/~components/MuiStepper.tsx
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import { CheckmarkIcon, ErrorIcon } from "../Icon.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiStepper.tsx
+++ b/packages/mui/src/~components/MuiStepper.tsx
@@ -7,7 +7,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 import { CheckmarkIcon, ErrorIcon } from "../Icon.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiStepper.tsx
+++ b/packages/mui/src/~components/MuiStepper.tsx
@@ -7,7 +7,7 @@ import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 import { CheckmarkIcon, ErrorIcon } from "../Icon.js";
 
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiStepper.tsx
+++ b/packages/mui/src/~components/MuiStepper.tsx
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { CheckmarkIcon, ErrorIcon } from "../Icon.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTable.tsx
+++ b/packages/mui/src/~components/MuiTable.tsx
@@ -6,12 +6,12 @@
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { ThemeProvider } from "@mui/material/styles";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import { SortAscendingIcon, SortDescendingIcon } from "../Icon.js";
 
 import type { Theme } from "@mui/material/styles";
 import type { TableSortLabelOwnerState } from "@mui/material/TableSortLabel";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTable.tsx
+++ b/packages/mui/src/~components/MuiTable.tsx
@@ -6,12 +6,12 @@
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { ThemeProvider } from "@mui/material/styles";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { SortAscendingIcon, SortDescendingIcon } from "../Icon.js";
 
 import type { Theme } from "@mui/material/styles";
 import type { TableSortLabelOwnerState } from "@mui/material/TableSortLabel";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTabs.tsx
+++ b/packages/mui/src/~components/MuiTabs.tsx
@@ -5,13 +5,10 @@
 
 import { Role } from "@ariakit/react/role";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import {
-	type BaseProps,
-	forwardRef,
-	useEventHandlers,
-} from "@stratakit/internal-utils";
+import { forwardRef, useEventHandlers } from "@stratakit/internal-utils";
 
 import type Tabs from "@mui/material/Tabs";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTabs.tsx
+++ b/packages/mui/src/~components/MuiTabs.tsx
@@ -8,7 +8,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import { forwardRef, useEventHandlers } from "@stratakit/internal-utils";
 
 import type Tabs from "@mui/material/Tabs";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTabs.tsx
+++ b/packages/mui/src/~components/MuiTabs.tsx
@@ -5,10 +5,11 @@
 
 import { Role } from "@ariakit/react/role";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { forwardRef, useEventHandlers } from "@stratakit/internal-utils";
+import { useEventHandlers } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
 import type Tabs from "@mui/material/Tabs";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTabs.tsx
+++ b/packages/mui/src/~components/MuiTabs.tsx
@@ -9,7 +9,7 @@ import {
 	type BaseProps,
 	forwardRef,
 	useEventHandlers,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 
 import type Tabs from "@mui/material/Tabs";
 

--- a/packages/mui/src/~components/MuiToggleButton.tsx
+++ b/packages/mui/src/~components/MuiToggleButton.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { ToggleButtonOwnProps } from "@mui/material/ToggleButton";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiToggleButton.tsx
+++ b/packages/mui/src/~components/MuiToggleButton.tsx
@@ -5,11 +5,11 @@
 
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { ToggleButtonOwnProps } from "@mui/material/ToggleButton";
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiToggleButton.tsx
+++ b/packages/mui/src/~components/MuiToggleButton.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { ToggleButtonOwnProps } from "@mui/material/ToggleButton";
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiToggleButton.tsx
+++ b/packages/mui/src/~components/MuiToggleButton.tsx
@@ -5,11 +5,11 @@
 
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import { MuiButtonBase } from "./MuiButtonBase.js";
 
 import type { ToggleButtonOwnProps } from "@mui/material/ToggleButton";
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTypography.tsx
+++ b/packages/mui/src/~components/MuiTypography.tsx
@@ -6,7 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "../~props.js";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTypography.tsx
+++ b/packages/mui/src/~components/MuiTypography.tsx
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTypography.tsx
+++ b/packages/mui/src/~components/MuiTypography.tsx
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/mui/src/~components/MuiTypography.tsx
+++ b/packages/mui/src/~components/MuiTypography.tsx
@@ -6,7 +6,7 @@
 import { Role } from "@ariakit/react/role";
 import { forwardRef } from "@stratakit/internal-utils";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "../~props.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/AccordionItem.tsx
+++ b/packages/structures/src/AccordionItem.tsx
@@ -14,15 +14,12 @@ import {
 	GhostAligner,
 	IconButtonPresentation,
 } from "@stratakit/bricks/secret-internals";
-import {
-	forwardRef,
-	useControlledState,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useControlledState } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface AccordionItemProps extends BaseProps {
 	/**

--- a/packages/structures/src/AccordionItem.tsx
+++ b/packages/structures/src/AccordionItem.tsx
@@ -19,7 +19,7 @@ import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/bricks/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 interface AccordionItemProps extends BaseProps {
 	/**

--- a/packages/structures/src/AccordionItem.tsx
+++ b/packages/structures/src/AccordionItem.tsx
@@ -14,12 +14,13 @@ import {
 	GhostAligner,
 	IconButtonPresentation,
 } from "@stratakit/bricks/secret-internals";
-import { forwardRef, useControlledState } from "@stratakit/internal-utils";
+import { useControlledState } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface AccordionItemProps extends BaseProps {
 	/**

--- a/packages/structures/src/AccordionItem.tsx
+++ b/packages/structures/src/AccordionItem.tsx
@@ -19,7 +19,7 @@ import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/bricks/secret-internals";
 
 interface AccordionItemProps extends BaseProps {
 	/**

--- a/packages/structures/src/Banner.tsx
+++ b/packages/structures/src/Banner.tsx
@@ -15,7 +15,7 @@ import { combine } from "zustand/middleware";
 import { Dismiss, StatusIcon } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/bricks/secret-internals";
 import type { ExtractState } from "zustand";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/Banner.tsx
+++ b/packages/structures/src/Banner.tsx
@@ -8,17 +8,14 @@ import { Role } from "@ariakit/react/role";
 import { IconButton, Text } from "@stratakit/bricks";
 import { GhostAligner } from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
-import {
-	forwardRef,
-	useSafeContext,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
 import { Dismiss, StatusIcon } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type { ExtractState } from "zustand";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/Banner.tsx
+++ b/packages/structures/src/Banner.tsx
@@ -15,7 +15,7 @@ import { combine } from "zustand/middleware";
 import { Dismiss, StatusIcon } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/bricks/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type { ExtractState } from "zustand";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/Banner.tsx
+++ b/packages/structures/src/Banner.tsx
@@ -8,14 +8,15 @@ import { Role } from "@ariakit/react/role";
 import { IconButton, Text } from "@stratakit/bricks";
 import { GhostAligner } from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
+import { useSafeContext } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
 import { Dismiss, StatusIcon } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 import type { ExtractState } from "zustand";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/Chip.tsx
+++ b/packages/structures/src/Chip.tsx
@@ -6,17 +6,14 @@
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { IconButton } from "@stratakit/bricks";
-import {
-	forwardRef,
-	useSafeContext,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
 import { Dismiss } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type { ExtractState } from "zustand";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/Chip.tsx
+++ b/packages/structures/src/Chip.tsx
@@ -6,14 +6,15 @@
 import * as React from "react";
 import { Role } from "@ariakit/react/role";
 import { IconButton } from "@stratakit/bricks";
-import { forwardRef, useSafeContext } from "@stratakit/internal-utils";
+import { useSafeContext } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
 import { Dismiss } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 import type { ExtractState } from "zustand";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/Chip.tsx
+++ b/packages/structures/src/Chip.tsx
@@ -13,7 +13,7 @@ import { combine } from "zustand/middleware";
 import { Dismiss } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/bricks/secret-internals";
 import type { ExtractState } from "zustand";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/Chip.tsx
+++ b/packages/structures/src/Chip.tsx
@@ -13,7 +13,7 @@ import { combine } from "zustand/middleware";
 import { Dismiss } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/bricks/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 import type { ExtractState } from "zustand";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/Dialog.tsx
+++ b/packages/structures/src/Dialog.tsx
@@ -19,7 +19,10 @@ import cx from "classnames";
 import { Dismiss } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Dialog.tsx
+++ b/packages/structures/src/Dialog.tsx
@@ -14,15 +14,12 @@ import {
 	forwardRef,
 	usePopoverApi,
 	useStableCallback,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import cx from "classnames";
 import { Dismiss } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Dialog.tsx
+++ b/packages/structures/src/Dialog.tsx
@@ -19,10 +19,7 @@ import cx from "classnames";
 import { Dismiss } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/bricks/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Dialog.tsx
+++ b/packages/structures/src/Dialog.tsx
@@ -11,15 +11,18 @@ import { useStoreState } from "@ariakit/react/store";
 import { IconButton, Text } from "@stratakit/bricks";
 import { GhostAligner } from "@stratakit/bricks/secret-internals";
 import {
-	forwardRef,
 	usePopoverApi,
 	useStableCallback,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { Dismiss } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -18,18 +18,15 @@ import {
 } from "@ariakit/react/menu";
 import { useStoreState } from "@ariakit/react/store";
 import { Button, Kbd, Text } from "@stratakit/bricks";
-import {
-	DisclosureArrow,
-	Dot,
-	predefinedSymbols,
-} from "@stratakit/bricks/secret-internals";
+import { DisclosureArrow, Dot } from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
 import {
 	forwardRef,
+	predefinedSymbols,
 	usePopoverApi,
 	useSafeContext,
 	useStableCallback,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import cx from "classnames";
 import { Checkmark, ChevronRight } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
@@ -40,12 +37,12 @@ import type {
 	MenuProviderProps,
 	MenuStore,
 } from "@ariakit/react/menu";
-import type { PredefinedSymbol } from "@stratakit/bricks/secret-internals";
 import type {
 	AnyString,
 	BaseProps,
 	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+	PredefinedSymbol,
+} from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -22,12 +22,12 @@ import { DisclosureArrow, Dot } from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
 import {
 	forwardRef,
-	predefinedSymbols,
 	usePopoverApi,
 	useSafeContext,
 	useStableCallback,
 } from "@stratakit/internal-utils";
 import cx from "classnames";
+import { predefinedSymbols } from "../../bricks/dist/Kbd.internal.js";
 import { Checkmark, ChevronRight } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
 import { useInit } from "./~utils.useInit.js";
@@ -38,11 +38,11 @@ import type {
 	MenuStore,
 } from "@ariakit/react/menu";
 import type {
-	AnyString,
 	BaseProps,
 	FocusableProps,
-	PredefinedSymbol,
-} from "@stratakit/internal-utils";
+} from "@stratakit/bricks/secret-internals";
+import type { AnyString } from "@stratakit/internal-utils";
+import type { PredefinedSymbol } from "../../bricks/dist/Kbd.internal.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -38,10 +38,10 @@ import type {
 	MenuStore,
 } from "@ariakit/react/menu";
 import type {
+	AnyString,
 	BaseProps,
 	FocusableProps,
-} from "@stratakit/bricks/secret-internals";
-import type { AnyString } from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils";
 import type { PredefinedSymbol } from "../../bricks/dist/Kbd.internal.js";
 
 // ----------------------------------------------------------------------------

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -18,7 +18,11 @@ import {
 } from "@ariakit/react/menu";
 import { useStoreState } from "@ariakit/react/store";
 import { Button, Kbd, Text } from "@stratakit/bricks";
-import { DisclosureArrow, Dot } from "@stratakit/bricks/secret-internals";
+import {
+	DisclosureArrow,
+	Dot,
+	predefinedSymbols,
+} from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
 import {
 	forwardRef,
@@ -27,7 +31,6 @@ import {
 	useStableCallback,
 } from "@stratakit/internal-utils";
 import cx from "classnames";
-import { predefinedSymbols } from "../../bricks/dist/Kbd.internal.js";
 import { Checkmark, ChevronRight } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
 import { useInit } from "./~utils.useInit.js";
@@ -37,12 +40,12 @@ import type {
 	MenuProviderProps,
 	MenuStore,
 } from "@ariakit/react/menu";
+import type { PredefinedSymbol } from "@stratakit/bricks/secret-internals";
 import type {
 	AnyString,
 	BaseProps,
 	FocusableProps,
 } from "@stratakit/internal-utils";
-import type { PredefinedSymbol } from "../../bricks/dist/Kbd.internal.js";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -25,11 +25,11 @@ import {
 } from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
 import {
-	forwardRef,
 	usePopoverApi,
 	useSafeContext,
 	useStableCallback,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { Checkmark, ChevronRight } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
@@ -41,11 +41,11 @@ import type {
 	MenuStore,
 } from "@ariakit/react/menu";
 import type { PredefinedSymbol } from "@stratakit/bricks/secret-internals";
+import type { AnyString } from "@stratakit/internal-utils/common";
 import type {
-	AnyString,
 	BaseProps,
 	FocusableProps,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -23,7 +23,7 @@ import cx from "classnames";
 import { ChevronDown, StatusIcon } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/bricks/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -18,12 +18,13 @@ import { Role } from "@ariakit/react/role";
 import { useStoreState } from "@ariakit/react/store";
 import { Button, Text, VisuallyHidden } from "@stratakit/bricks";
 import { IconButtonPresentation } from "@stratakit/bricks/secret-internals";
-import { forwardRef, useControlledState } from "@stratakit/internal-utils";
+import { useControlledState } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { ChevronDown, StatusIcon } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -18,15 +18,12 @@ import { Role } from "@ariakit/react/role";
 import { useStoreState } from "@ariakit/react/store";
 import { Button, Text, VisuallyHidden } from "@stratakit/bricks";
 import { IconButtonPresentation } from "@stratakit/bricks/secret-internals";
-import {
-	forwardRef,
-	useControlledState,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useControlledState } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { ChevronDown, StatusIcon } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/ErrorRegion.tsx
+++ b/packages/structures/src/ErrorRegion.tsx
@@ -23,7 +23,7 @@ import cx from "classnames";
 import { ChevronDown, StatusIcon } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationList.tsx
+++ b/packages/structures/src/NavigationList.tsx
@@ -15,7 +15,10 @@ import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationList.tsx
+++ b/packages/structures/src/NavigationList.tsx
@@ -10,12 +10,15 @@ import { Focusable } from "@ariakit/react/focusable";
 import { Role } from "@ariakit/react/role";
 import { Text } from "@stratakit/bricks";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationList.tsx
+++ b/packages/structures/src/NavigationList.tsx
@@ -15,10 +15,7 @@ import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/bricks/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationList.tsx
+++ b/packages/structures/src/NavigationList.tsx
@@ -10,15 +10,12 @@ import { Focusable } from "@ariakit/react/focusable";
 import { Role } from "@ariakit/react/role";
 import { Text } from "@stratakit/bricks";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { ChevronDown } from "./~utils.icons.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -9,19 +9,22 @@ import { Role } from "@ariakit/react/role";
 import { Tooltip, VisuallyHidden } from "@stratakit/bricks";
 import { Icon } from "@stratakit/foundations";
 import {
-	forwardRef,
 	useEventHandlers,
 	useMergedRefs,
 	useSafeContext,
 	useStableCallback,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
 import { useWarnOnInteractiveDescendants } from "./~hooks.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -21,7 +21,10 @@ import { combine } from "zustand/middleware";
 import { useWarnOnInteractiveDescendants } from "./~hooks.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -14,17 +14,14 @@ import {
 	useMergedRefs,
 	useSafeContext,
 	useStableCallback,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import cx from "classnames";
 import { createStore, useStore } from "zustand";
 import { combine } from "zustand/middleware";
 import { useWarnOnInteractiveDescendants } from "./~hooks.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -21,10 +21,7 @@ import { combine } from "zustand/middleware";
 import { useWarnOnInteractiveDescendants } from "./~hooks.js";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/bricks/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Popover.tsx
+++ b/packages/structures/src/Popover.tsx
@@ -16,10 +16,7 @@ import {
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/bricks/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Popover.tsx
+++ b/packages/structures/src/Popover.tsx
@@ -9,14 +9,17 @@ import { PortalContext } from "@ariakit/react/portal";
 import { useStoreState } from "@ariakit/react/store";
 import { Button } from "@stratakit/bricks";
 import {
-	forwardRef,
 	usePopoverApi,
 	useStableCallback,
-} from "@stratakit/internal-utils";
+} from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Popover.tsx
+++ b/packages/structures/src/Popover.tsx
@@ -16,7 +16,10 @@ import {
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Popover.tsx
+++ b/packages/structures/src/Popover.tsx
@@ -12,14 +12,11 @@ import {
 	forwardRef,
 	usePopoverApi,
 	useStableCallback,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -13,7 +13,10 @@ import {
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -13,10 +13,7 @@ import {
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/bricks/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -5,15 +5,16 @@
 
 import { useStoreState } from "@ariakit/react/store";
 import * as AkTab from "@ariakit/react/tab";
-import {
-	forwardRef,
-	isBrowser,
-	useStableCallback,
-} from "@stratakit/internal-utils";
+import { isBrowser } from "@stratakit/internal-utils/dom";
+import { useStableCallback } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
+import type {
+	BaseProps,
+	FocusableProps,
+} from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Tabs.tsx
+++ b/packages/structures/src/Tabs.tsx
@@ -9,14 +9,11 @@ import {
 	forwardRef,
 	isBrowser,
 	useStableCallback,
-} from "@stratakit/foundations/secret-internals";
+} from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type {
-	BaseProps,
-	FocusableProps,
-} from "@stratakit/foundations/secret-internals";
+import type { BaseProps, FocusableProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Toolbar.tsx
+++ b/packages/structures/src/Toolbar.tsx
@@ -13,7 +13,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/bricks/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Toolbar.tsx
+++ b/packages/structures/src/Toolbar.tsx
@@ -9,11 +9,11 @@ import {
 	IconButtonContext,
 	TooltipContext,
 } from "@stratakit/bricks/secret-internals";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Toolbar.tsx
+++ b/packages/structures/src/Toolbar.tsx
@@ -9,11 +9,11 @@ import {
 	IconButtonContext,
 	TooltipContext,
 } from "@stratakit/bricks/secret-internals";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Toolbar.tsx
+++ b/packages/structures/src/Toolbar.tsx
@@ -13,7 +13,7 @@ import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Tree.tsx
+++ b/packages/structures/src/Tree.tsx
@@ -10,7 +10,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { Action as TreeItemAction, Root as TreeItemRoot } from "./TreeItem.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Tree.tsx
+++ b/packages/structures/src/Tree.tsx
@@ -5,12 +5,12 @@
 
 import { Composite, useCompositeStore } from "@ariakit/react/composite";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { Action as TreeItemAction, Root as TreeItemRoot } from "./TreeItem.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Tree.tsx
+++ b/packages/structures/src/Tree.tsx
@@ -5,12 +5,12 @@
 
 import { Composite, useCompositeStore } from "@ariakit/react/composite";
 import { Role } from "@ariakit/react/role";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { Action as TreeItemAction, Root as TreeItemRoot } from "./TreeItem.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/Tree.tsx
+++ b/packages/structures/src/Tree.tsx
@@ -10,7 +10,7 @@ import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 import { Action as TreeItemAction, Root as TreeItemRoot } from "./TreeItem.js";
 
-import type { BaseProps } from "@stratakit/bricks/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -19,7 +19,7 @@ import { ChevronDown, MoreHorizontal, StatusIcon } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
 import * as DropdownMenu from "./DropdownMenu.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -13,13 +13,14 @@ import {
 	IconButtonPresentation,
 } from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
-import { forwardRef, useEventHandlers } from "@stratakit/internal-utils";
+import { useEventHandlers } from "@stratakit/internal-utils/hooks";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { ChevronDown, MoreHorizontal, StatusIcon } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
 import * as DropdownMenu from "./DropdownMenu.js";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -13,16 +13,13 @@ import {
 	IconButtonPresentation,
 } from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
-import {
-	forwardRef,
-	useEventHandlers,
-} from "@stratakit/foundations/secret-internals";
+import { forwardRef, useEventHandlers } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { ChevronDown, MoreHorizontal, StatusIcon } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
 import * as DropdownMenu from "./DropdownMenu.js";
 
-import type { BaseProps } from "@stratakit/foundations/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/TreeItem.tsx
+++ b/packages/structures/src/TreeItem.tsx
@@ -19,7 +19,7 @@ import { ChevronDown, MoreHorizontal, StatusIcon } from "./~utils.icons.js";
 import * as ListItem from "./~utils.ListItem.js";
 import * as DropdownMenu from "./DropdownMenu.js";
 
-import type { BaseProps } from "@stratakit/bricks/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/~utils.ListItem.tsx
+++ b/packages/structures/src/~utils.ListItem.tsx
@@ -5,7 +5,7 @@
 
 import { Role } from "@ariakit/react/role";
 import { Text } from "@stratakit/bricks";
-import { forwardRef } from "@stratakit/foundations/secret-internals";
+import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 

--- a/packages/structures/src/~utils.ListItem.tsx
+++ b/packages/structures/src/~utils.ListItem.tsx
@@ -5,7 +5,7 @@
 
 import { Role } from "@ariakit/react/role";
 import { Text } from "@stratakit/bricks";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 import { useInit } from "./~utils.useInit.js";
 

--- a/packages/structures/src/~utils.icons.tsx
+++ b/packages/structures/src/~utils.icons.tsx
@@ -7,7 +7,7 @@ import { createIconFromPath } from "@stratakit/bricks/secret-internals";
 import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/bricks/secret-internals";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/~utils.icons.tsx
+++ b/packages/structures/src/~utils.icons.tsx
@@ -7,7 +7,7 @@ import { createIconFromPath } from "@stratakit/bricks/secret-internals";
 import { forwardRef } from "@stratakit/internal-utils";
 import cx from "classnames";
 
-import type { BaseProps } from "@stratakit/bricks/secret-internals";
+import type { BaseProps } from "@stratakit/internal-utils";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/~utils.icons.tsx
+++ b/packages/structures/src/~utils.icons.tsx
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createIconFromPath } from "@stratakit/bricks/secret-internals";
-import { forwardRef } from "@stratakit/internal-utils";
+import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
 
-import type { BaseProps } from "@stratakit/internal-utils";
+import type { BaseProps } from "@stratakit/internal-utils/props";
 
 // ----------------------------------------------------------------------------
 

--- a/packages/structures/src/~utils.useInit.tsx
+++ b/packages/structures/src/~utils.useInit.tsx
@@ -5,7 +5,7 @@
 
 import * as React from "react";
 import { RootContext } from "@stratakit/foundations/secret-internals";
-import { useSafeContext } from "@stratakit/internal-utils";
+import { useSafeContext } from "@stratakit/internal-utils/hooks";
 import css from "./styles.css.js";
 
 const packageName = "@stratakit/structures";

--- a/packages/structures/src/~utils.useInit.tsx
+++ b/packages/structures/src/~utils.useInit.tsx
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from "react";
-import {
-	RootContext,
-	useSafeContext,
-} from "@stratakit/foundations/secret-internals";
+import { RootContext } from "@stratakit/foundations/secret-internals";
+import { useSafeContext } from "@stratakit/internal-utils";
 import css from "./styles.css.js";
 
 const packageName = "@stratakit/structures";


### PR DESCRIPTION
### Changes

This PR is stacked on #1565 to reduce the overhead for reviewers. It simply replaces all imports of `@stratakit/foundations/secret-internals` with `@stratakit/internal-utils` (except those that use `RootContext`).

### Testing

Tested `pnpm dev` and `pnpm run docs` locally.
