### PR TITLE
change Emotion cache key

### DIFF
--- a/.changeset/large-forks-punch.md
+++ b/.changeset/large-forks-punch.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Changed the `key` used for `@emotion/cache`.

--- a/apps/website/src/components/Head.astro
+++ b/apps/website/src/components/Head.astro
@@ -29,7 +29,6 @@ const fixedHead = originalHead.map((item) => {
 <style is:inline>
 	@layer reset, starlight;
 </style>
-<meta name="emotion-insertion-point" />
 
 <StrataKit />
 <Fonts />

--- a/packages/mui/src/Root.internal.tsx
+++ b/packages/mui/src/Root.internal.tsx
@@ -21,7 +21,7 @@ export function StyledEngineProvider({ children }: React.PropsWithChildren) {
 
 function createEmotionCache() {
 	const cache = createCache({
-		key: "css",
+		key: "mui",
 		speedy: true, // This injects styles using the `insertRule` API.
 		stylisPlugins: [prefixer],
 	});


### PR DESCRIPTION
### Changes

Main change: Updated the [Emotion key](https://emotion.sh/docs/@emotion/cache#key) used in our custom `CacheProvider` (which was originally added in #1312). The value is changed from `"css"` (default) to `"mui"` (same as [material-ui#48603](https://redirect.github.com/mui/material-ui/pull/48603)). This makes the behavior more consistent with MUI, and avoids potential caches when multiple Emotion caches are used in the same app.

Unrelated change: Removed the leftover `<meta name="emotion-insertion-point">` from docsite. This is not needed after #1312.

### Testing

Observed that generated classes are now prefixed with `mui-` instead of `css-`.