### PR TITLE
Increase `Tabs` icon + label contrast

### DIFF
--- a/.changeset/late-emus-lick.md
+++ b/.changeset/late-emus-lick.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Increased contrast of `Tabs` icons and labels.

--- a/packages/mui/src/~components/MuiTabs.css
+++ b/packages/mui/src/~components/MuiTabs.css
@@ -61,12 +61,12 @@
 	--✨bg--hover-neutral: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
 	--✨bg--hover-accent: var(--stratakit-color-bg-glow-on-surface-accent-hover);
 
-	--✨color--default: var(--stratakit-color-text-neutral-tertiary);
+	--✨color--default: var(--stratakit-color-text-neutral-secondary);
 	--✨color--selected-neutral: var(--stratakit-color-text-neutral-primary);
 	--✨color--selected-accent: var(--stratakit-color-text-accent-strong);
 	--✨color--disabled: var(--stratakit-color-text-neutral-disabled);
 
-	--✨icon--default: var(--stratakit-color-icon-neutral-tertiary);
+	--✨icon--default: var(--stratakit-color-icon-neutral-base);
 	--✨icon--selected-neutral: var(--stratakit-color-icon-neutral-primary);
 	--✨icon--selected-accent: var(--stratakit-color-icon-accent-strong);
 	--✨icon--disabled: var(--stratakit-color-icon-neutral-disabled);


### PR DESCRIPTION
### Changes

Updated `Tabs` icon & label color values when in the default state as discussed in our teams call on June 23rd.

| Static variable | Prior value | New value |
| -- | -- | -- |
| `--✨color--default` | `--stratakit-color-text-neutral-tertiary` | `--stratakit-color-text-neutral-secondary` |
| `--✨icon--default` | `--stratakit-color-icon-neutral-tertiary` | `--stratakit-color-icon-neutral-base` |

### Testing

- Confirmed with my eyeballs. 👀
