### PR TITLE
update icons in `MobileStepper`

### DIFF
--- a/examples/mui/MobileStepper.default.tsx
+++ b/examples/mui/MobileStepper.default.tsx
@@ -8,8 +8,8 @@ import Button from "@mui/material/Button";
 import MobileStepper from "@mui/material/MobileStepper";
 import { Icon } from "@stratakit/mui";
 
-import svgBack from "@stratakit/icons/caret-left.svg";
-import svgNext from "@stratakit/icons/caret-right.svg";
+import svgBack from "@stratakit/icons/chevron-left.svg";
+import svgNext from "@stratakit/icons/chevron-right.svg";
 
 export default () => {
 	const [activeStep, setActiveStep] = React.useState(0);


### PR DESCRIPTION
### Changes

Changed the icons used in the `MobileStepper` example from caret-* to chevron-*, which is easier to see and more closely matches the icons used elsewhere (e.g. `Pagination`).

### Testing

| Before | After |
| --- | --- |
| <img width="380" height="58" alt="image" src="https://github.com/user-attachments/assets/50f79f7f-307c-4b4a-9bfe-1412617e49b6" /> | <img width="371" height="57" alt="image" src="https://github.com/user-attachments/assets/aaf9f583-5bac-4016-87d5-3d2aa797ae21" /> |