### PR TITLE
fix `DatePicker` button alignment

### DIFF
--- a/.changeset/old-parts-drive.md
+++ b/.changeset/old-parts-drive.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed text alignment for buttons in `DatePicker` and `TimePicker`.

--- a/packages/mui/src/~components.css
+++ b/packages/mui/src/~components.css
@@ -34,6 +34,8 @@
 @import "./~components/MuiToggleButton.css";
 @import "./~components/MuiTooltip.css";
 
+@import "./~components/MuiDatePicker.css";
+
 .MuiAppBar-root {
 	background-color: var(--stratakit-color-bg-page-base);
 	box-shadow: none;

--- a/packages/mui/src/~components/MuiDatePicker.css
+++ b/packages/mui/src/~components/MuiDatePicker.css
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+.MuiYearCalendar-button {
+	text-align: center;
+}
+
+.MuiMultiSectionDigitalClockSection-item:is(.MuiMenuItem-root) {
+	&::before {
+		content: none;
+	}
+}


### PR DESCRIPTION
_~~Stacked against~~ Builds upon #1579._

### Changes

This fixes text alignment in two places:
- `DatePicker`: the calendar year buttons were appearing left aligned due to StrataKit's reset. (see [#1439](https://github.com/iTwin/stratakit/issues/1439))
- `TimePicker`: all the time parts had extra space on the left because these options extend from `MenuItem`, which reserves space for a checkmark (see [#1471](https://github.com/iTwin/stratakit/pull/1471)).

Much more work to be done as part of #818, but this is a start.

All the CSS lives in a new file which is imported _after_ the base MUI components, since MUI X components build upon the base components and might need more specific styles.

### Testing

| | Before | After |
| --- | --- | --- |
| DatePicker | <img width="345" height="431" alt="image" src="https://github.com/user-attachments/assets/ea3c34a2-b50f-48e7-a3b3-cbc607d650d4" />  | <img width="346" height="439" alt="image" src="https://github.com/user-attachments/assets/4bb9db44-016c-41a1-acaf-b827c8e8a525" /> |
| TimePicker | <img width="284" height="398" alt="image" src="https://github.com/user-attachments/assets/e86bd264-f266-47e8-b949-435431f12d2d" /> | <img width="287" height="397" alt="image" src="https://github.com/user-attachments/assets/8178ef8d-39d8-4277-98e8-d5b86268d389" /> |