### PR TITLE
test-app: fix skip link on `/sandbox` route

### DIFF
--- a/apps/test-app/app/sandbox/index.tsx
+++ b/apps/test-app/app/sandbox/index.tsx
@@ -34,6 +34,7 @@ import {
 	PanelGroup,
 	PanelResizeHandle,
 } from "react-resizable-panels";
+import { SkipLinkContext } from "~/~navigation.tsx";
 import { toUpperCamelCase } from "~/~utils.tsx";
 
 import type { UseQueryResult } from "@tanstack/react-query";
@@ -94,7 +95,7 @@ export const meta: MetaFunction = () => {
 
 export default function Page() {
 	return (
-		<div className={styles.appLayout}>
+		<div className={styles.appLayout} id={React.use(SkipLinkContext)?.id}>
 			<Header />
 			<PanelGroup
 				direction="horizontal"


### PR DESCRIPTION
### Changes

This fixes a leftover issue from https://github.com/iTwin/stratakit/pull/1187, where the `/sandbox` route was not consuming the `id` from `SkipLinkContext`.

### Testing

Confirmed that skip link works correctly on the `/sandbox` route. ([Deploy preview](https://stratakit.bentley.com/1581/sandbox/))

Steps: <kbd>Tab</kbd> to skip link, activate the skip link by pressing <kbd>Enter</kbd>, continue <kbd>Tab</kbd>-ing forward.

- Before: Focus goes through the items in the primary navRail.
- After: Focus correctly skips navRail, entering the leftPanel directly.