### PR TITLE
Put the focus ring around entire Rating component

### DIFF
--- a/.changeset/big-terms-win.md
+++ b/.changeset/big-terms-win.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Display focus ring around entire `Rating` component intead of individual values.

--- a/packages/mui/src/~components/MuiRating.css
+++ b/packages/mui/src/~components/MuiRating.css
@@ -5,10 +5,16 @@
 .MuiRating-root {
 	--_MuiRating-icon-color: var(--stratakit-color-icon-neutral-base);
 	inline-size: fit-content;
+	border-radius: var(--stratakit-mui-shape-borderRadius);
 
 	&:where(.Mui-disabled) {
 		--_MuiRating-icon-color: var(--stratakit-color-icon-neutral-disabled);
 		opacity: 1;
+	}
+
+	&.Mui-focusVisible {
+		outline: var(--🥝focus-outline);
+		outline-offset: var(--🥝focus-outline-offset);
 	}
 }
 
@@ -23,14 +29,14 @@
 		--_MuiRating-icon-color: var(--stratakit-color-icon-neutral-primary);
 
 		:where(.MuiRating-root.Mui-focusVisible) & {
-			outline: var(--🥝focus-outline);
-			outline-offset: var(--🥝focus-outline-offset);
+			outline: 0;
 		}
 	}
 }
 
 .MuiRating-label {
 	&:where(.MuiRating-labelEmptyValueActive) {
+		border-radius: var(--stratakit-mui-shape-borderRadius);
 		outline: var(--🥝focus-outline);
 		outline-offset: var(--🥝focus-outline-offset);
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Always show focus ring around entire set of starts and add rounded border.  Previously would show ring only around top star, unless there were 0 starts and then it would show around the entire component.

Fixes https://github.com/iTwin/stratakit/issues/1564


**Before**
<img width="413" height="177" alt="image" src="https://github.com/user-attachments/assets/aaed71d4-ed53-4ed4-b17a-b0adcf752e0b" />
<img width="358" height="185" alt="image" src="https://github.com/user-attachments/assets/72dd2a1b-cdea-4728-bacf-8134771dfc19" />



**After**

<img width="436" height="156" alt="image" src="https://github.com/user-attachments/assets/6f5d601c-92fd-4b43-bc9d-71d88379cc9f" />
<img width="418" height="191" alt="image" src="https://github.com/user-attachments/assets/8ae81392-e561-405b-ad46-74b63c0dd695" />



### Testing


Test focus with stars selected and no stars selected.