### PR TITLE
Demo improvements

### DIFF
--- a/examples/mui/Autocomplete.default.tsx
+++ b/examples/mui/Autocomplete.default.tsx
@@ -22,7 +22,7 @@ export default () => {
 				"TextField",
 			]}
 			renderInput={(params) => (
-				<TextField {...params} label="Favorite component:" />
+				<TextField {...params} label="Favorite component" />
 			)}
 		/>
 	);

--- a/examples/mui/Autocomplete.multiple.tsx
+++ b/examples/mui/Autocomplete.multiple.tsx
@@ -22,7 +22,7 @@ export default () => {
 				"TextField",
 			]}
 			renderInput={(params) => (
-				<TextField {...params} label="Favorite components:" />
+				<TextField {...params} label="Favorite components" />
 			)}
 			multiple
 		/>

--- a/examples/mui/Autocomplete.sizes.tsx
+++ b/examples/mui/Autocomplete.sizes.tsx
@@ -14,14 +14,14 @@ export default () => {
 				size="small"
 				options={["Mouse", "Worm"]}
 				renderInput={(params) => (
-					<TextField {...params} label="Favorite small animal:" />
+					<TextField {...params} label="Favorite small animal" />
 				)}
 			/>
 
 			<Autocomplete
 				options={["Cat", "Dog"]}
 				renderInput={(params) => (
-					<TextField {...params} label="Favorite medium animal:" />
+					<TextField {...params} label="Favorite medium animal" />
 				)}
 			/>
 		</Stack>

--- a/examples/mui/Checkbox.error.tsx
+++ b/examples/mui/Checkbox.error.tsx
@@ -16,7 +16,7 @@ export default () => {
 	const errorId = React.useId();
 	return (
 		<FormControl render={<fieldset />} error aria-describedby={errorId}>
-			<FormLabel render={<legend />}>Privacy preferences:</FormLabel>
+			<FormLabel render={<legend />}>Privacy preferences</FormLabel>
 			<FormGroup>
 				<FormControlLabel control={<Checkbox />} label="Allow cookies" />
 				<FormControlLabel

--- a/examples/mui/Checkbox.group.tsx
+++ b/examples/mui/Checkbox.group.tsx
@@ -28,7 +28,7 @@ export default () => {
 				/>
 			</FormGroup>
 			<FormHelperText id={descriptionId}>
-				You can change these settings at any time
+				You can change these settings at any time.
 			</FormHelperText>
 		</FormControl>
 	);

--- a/examples/mui/Checkbox.group.tsx
+++ b/examples/mui/Checkbox.group.tsx
@@ -15,7 +15,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<FormControl render={<fieldset />} aria-describedby={descriptionId}>
-			<FormLabel render={<legend />}>Privacy preferences:</FormLabel>
+			<FormLabel render={<legend />}>Privacy preferences</FormLabel>
 			<FormGroup>
 				<FormControlLabel control={<Checkbox />} label="Allow cookies" />
 				<FormControlLabel

--- a/examples/mui/IconButton._placements.tsx
+++ b/examples/mui/IconButton._placements.tsx
@@ -10,10 +10,10 @@ import svgPlaceholder from "@stratakit/icons/placeholder.svg";
 
 type IconButtonProps = React.ComponentProps<typeof IconButton>;
 const placements = [
-	"top",
-	"right",
-	"bottom",
 	"left",
+	"top",
+	"bottom",
+	"right",
 ] as const satisfies IconButtonProps["labelPlacement"][];
 
 export default () => {

--- a/examples/mui/NativeSelect.default.tsx
+++ b/examples/mui/NativeSelect.default.tsx
@@ -13,7 +13,7 @@ export default () => {
 	return (
 		<FormControl>
 			<InputLabel variant="standard" htmlFor={inputId}>
-				Design system:
+				Design system
 			</InputLabel>
 			<NativeSelect
 				defaultValue={2}

--- a/examples/mui/RadioGroup.default.tsx
+++ b/examples/mui/RadioGroup.default.tsx
@@ -12,7 +12,7 @@ import RadioGroup from "@mui/material/RadioGroup";
 export default () => {
 	return (
 		<FormControl render={<fieldset />} role="radiogroup">
-			<FormLabel render={<legend />}>Design system:</FormLabel>
+			<FormLabel render={<legend />}>Design system</FormLabel>
 			<RadioGroup name="design-system" role={undefined}>
 				<FormControlLabel
 					value="StrataKit"

--- a/examples/mui/RadioGroup.defaultValue.tsx
+++ b/examples/mui/RadioGroup.defaultValue.tsx
@@ -12,7 +12,7 @@ import RadioGroup from "@mui/material/RadioGroup";
 export default () => {
 	return (
 		<FormControl render={<fieldset />} role="radiogroup">
-			<FormLabel render={<legend />}>Design system:</FormLabel>
+			<FormLabel render={<legend />}>Design system</FormLabel>
 			<RadioGroup
 				name="design-system"
 				role={undefined}

--- a/examples/mui/RadioGroup.error.tsx
+++ b/examples/mui/RadioGroup.error.tsx
@@ -16,7 +16,7 @@ export default () => {
 	const errorId = React.useId();
 	return (
 		<FormControl render={<fieldset />} role="radiogroup" error>
-			<FormLabel render={<legend />}>Gender:</FormLabel>
+			<FormLabel render={<legend />}>Gender</FormLabel>
 			<RadioGroup aria-describedby={errorId} name="gender" role={undefined}>
 				<FormControlLabel value="female" control={<Radio />} label="Female" />
 				<FormControlLabel value="male" control={<Radio />} label="Male" />

--- a/examples/mui/Rating.default.tsx
+++ b/examples/mui/Rating.default.tsx
@@ -10,7 +10,7 @@ import Rating from "@mui/material/Rating";
 export default () => {
 	return (
 		<FormControl render={<fieldset />} role="radiogroup">
-			<FormLabel render={<legend />}>Product rating:</FormLabel>
+			<FormLabel render={<legend />}>Product rating</FormLabel>
 			<Rating name="product-rating" defaultValue={2} />
 		</FormControl>
 	);

--- a/examples/mui/Rating.sizes.tsx
+++ b/examples/mui/Rating.sizes.tsx
@@ -11,17 +11,17 @@ export default () => {
 	return (
 		<>
 			<FormControl render={<fieldset />} role="radiogroup">
-				<FormLabel render={<legend />}>Small rating:</FormLabel>
+				<FormLabel render={<legend />}>Small rating</FormLabel>
 				<Rating size="small" name="product-rating-small" defaultValue={1} />
 			</FormControl>
 
 			<FormControl render={<fieldset />} role="radiogroup">
-				<FormLabel render={<legend />}>Medium rating:</FormLabel>
+				<FormLabel render={<legend />}>Medium rating</FormLabel>
 				<Rating size="medium" name="product-rating-medium" defaultValue={3} />
 			</FormControl>
 
 			<FormControl render={<fieldset />} role="radiogroup">
-				<FormLabel render={<legend />}>Large rating:</FormLabel>
+				<FormLabel render={<legend />}>Large rating</FormLabel>
 				<Rating size="large" name="product-rating-large" defaultValue={5} />
 			</FormControl>
 		</>

--- a/examples/mui/Select.default.tsx
+++ b/examples/mui/Select.default.tsx
@@ -11,7 +11,7 @@ import Select from "@mui/material/Select";
 
 export default () => {
 	const labelId = React.useId();
-	const label = "Design system:";
+	const label = "Design system";
 	return (
 		<FormControl>
 			<InputLabel id={labelId}>{label}</InputLabel>

--- a/examples/mui/Select.icon.tsx
+++ b/examples/mui/Select.icon.tsx
@@ -18,7 +18,7 @@ import svgStar from "@stratakit/icons/star.svg";
 
 export default () => {
 	const labelId = React.useId();
-	const label = "Favorite shape:";
+	const label = "Favorite shape";
 	return (
 		<FormControl>
 			<InputLabel id={labelId}>{label}</InputLabel>

--- a/examples/mui/Select.multiple.tsx
+++ b/examples/mui/Select.multiple.tsx
@@ -11,7 +11,7 @@ import Select from "@mui/material/Select";
 
 export default () => {
 	const labelId = React.useId();
-	const label = "Design systems:";
+	const label = "Design systems";
 	return (
 		<FormControl>
 			<InputLabel id={labelId}>{label}</InputLabel>

--- a/examples/mui/Select.sizes.tsx
+++ b/examples/mui/Select.sizes.tsx
@@ -21,7 +21,7 @@ export default () => {
 
 const SmallSelect = () => {
 	const id = React.useId();
-	const label = "Favorite small animal:";
+	const label = "Favorite small animal";
 	return (
 		<FormControl>
 			<InputLabel id={id} size="small">
@@ -37,7 +37,7 @@ const SmallSelect = () => {
 
 const MediumSelect = () => {
 	const id = React.useId();
-	const label = "Favorite medium animal:";
+	const label = "Favorite medium animal";
 	return (
 		<FormControl>
 			<InputLabel id={id}>{label}</InputLabel>

--- a/examples/mui/Slider.default.tsx
+++ b/examples/mui/Slider.default.tsx
@@ -21,7 +21,6 @@ export default () => {
 					{" "}
 					from 0 (very sad) to 100 (very happy)
 				</span>
-				:
 			</FormLabel>
 			<Stack spacing={1} direction="row" sx={{ alignItems: "center", mb: 1 }}>
 				<Typography aria-hidden="true">Sad</Typography>

--- a/examples/mui/Slider.marks.tsx
+++ b/examples/mui/Slider.marks.tsx
@@ -23,7 +23,7 @@ export default () => {
 	return (
 		<FormControl fullWidth>
 			<FormLabel htmlFor={id}>
-				Temperature<span style={visuallyHidden}> from 0°C to 100°C</span>:
+				Temperature<span style={visuallyHidden}> from 0°C to 100°C</span>
 			</FormLabel>
 			<Slider
 				marks={marks}

--- a/examples/mui/Slider.range.tsx
+++ b/examples/mui/Slider.range.tsx
@@ -23,7 +23,7 @@ export default () => {
 	return (
 		<FormControl fullWidth>
 			<FormLabel htmlFor={id}>
-				Temperature range<span style={visuallyHidden}> from 0°C to 100°C</span>:
+				Temperature range<span style={visuallyHidden}> from 0°C to 100°C</span>
 			</FormLabel>
 			<Slider
 				marks={marks}

--- a/examples/mui/Slider.sizes.tsx
+++ b/examples/mui/Slider.sizes.tsx
@@ -26,7 +26,7 @@ const SmallSlider = () => {
 		<FormControl fullWidth>
 			<FormLabel htmlFor={id}>
 				Small size
-				<span style={visuallyHidden}> from 0 to 100 inches</span>:
+				<span style={visuallyHidden}> from 0 to 100 inches</span>
 			</FormLabel>
 			<Stack spacing={1} direction="row" sx={{ alignItems: "center", mb: 1 }}>
 				<Typography aria-hidden="true">0″</Typography>
@@ -43,7 +43,7 @@ const MediumSlider = () => {
 		<FormControl fullWidth>
 			<FormLabel htmlFor={id}>
 				Medium size
-				<span style={visuallyHidden}> from 0 to 100 feet</span>:
+				<span style={visuallyHidden}> from 0 to 100 feet</span>
 			</FormLabel>
 			<Stack spacing={1} direction="row" sx={{ alignItems: "center", mb: 1 }}>
 				<Typography aria-hidden="true" sx={{ textWrap: "nowrap" }}>

--- a/examples/mui/Slider.tooltip.tsx
+++ b/examples/mui/Slider.tooltip.tsx
@@ -20,7 +20,7 @@ export default () => {
 		<FormControl fullWidth>
 			<FormLabel htmlFor={id}>
 				Volume
-				<span style={visuallyHidden}> from 0 to 100</span>:
+				<span style={visuallyHidden}> from 0 to 100</span>
 			</FormLabel>
 			<Stack spacing={1} direction="row" sx={{ alignItems: "center", mb: 1 }}>
 				<Icon href={svgSoundQuiet} />

--- a/examples/mui/Slider.vertical.tsx
+++ b/examples/mui/Slider.vertical.tsx
@@ -24,7 +24,6 @@ export default () => {
 					{" "}
 					from 0 (very sad) to 100 (very happy)
 				</span>
-				:
 			</FormLabel>
 			<Stack spacing={1} direction="column-reverse">
 				<Icon href={svgSad} />

--- a/examples/mui/Table.footer.tsx
+++ b/examples/mui/Table.footer.tsx
@@ -67,6 +67,7 @@ export default () => {
 					<TableRow>
 						<TablePagination
 							rowsPerPageOptions={[5, 10, 25, { label: "All", value: -1 }]}
+							labelRowsPerPage="Rows per page"
 							colSpan={5}
 							count={100}
 							rowsPerPage={10}

--- a/examples/mui/TextField.default.tsx
+++ b/examples/mui/TextField.default.tsx
@@ -6,5 +6,5 @@
 import TextField from "@mui/material/TextField";
 
 export default () => {
-	return <TextField label="Name:" />;
+	return <TextField label="Name" />;
 };

--- a/examples/mui/TextField.error.tsx
+++ b/examples/mui/TextField.error.tsx
@@ -9,7 +9,7 @@ import { visuallyHidden } from "@mui/utils";
 export default () => {
 	return (
 		<TextField
-			label="Email:"
+			label="Email"
 			error
 			helperText={
 				<>

--- a/examples/mui/TextField.icon.tsx
+++ b/examples/mui/TextField.icon.tsx
@@ -12,7 +12,7 @@ import svgEmailAt from "@stratakit/icons/email-at.svg";
 export default () => {
 	return (
 		<TextField
-			label="Username:"
+			label="Username"
 			slotProps={{
 				input: {
 					startAdornment: (

--- a/examples/mui/TextField.multiline.tsx
+++ b/examples/mui/TextField.multiline.tsx
@@ -6,5 +6,5 @@
 import TextField from "@mui/material/TextField";
 
 export default () => {
-	return <TextField label="Description:" multiline />;
+	return <TextField label="Description" multiline />;
 };

--- a/examples/mui/TextField.sizes.tsx
+++ b/examples/mui/TextField.sizes.tsx
@@ -9,8 +9,8 @@ import TextField from "@mui/material/TextField";
 export default () => {
 	return (
 		<Stack spacing={1} direction="row" sx={{ alignItems: "center" }}>
-			<TextField size="small" label="Small:" />
-			<TextField size="medium" label="Medium:" />
+			<TextField size="small" label="Small" />
+			<TextField size="medium" label="Medium" />
 		</Stack>
 	);
 };


### PR DESCRIPTION
### Changes

- In #1473 I added `:` to the end of all labels.  We discussed this in a **Weekly accessibility review** meeting and decided to do the opposite.  This PR removes `:` from all labels.  I was reminded of this task when testing the `required` prop in #1592.
	- One exception is the `Rows per page:` in the `TablePagination` which doesn't seem to be defined in the `Table.footer.tsx`. <img width="1208" height="597" alt="Screenshot 2026-06-30 at 12 00 39 PM" src="https://github.com/user-attachments/assets/cb05626f-8421-427e-ac6e-d2aae7f2310a" />
- Made sure all `FormHelperText` ends with a `.`.
- In `IconButton._placements.tsx` changed the order of the `IconButton`s so the `Tooltip` would not overlap the adjacent `IconButton`.

| Before | After |
| -- | -- |
| <img alt="before" src="https://github.com/user-attachments/assets/c4ff3891-e403-4cb6-872f-a92fd91b84d6" /> | <img alt="after" src="https://github.com/user-attachments/assets/67a272ea-ee0a-4504-958b-2f48c05f5893" /> |


### Testing

n/a