### PR TITLE
Allow :global in CSS modules

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -103,6 +103,17 @@
 	},
 	"overrides": [
 		{
+			"includes": ["**/*.module.css"],
+			"linter": {
+				"rules": {
+					"correctness": {
+						/* Allow using :global in CSS modules*/
+						"noUnknownPseudoClass": "off"
+					}
+				}
+			}
+		},
+		{
 			"includes": ["apps/test-app/**"],
 			"linter": {
 				"rules": {


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Changes biome configuration to allow use of the [`:global` selector for CSS modules](https://github.com/css-modules/css-modules/blob/c7bf6c02472fdce4dd8e569abc10d2aeb234e1c2/docs/composition.md#exceptions)

### Testing


Add a CSS rule that uses `:global`.  Run `pnpm lint` and verify no errors.  Running with the rule on main produces errors.