### PR TITLE
fix `Alert` docs

### DIFF
--- a/apps/website/src/content/docs/components/mui/Alert.md
+++ b/apps/website/src/content/docs/components/mui/Alert.md
@@ -1,6 +1,6 @@
 ---
 title: Alert
-description: Alerts are used to provide feedback without interrupting the user's workflow.
+description: Alerts are used to highlight information without interrupting the user's workflow.
 links:
   muiDocs: https://mui.com/material-ui/react-alert/
   apiReference: https://mui.com/material-ui/api/alert/
@@ -8,17 +8,19 @@ links:
 
 ::example{src="mui/Alert.default"}
 
-## Examples
-
-### Actions
-
-Providing an `onClose` prop will include a close icon button on the `Alert`. Other actions can be provided using the `actions` prop. See the [Material UI Component documentation for Alert actions](https://mui.com/material-ui/react-alert/#actions) for more examples.
-
-::example{src="mui/Alert.close"}
-
 ## StrataKit MUI modifications
 
 - Restyled using StrataKit's visual language.
 - The `"standard"` variant has been removed. The default variant is now `"outlined"`.
 - The default severity is now a new `"none"` value instead of `"success"`.
 - The **Alert** will no longer create a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) by default. It now uses [`role="group"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role) instead of [`role="alert"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role).
+
+## Examples
+
+### Actions
+
+A close icon button can be included by using the [`onClose`](https://mui.com/material-ui/api/alert/#alert-prop-onClose) prop.
+
+::example{src="mui/Alert.close"}
+
+For other types of actions, the [`action`](https://mui.com/material-ui/api/alert/#alert-prop-action) prop can be used instead. See [more examples in MUI docs](https://mui.com/material-ui/react-alert/#actions).


### PR DESCRIPTION


### Changes

Several changes to `Alert.md` after #1570:
- adjusted "provide feedback" wording to make it more generic (esp. since it's no longer a live region after #1388)
- examples moved below modifications, per [established order](https://stratakit.bentley.com/docs/components/overview/#component-guidance)
- typo fix: `actions` → `action` prop
- moved `action` description after `onClose` example and adjusted wording
- link to MUI API reference for props

### Testing

Read the docs from top to bottom to ensure it makes sense.

[Deploy preview](https://stratakit.bentley.com/1604/docs/components/alert)