### PR TITLE
fix `DialogTitle` size

### DIFF
--- a/.changeset/real-pants-wonder.md
+++ b/.changeset/real-pants-wonder.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed the size of `DialogTitle`.

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -334,7 +334,12 @@ function createTheme(args: CreateThemeArgs) {
 					variant: "inherit",
 				},
 			},
-			MuiDialogTitle: { defaultProps: { component: Role.h2 } },
+			MuiDialogTitle: {
+				defaultProps: {
+					component: Role.h2,
+					variant: "body-lg",
+				},
+			},
 			MuiDivider: { defaultProps: { component: MuiDivider } },
 			MuiDrawer: { defaultProps: { component: Role.div } },
 			MuiFab: {


### PR DESCRIPTION
### Changes

After #1550, the `DialogTitle` was appearing too small. This PR changes the `variant` from `"h6"` to `"body-lg"` (matching the [legacy StrataKit value](https://github.com/iTwin/stratakit/blob/0a6aa1d07554228b3c901b97dd04d726b39bb0a5/packages/structures/src/Dialog.tsx#L200)).

### Testing

| Before | After |
| --- | --- |
| <img width="516" height="172" alt="screenshot" src="https://github.com/user-attachments/assets/bfe25cc5-625c-45ca-bc16-f7332e44a511" /> | <img width="518" height="179" alt="screenshot" src="https://github.com/user-attachments/assets/87323b03-434d-46e6-9425-44abf1287b66" /> |