### PR TITLE
test-app: allow resizing examples

### DIFF
--- a/apps/test-app/app/~examples.module.css
+++ b/apps/test-app/app/~examples.module.css
@@ -33,15 +33,28 @@
 .exampleContent {
 	position: relative;
 
+	anchor-name: --example-content;
+	anchor-scope: --example-content;
+
 	background-color: var(--stratakit-color-bg-page-base);
 	border: 1px solid var(--stratakit-color-border-neutral-muted);
 
 	padding: calc(var(--stratakit-size-control-field-height-small) / 2 + var(--stratakit-space-x3));
 	border-radius: 8px;
 
-	:where(.exampleContainer[data-highlight]) & {
+	:where(.exampleContainer[data-highlight]) &::before {
+		content: "";
+		pointer-events: none;
+
+		position: fixed;
+		position-anchor: --example-content;
+		position-area: center center;
+		inline-size: anchor-size();
+		block-size: anchor-size();
+
 		outline: 1px solid var(--stratakit-color-border-mono-base);
 		outline-offset: 1px;
+		border-radius: inherit;
 	}
 }
 
@@ -71,10 +84,12 @@
 }
 
 .exampleToolbar {
-	position: absolute;
-	inset-block-start: 0;
-	inset-inline-end: 8px;
-	translate: 0 -50%;
+	position: fixed;
+	position-anchor: --example-content;
+
+	inset-block-start: anchor(start);
+	inset-inline-end: calc(anchor(end) + 8px); /* offset from rounded corner */
+	translate: 0 -50%; /* center vertically on top edge */
 
 	background-color: var(--stratakit-color-bg-page-base);
 	border-radius: 4px;

--- a/apps/test-app/app/~examples.module.css
+++ b/apps/test-app/app/~examples.module.css
@@ -45,6 +45,31 @@
 	}
 }
 
+.resizeHandle {
+	align-self: stretch;
+
+	display: grid;
+	place-items: center;
+	inline-size: 24px;
+
+	color: var(--stratakit-color-icon-neutral-base);
+	border-radius: 4px;
+	cursor: ew-resize;
+
+	&:where(
+			:hover,
+			:focus-visible,
+			[data-resize-handle-state="hover"],
+			[data-resize-handle-state="drag"]
+		) {
+		color: var(--stratakit-color-icon-neutral-primary);
+	}
+
+	&:focus-visible {
+		outline-offset: -2px;
+	}
+}
+
 .exampleToolbar {
 	position: absolute;
 	inset-block-start: 0;

--- a/apps/test-app/app/~examples.tsx
+++ b/apps/test-app/app/~examples.tsx
@@ -12,11 +12,18 @@ import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 import { Icon } from "@stratakit/mui";
+import {
+	getResizeHandleElement,
+	Panel,
+	PanelGroup,
+	PanelResizeHandle,
+} from "react-resizable-panels";
 import { createStore, useStore } from "zustand";
 
 import type { Knob } from "./~utils.tsx";
 
 import svgConfiguration from "@stratakit/icons/configuration.svg";
+import svgDragHandleVertical from "@stratakit/icons/drag-handle-vertical.svg";
 import svgLink from "@stratakit/icons/link.svg";
 import styles from "./~examples.module.css";
 
@@ -74,11 +81,59 @@ export function ExamplesShowcase(props: ExamplesShowcaseProps) {
 				</IconButton>
 			</hgroup>
 
-			<div className={styles.exampleContent}>
-				{toolbar}
-				{children}
-			</div>
+			<Resizable label={`Resize ${name} examples`}>
+				<div className={styles.exampleContent}>
+					{toolbar}
+					{children}
+				</div>
+			</Resizable>
 		</section>
+	);
+}
+
+// ----------------------------------------------------------------------------
+
+interface ResizableProps extends React.PropsWithChildren {
+	label: string;
+}
+
+function Resizable(props: ResizableProps) {
+	const { children, label } = props;
+
+	const resizerId = React.useId();
+
+	React.useEffect(
+		function overrideResizerRole() {
+			const resizer = getResizeHandleElement(resizerId);
+
+			// The slider role has better NVDA support than the default separator role.
+			// It is also more semantically correct, since there is only one panel that is being resized.
+			resizer?.setAttribute("role", "slider");
+		},
+		[resizerId],
+	);
+
+	return (
+		<PanelGroup
+			direction="horizontal"
+			keyboardResizeBy={5}
+			style={{ overflow: "visible" }} // Prevent clipping
+		>
+			<Panel defaultSize={100} minSize={25} style={{ overflow: "visible" }}>
+				{children}
+			</Panel>
+
+			<PanelResizeHandle
+				id={resizerId}
+				hitAreaMargins={{ fine: 0, coarse: 8 }}
+				className={styles.resizeHandle}
+				aria-label={label}
+			>
+				<Icon href={svgDragHandleVertical} />
+			</PanelResizeHandle>
+
+			<Panel defaultSize={0} minSize={0} aria-hidden="true" />
+		</PanelGroup>
 	);
 }
 

--- a/apps/test-app/app/~examples.tsx
+++ b/apps/test-app/app/~examples.tsx
@@ -117,9 +117,9 @@ function Resizable(props: ResizableProps) {
 		<PanelGroup
 			direction="horizontal"
 			keyboardResizeBy={5}
-			style={{ overflow: "visible" }} // Prevent clipping
+			style={{ overflow: "auto" }}
 		>
-			<Panel defaultSize={100} minSize={25} style={{ overflow: "visible" }}>
+			<Panel defaultSize={100} minSize={25} style={{ overflow: "auto" }}>
 				{children}
 			</Panel>
 


### PR DESCRIPTION
### Changes

This adds a resizer to all the component examples on the `/mui` page.

The implementation is contained to a private `Resizable` component, which simply wraps the content that is being resized. It uses [`react-resizable-panels`](https://github.com/bvaughn/react-resizable-panels) v3, which is already used in the `/sandbox` page as well. This is admittedly not the best library for this use case, since there are no "panels" being split, but it's very simple to use and works for now.

The resizer is keyboard accessible and its role is overridden from `"separator"` to `"slider"`. On touch devices, its hit target is increased from 24px to 40px.

To prevent the toolbar and target outline from getting clipped, [anchor positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning) is being used.

One thing to note: the resizer comes _after_ the content in the source (and tab) order, which may not be ideal.

### Testing

Visit the [**`/mui`** page](https://stratakit.bentley.com/1609/mui) on various browsers/devices, and test with different input modalities.

Demo:

https://github.com/user-attachments/assets/4050c81a-e8e7-41c6-8a45-fbf394144c61

