### PR TITLE
fix `RadioGroup` error example

### DIFF
--- a/examples/mui/RadioGroup.error.tsx
+++ b/examples/mui/RadioGroup.error.tsx
@@ -15,9 +15,14 @@ import visuallyHidden from "@mui/utils/visuallyHidden";
 export default () => {
 	const errorId = React.useId();
 	return (
-		<FormControl render={<fieldset />} role="radiogroup" error>
+		<FormControl
+			render={<fieldset />}
+			role="radiogroup"
+			error
+			aria-describedby={errorId}
+		>
 			<FormLabel render={<legend />}>Gender</FormLabel>
-			<RadioGroup aria-describedby={errorId} name="gender" role={undefined}>
+			<RadioGroup name="gender" role={undefined}>
 				<FormControlLabel value="female" control={<Radio />} label="Female" />
 				<FormControlLabel value="male" control={<Radio />} label="Male" />
 				<FormControlLabel value="other" control={<Radio />} label="Other" />


### PR DESCRIPTION
### Changes

Updates the `RadioGroup.error` example to set `aria-describedby` on the `<fieldset>` element which has `role="radiogroup"`, instead of the `RadioGroup` element which has `role={undefined}`.

> [!IMPORTANT]
> This is just fixing a small error (no pun intended) in the place where the description is set. There are likely larger changes needed to this and other `<fieldset>` examples, to ensure that the description is more reliably exposed (see testing notes below).

### Testing

Confirmed that the Description is correctly associated in the accessibility tree:

<img width="356" height="343" alt="screenshot of chrome devtools" src="https://github.com/user-attachments/assets/ba66cb82-6729-4f81-9651-0aa48c6197f9" />

However, when testing with screen readers, the description was **not** automatically announced when the virtual cursor is on the radiogroup. Both VoiceOver and NVDA only announce the group name, requiring the user to manually navigate past all the radio buttons to find the error message.