### PR TITLE
`Switch` prop deprecation

### DIFF
--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -1,5 +1,5 @@
 ---
-"@stratakit/mui": patch
+"@stratakit/mui": minor
 ---
 
 `Switch` component props `checkedIcon`, `disableRipple`, and `icon` have been deprecated.

--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -1,5 +1,5 @@
 ---
-"@stratakit/mui": minor
+"@stratakit/mui": patch
 ---
 
-`<Switch>` does not support the `checkedIcon`, `disableRipple`, and `icon` prop.
+`<Switch>` props `checkedIcon`, `disableRipple`, and `icon` have been deprecated.

--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-`<Switch>` props `checkedIcon`, `disableRipple`, and `icon` have been deprecated.
+`Switch` component props `checkedIcon`, `disableRipple`, and `icon` have been deprecated.

--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, and `icon` props of `Switch`.
+Deprecated `action`, `centerRipple`, `checkedIcon`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `LinkComponent`, `TouchRippleProps`, and `touchRippleRef` props of `Switch`.

--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+`<Switch>` does not support the `checkedIcon`, `disableRipple`, and `icon` prop.

--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-`Switch` component props `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, and `icon` have been deprecated.
+Deprecated `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, and `icon` props of `Switch`.

--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-`Switch` component props `checkedIcon`, `disableRipple`, and `icon` have been deprecated.
+`Switch` component props `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, and `icon` have been deprecated.

--- a/apps/website/src/content/docs/components/mui/Switch.md
+++ b/apps/website/src/content/docs/components/mui/Switch.md
@@ -22,7 +22,8 @@ Make sure the **Switch** is suitable for your use case. There may be other, more
 ## StrataKit MUI modifications
 
 - The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled).
-- The `checkedIcon`, `disableRipple`, and `icon` props are not supported.
+- The `action`, `checkedIcon`, `icon`, and `LinkComponent` props are not supported.
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
 

--- a/apps/website/src/content/docs/components/mui/Switch.md
+++ b/apps/website/src/content/docs/components/mui/Switch.md
@@ -22,6 +22,7 @@ Make sure the **Switch** is suitable for your use case. There may be other, more
 ## StrataKit MUI modifications
 
 - The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled).
+- The `checkedIcon`, `disableRipple`, and `icon` props are deprecated and should not be used.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
 

--- a/apps/website/src/content/docs/components/mui/Switch.md
+++ b/apps/website/src/content/docs/components/mui/Switch.md
@@ -22,7 +22,7 @@ Make sure the **Switch** is suitable for your use case. There may be other, more
 ## StrataKit MUI modifications
 
 - The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled).
-- The `checkedIcon`, `disableRipple`, and `icon` props are deprecated and should not be used.
+- The `checkedIcon`, `disableRipple`, and `icon` props are not supported.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -20,6 +20,7 @@ import type {
 } from "@mui/material/OverridableComponent";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
+import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";
@@ -438,6 +439,11 @@ declare module "@mui/material/Icon" {
 	export default function Icon(props: IconProps): React.JSX.Element | null;
 }
 
+interface IconButtonDeprecatedProps extends ButtonBaseDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	disableFocusRipple?: IconButtonProps["disableFocusRipple"];
+}
+
 declare module "@mui/material/IconButton" {
 	interface IconButtonPropsColorOverrides {
 		default: false;
@@ -583,7 +589,7 @@ declare module "@mui/material/SvgIcon" {
 }
 
 declare module "@mui/material/Switch" {
-	interface SwitchProps {
+	interface SwitchProps extends SwitchDeprecatedProps {
 		/** @deprecated StrataKit does not support this prop. */
 		checkedIcon?: SwitchProps["checkedIcon"];
 
@@ -591,13 +597,7 @@ declare module "@mui/material/Switch" {
 		color?: SwitchProps["color"];
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
-		disableFocusRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
-		disableTouchRipple?: boolean;
+		disableFocusRipple?: IconButtonProps["disableFocusRipple"];
 
 		/** @deprecated StrataKit does not support this prop. */
 		icon?: SwitchProps["icon"];
@@ -611,6 +611,25 @@ declare module "@mui/material/Switch" {
 		warning: false;
 		error: false;
 	}
+
+	export default function Switch(
+		props: Omit<SwitchProps, keyof SwitchDeprecatedProps> &
+			SwitchDeprecatedProps,
+	): React.JSX.Element;
+}
+
+interface SwitchDeprecatedProps extends IconButtonDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	checkedIcon?: SwitchProps["checkedIcon"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	color?: SwitchProps["color"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableFocusRipple?: IconButtonProps["disableFocusRipple"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	icon?: SwitchProps["icon"];
 }
 
 declare module "@mui/material/StepButton" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -593,7 +593,7 @@ declare module "@mui/material/Switch" {
 		error: false;
 	}
 
-	interface SwitchOwnProps {
+	interface SwitchProps {
 		/** @deprecated DO NOT USE. */
 		checkedIcon?: SwitchProps["checkedIcon"];
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -600,6 +600,12 @@ declare module "@mui/material/Switch" {
 		disableRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableTouchRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
 		icon?: SwitchProps["icon"];
 	}
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -602,6 +602,15 @@ declare module "@mui/material/Switch" {
 		/** @deprecated StrataKit does not support this prop. */
 		icon?: SwitchProps["icon"];
 	}
+
+	interface SwitchPropsColorOverrides {
+		secondary: false;
+		default: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
 }
 
 declare module "@mui/material/StepButton" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -20,6 +20,7 @@ import type {
 } from "@mui/material/OverridableComponent";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
+import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";
@@ -590,6 +591,17 @@ declare module "@mui/material/Switch" {
 		success: false;
 		warning: false;
 		error: false;
+	}
+
+	interface SwitchOwnProps {
+		/** @deprecated DO NOT USE. */
+		checkedIcon?: SwitchProps["checkedIcon"];
+
+		/** @deprecated DO NOT USE. */
+		disableRipple?: SwitchProps["disableRipple"];
+
+		/** @deprecated DO NOT USE. */
+		icon?: SwitchProps["icon"];
 	}
 }
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -583,18 +583,12 @@ declare module "@mui/material/SvgIcon" {
 }
 
 declare module "@mui/material/Switch" {
-	interface SwitchPropsColorOverrides {
-		secondary: false;
-		default: false;
-		info: false;
-		success: false;
-		warning: false;
-		error: false;
-	}
-
 	interface SwitchProps {
 		/** @deprecated StrataKit does not support this prop. */
 		checkedIcon?: SwitchProps["checkedIcon"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		color?: SwitchProps["color"];
 
 		/** @deprecated StrataKit does not support this prop. */
 		disableRipple?: boolean;

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -598,7 +598,7 @@ declare module "@mui/material/Switch" {
 		checkedIcon?: SwitchProps["checkedIcon"];
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: SwitchProps["disableRipple"];
+		disableRipple?: boolean | undefined;
 
 		/** @deprecated StrataKit does not support this prop. */
 		icon?: SwitchProps["icon"];

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -594,13 +594,13 @@ declare module "@mui/material/Switch" {
 	}
 
 	interface SwitchProps {
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		checkedIcon?: SwitchProps["checkedIcon"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		disableRipple?: SwitchProps["disableRipple"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		icon?: SwitchProps["icon"];
 	}
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -598,7 +598,7 @@ declare module "@mui/material/Switch" {
 		checkedIcon?: SwitchProps["checkedIcon"];
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: boolean | undefined;
+		disableRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
 		icon?: SwitchProps["icon"];

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -20,7 +20,6 @@ import type {
 } from "@mui/material/OverridableComponent";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
-import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17425316.

- `action`
- `centerRipple`
- `checkedIcon`
- `color`
- `disableFocusRipple`
- `disableRipple`
- `disableTouchRipple`
- `focusRipple`
- `icon`
- `LinkComponent`
- `TouchRippleProps`
- `touchRippleRef` 

### Testing

- Confirmed wanted props remaining (`edge` & `required`) do functionally work, may want refinement.
- Confirmed deprecated props when applied have a strikethrough in VSCode. 
<img width="280" height="308" alt="Screenshot 2026-08-18 at 11 18 48 AM" src="https://github.com/user-attachments/assets/23f812df-e8bd-4196-a5c3-7ab6b82500fc" />