### PR TITLE
Fix `<Slider>` when `track="inverted"`

### DIFF
--- a/.changeset/flat-steaks-retire.md
+++ b/.changeset/flat-steaks-retire.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed `<Slider>` when `track` prop is set to `"inverted"`.

--- a/apps/test-app/app/mui/Slider.showcase.tsx
+++ b/apps/test-app/app/mui/Slider.showcase.tsx
@@ -29,6 +29,9 @@ export const knobs = {
 			MuiFormControl: {
 				disabled: true,
 			},
+			MuiSlider: {
+				disabled: true,
+			},
 		},
 	}),
 };

--- a/packages/mui/src/~components/MuiSlider.css
+++ b/packages/mui/src/~components/MuiSlider.css
@@ -7,11 +7,11 @@
 	--✨color-rail-bg--default: var(--stratakit-color-bg-control-slider-track);
 	--✨color-rail-bg--disabled: var(--stratakit-color-bg-control-switch);
 	--✨color-rail-border--default: var(--stratakit-color-bg-control-slider-track);
-	--✨color-rail-border--disabled: var(--stratakit-color-border-glow-on-surface-disabled);
+	--✨color-rail-border--disabled: var(--stratakit-color-border-neutral-disabled);
 	--✨color-track-bg--default: var(--stratakit-color-bg-accent-base);
-	--✨color-track-bg--disabled: var(--stratakit-color-border-glow-on-surface-disabled);
+	--✨color-track-bg--disabled: var(--stratakit-color-border-neutral-disabled);
 	--✨color-track-border--default: var(--stratakit-color-bg-accent-base);
-	--✨color-track-border--disabled: var(--stratakit-color-border-glow-on-surface-disabled);
+	--✨color-track-border--disabled: var(--stratakit-color-border-neutral-disabled);
 	--✨size-thumb--small: 0.875rem;
 	--✨size-thumb--medium: 1rem;
 	--✨size-track--small: 0.125rem;

--- a/packages/mui/src/~components/MuiSlider.css
+++ b/packages/mui/src/~components/MuiSlider.css
@@ -89,6 +89,11 @@
 	border: 1px solid var(--_MuiSlider-rail-border-color);
 	opacity: 1;
 
+	:where(.MuiSlider-root.MuiSlider-trackInverted) & {
+		background-color: var(--_MuiSlider-track-background-color);
+		border-color: var(--_MuiSlider-track-border-color);
+	}
+
 	@media (prefers-reduced-motion: no-preference) {
 		:where(.MuiSlider-root:not(.MuiSlider-vertical)) & {
 			transition: block-size 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
@@ -103,6 +108,11 @@
 .MuiSlider-track {
 	background-color: var(--_MuiSlider-track-background-color);
 	border: 1px solid var(--_MuiSlider-track-border-color);
+
+	:where(.MuiSlider-root.MuiSlider-trackInverted) & {
+		background-color: var(--_MuiSlider-rail-background-color);
+		border-color: var(--_MuiSlider-rail-border-color);
+	}
 }
 
 .MuiSlider-thumb {


### PR DESCRIPTION
### Changes

While validating [`<Slider>` props](https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17425229) I discovered that `track="inverted"` was not working.

| Before | After |
| -- | -- |
| <img width="660" height="360" alt="Screenshot 2026-07-08 at 12 46 56 PM" src="https://github.com/user-attachments/assets/99575229-e0de-4a50-8915-fc9019b904f2" /> | <img width="660" height="360" alt="Screenshot 2026-07-08 at 12 46 45 PM" src="https://github.com/user-attachments/assets/8f9e8213-b783-446b-a653-c5119c576f8d" /> |

Also fixed showcase disabled knob.

| Before | After |
| -- | -- |
| <img width="874" height="490" alt="Screenshot 2026-07-08 at 12 48 30 PM" src="https://github.com/user-attachments/assets/c43d93ef-389a-4a68-afcb-edfc9e8b0ea6" /> | <img width="874" height="490" alt="Screenshot 2026-07-08 at 12 48 45 PM" src="https://github.com/user-attachments/assets/e66e1836-06c7-497c-aba7-7d069b36e0e8" /> |

### Testing

- Confirmed `track="inverted"` is working for regular slider, range slider.
- Confirmed working in light, dark, forced-colors, disabled.