### PR TITLE
Fix bug with role prop being ignored.

### DIFF
--- a/.changeset/perky-planes-throw.md
+++ b/.changeset/perky-planes-throw.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Fix bug preventing the `role` prop on `Alert` from being applied.

--- a/apps/test-app/app/mui/Alert.showcase.tsx
+++ b/apps/test-app/app/mui/Alert.showcase.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import Stack from "@mui/material/Stack";
 import AlertPermutations_ from "examples/mui/Alert._permutations.tsx";
+import AlertRole from "examples/mui/Alert._role.tsx";
 import AlertClose from "examples/mui/Alert.close.tsx";
 import AlertDefault from "examples/mui/Alert.default.tsx";
 import { isProduction } from "~/~utils.tsx";
@@ -14,6 +15,7 @@ export default function AlertExamples() {
 			<AlertDefault />
 			<AlertClose />
 			{!isProduction && <AlertPermutations_ />}
+			{!isProduction && <AlertRole />}
 		</Stack>
 	);
 }

--- a/examples/mui/Alert._role.tsx
+++ b/examples/mui/Alert._role.tsx
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+
+export default () => {
+	return (
+		<Alert severity="error" role="alert">
+			<AlertTitle>Invalid credit card</AlertTitle>
+			Your bank has declined the charge to your card. Please check the card
+			number or contact your bank.
+		</Alert>
+	);
+};

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -165,6 +165,7 @@ function createTheme(args: CreateThemeArgs) {
 					component: MuiAlert,
 					variant: "outlined",
 					severity: "none",
+					role: "group", // Overriding role="alert".
 					iconMapping: {
 						error: <ErrorIcon />,
 						info: <InfoIcon />,
@@ -172,9 +173,6 @@ function createTheme(args: CreateThemeArgs) {
 						warning: <WarningIcon />,
 					},
 					slotProps: {
-						root: {
-							role: "group", // Overriding role="alert".
-						},
 						closeButton: {
 							edge: "end",
 						},


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Fixes a bug that prevented consumers from using the [`role` prop on alert](https://mui.com/material-ui/api/alert/#props) to override the default role of group.

https://github.com/iTwin/stratakit/pull/1388 changed the default by overriding the `slotProps.root.role` which took precdene over the `role` prop.  If a conusmer did set `role=alert` it was ignored.  Changing to setting the default role prop value now allows consumers to use either `role` or `slotProps.root.role` to control the value of the role.

### Testing


Make sure the other alerts still have `role=group`.  Make sure the last alert about the credit card has `role=alert`.  Test this in dev since I didn't want to add an assertive alert to our live site.
