### PR TITLE
clean up `Rating` CSS

### DIFF
--- a/examples/mui/Rating.precision.tsx
+++ b/examples/mui/Rating.precision.tsx
@@ -11,7 +11,7 @@ export default () => {
 	return (
 		<FormControl render={<fieldset />} role="radiogroup">
 			<FormLabel render={<legend />}>Precision rating:</FormLabel>
-			<Rating name="product-rating" defaultValue={2.5} precision={0.5} />
+			<Rating name="precision-rating" defaultValue={2.5} precision={0.5} />
 		</FormControl>
 	);
 };

--- a/packages/mui/src/~components/MuiRating.css
+++ b/packages/mui/src/~components/MuiRating.css
@@ -6,42 +6,38 @@
 	--_MuiRating-icon-color: var(--stratakit-color-icon-neutral-base);
 	inline-size: fit-content;
 	border-radius: var(--stratakit-mui-shape-borderRadius);
+	color: var(--_MuiRating-icon-color);
+
+	&:where(:has(.MuiRating-icon.MuiRating-iconHover)) {
+		--_MuiRating-icon-color: var(--stratakit-color-icon-neutral-primary);
+	}
 
 	&:where(.Mui-disabled) {
 		--_MuiRating-icon-color: var(--stratakit-color-icon-neutral-disabled);
 		opacity: 1;
 	}
 
-	&.Mui-focusVisible {
+	&:where(.Mui-focusVisible) {
 		outline: var(--🥝focus-outline);
 		outline-offset: var(--🥝focus-outline-offset);
 	}
 }
 
 .MuiRating-icon {
-	color: var(--_MuiRating-icon-color);
-
-	&:where(.MuiRating-iconHover, .MuiRating-iconFocus, .MuiRating-iconActive) {
-		--_MuiRating-icon-color: var(--stratakit-color-icon-neutral-primary);
-		outline: 0;
-	}
+	outline: 0; /* Remove focus outline from individual icons. */
 }
 
-/*	When using a non-integer precision value the MuiIcon gets wrapped in element
-		with an MuiDecimal class. However the MuiRating-iconActive class is still
-		applied to the MuiDecimal element instead of the MuiRating-icon element.
-		The other classes still apply to the MuiRating-icon element, so only the
-		MuiRating-iconActive rule is duplicated here */
-.MuiRating-decimal:where(.MuiRating-iconActive) {
-	--_MuiRating-icon-color: var(--stratakit-color-icon-neutral-primary);
+.MuiRating-decimal {
+	/* When using a non-integer precision value, the MuiIcon gets wrapped in the MuiDecimal element,
+     which brings its own focus outline that needs to be removed separately. */
 	outline: 0;
 }
 
 :where(.MuiRating-decimal) .MuiSvgIcon-root {
 	/* 
-		reset css sets max-inline-size to 100%, however the Rating component + precision
+		reset.css sets max-inline-size to 100%, however the Rating component + precision
 		prop relies on the svg size being greater than than the width of the
-		container and getting clipped.  Unset it here to allow the icon to overflow and clip.
+		container and getting clipped. Unset it here to allow the icon to overflow and clip.
 		*/
 	max-inline-size: unset;
 }


### PR DESCRIPTION
### Changes

_Follow-up to #1589 (and #1557)_

`Rating` CSS changes:

- Moved the icon color from `Rating-icon` to `Rating-root`, which is where it's originally set (and inherited).
- Undid extra grouping of hover and focus styles, and moved `outline: 0` out of modifiers for simplicity.
- Removed extra color declaration under `Rating-decimal`.
- Flattened specificity for focus block.

Example changes:
- Fixed `name` in `Rating.precision` example to prevent collision with `Rating.default`.

### Testing

Tested hover and focus interactions using mouse and keyboard.
- Visuals unchanged.
- No extra outline appears for `Rating.precision`.