### PR TITLE
Adjust Divider for toolbars

### DIFF
--- a/.changeset/fuzzy-items-bake.md
+++ b/.changeset/fuzzy-items-bake.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Change `Divider` middle variant to work in toolbars

--- a/apps/test-app/app/mui/Divider.showcase.tsx
+++ b/apps/test-app/app/mui/Divider.showcase.tsx
@@ -6,6 +6,7 @@ import Stack from "@mui/material/Stack";
 import DividerDefault from "examples/mui/Divider.default.tsx";
 import DividerMargin from "examples/mui/Divider.margin.tsx";
 import DividerPresentational from "examples/mui/Divider.presentational.tsx";
+import DividerVariant from "examples/mui/Divider.variant.tsx";
 import DividerVertical from "examples/mui/Divider.vertical.tsx";
 
 export default function DividerExamples() {
@@ -17,6 +18,7 @@ export default function DividerExamples() {
 			<DividerVertical />
 			<DividerPresentational />
 			<DividerMargin />
+			<DividerVariant />
 		</>
 	);
 }

--- a/apps/website/src/content/docs/components/mui/Divider.md
+++ b/apps/website/src/content/docs/components/mui/Divider.md
@@ -58,7 +58,7 @@ The `margin` prop can be set to include some space before and after the **Divide
 
 ### Variant
 
-The variant can control how much of the container the **Divider** spans. The default is `fullWidth`. Use `middle` in toolbars.
+The variant can control how much of the container the **Divider** spans. The default is `fullWidth`. `middle` will leave space on either side of the **Divider**.
 
 ::example{src="mui/Divider.variant"}
 

--- a/apps/website/src/content/docs/components/mui/Divider.md
+++ b/apps/website/src/content/docs/components/mui/Divider.md
@@ -58,7 +58,7 @@ The `margin` prop can be set to include some space before and after the **Divide
 
 ### Variant
 
-The variant can control how much of the container the **Divider** spans. The default is `fullWidth`. `middle` will leave space on either side of the **Divider**.
+The variant can control how much of the container the **Divider** spans. The default is `"fullWidth"`.
 
 ::example{src="mui/Divider.variant"}
 

--- a/apps/website/src/content/docs/components/mui/Divider.md
+++ b/apps/website/src/content/docs/components/mui/Divider.md
@@ -56,6 +56,12 @@ The `margin` prop can be set to include some space before and after the **Divide
 
 ::example{src="mui/Divider.margin"}
 
+### Variant
+
+The variant can control how much of the container the **Divider** spans. The default is `fullWidth`. Use `middle` in toolbars.
+
+::example{src="mui/Divider.variant"}
+
 ## ✅ Do
 
 - Use the **Divider** to break up flow content.

--- a/examples/mui/Divider.variant.tsx
+++ b/examples/mui/Divider.variant.tsx
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import Divider from "@mui/material/Divider";
+import Typography from "@mui/material/Typography";
+
+export default () => {
+	return (
+		<div>
+			<Typography>
+				A full-width divider spans the entire available width of its container,
+				creating a strong visual separation between sections of content.
+			</Typography>
+			<Divider margin />
+			<Typography gutterBottom>
+				A center-aligned divider that occupies 50% of the available width
+				provides a more subtle visual break. By leaving equal whitespace on both
+				sides, it draws less attention than a full-width divider and can be used
+				to separate related content while preserving a lighter, more balanced
+				appearance.
+			</Typography>
+			<Divider variant="middle" margin />
+			<Typography gutterBottom>
+				An inset divider is offset from the leading edge of its container so it
+				aligns with the content rather than spanning the full width. In Material
+				UI, this variant is commonly used in lists to align the divider with
+				list text while leaving space for icons, avatars, or other leading
+				elements.
+			</Typography>
+			<Divider variant="inset" margin />
+		</div>
+	);
+};

--- a/examples/mui/Divider.variant.tsx
+++ b/examples/mui/Divider.variant.tsx
@@ -15,11 +15,9 @@ export default () => {
 			</Typography>
 			<Divider margin />
 			<Typography gutterBottom>
-				A center-aligned divider that occupies 50% of the available width
-				provides a more subtle visual break. By leaving equal whitespace on both
-				sides, it draws less attention than a full-width divider and can be used
-				to separate related content while preserving a lighter, more balanced
-				appearance.
+				A middle divider provides a space between the edge of the container and
+				the start of the divider. This keeps the divider visually distinct from
+				any container borders.
 			</Typography>
 			<Divider variant="middle" margin />
 			<Typography gutterBottom>

--- a/examples/mui/Divider.variant.tsx
+++ b/examples/mui/Divider.variant.tsx
@@ -16,16 +16,15 @@ export default () => {
 			<Divider margin />
 			<Typography gutterBottom>
 				A middle divider provides a space between the edge of the container and
-				the start of the divider. This keeps the divider visually distinct from
+				the ends of the divider. This keeps the divider visually distinct from
 				any container borders.
 			</Typography>
 			<Divider variant="middle" margin />
 			<Typography gutterBottom>
 				An inset divider is offset from the leading edge of its container so it
-				aligns with the content rather than spanning the full width. In Material
-				UI, this variant is commonly used in lists to align the divider with
-				list text while leaving space for icons, avatars, or other leading
-				elements.
+				aligns with the content rather than spanning the full width. In MUI,
+				this variant is commonly used in lists to align the divider with list
+				text while leaving space for icons, avatars, or other leading elements.
 			</Typography>
 			<Divider variant="inset" margin />
 		</div>

--- a/examples/structures/Toolbar.divider.tsx
+++ b/examples/structures/Toolbar.divider.tsx
@@ -30,7 +30,7 @@ export default () => {
 					</IconButton>
 				}
 			/>
-			<Divider orientation="vertical" flexItem margin />
+			<Divider orientation="vertical" flexItem margin variant="middle" />
 			<Toolbar.Item
 				render={
 					<IconButton label="Save">

--- a/examples/structures/Toolbar.vertical.tsx
+++ b/examples/structures/Toolbar.vertical.tsx
@@ -30,7 +30,7 @@ export default () => {
 					</IconButton>
 				}
 			/>
-			<Divider flexItem margin />
+			<Divider flexItem margin variant="middle" />
 			<Toolbar.Item
 				render={
 					<IconButton label="Save" labelPlacement="right">

--- a/packages/mui/src/~components/MuiDivider.css
+++ b/packages/mui/src/~components/MuiDivider.css
@@ -9,14 +9,42 @@
 			margin-block-end: var(--stratakit-space-x1);
 		}
 
-		&:where([data-_sk-middle]) {
+		&:where(.MuiDivider-middle) {
 			margin-inline-start: 25%;
 			margin-inline-end: 25%;
 		}
 	}
 
-	&:where(.MuiDivider-vertical[data-_sk-margin]) {
-		margin-inline-start: var(--stratakit-space-x1);
-		margin-inline-end: var(--stratakit-space-x1);
+	&:where(.MuiDivider-vertical) {
+		&:where([data-_sk-margin]) {
+			margin-inline-start: var(--stratakit-space-x1);
+			margin-inline-end: var(--stratakit-space-x1);
+		}
+
+		&:where(.MuiDivider-middle) {
+			/** 
+				CSS computes the margin percentage values based on the containing block
+				width so margin-block-start: 25% will not work.  See
+				https://drafts.csswg.org/css-box-3/#margin-physical.  
+				Instead of trying to set a percentage top/bottom margin, use an
+				absolutely positioned pseudo element with top/bottom set to get the same effect.
+			*/
+			position: relative;
+			margin-block: 0;
+			/** 
+				Reserve space for the child element's border. Otherwise the width is 0
+			 	and the child pseudo element ends up drawing its border in the margin
+			*/
+			border-inline-end: thin solid transparent;
+
+			&::after {
+				position: absolute;
+				content: "";
+				display: block;
+				border-inline-end: thin solid var(--stratakit-mui-palette-divider);
+				top: 25%;
+				bottom: 25%;
+			}
+		}
 	}
 }

--- a/packages/mui/src/~components/MuiDivider.css
+++ b/packages/mui/src/~components/MuiDivider.css
@@ -3,9 +3,16 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .MuiDivider-root {
-	&:where(:not(.MuiDivider-vertical)[data-_sk-margin]) {
-		margin-block-start: var(--stratakit-space-x1);
-		margin-block-end: var(--stratakit-space-x1);
+	&:where(:not(.MuiDivider-vertical)) {
+		&:where([data-_sk-margin]) {
+			margin-block-start: var(--stratakit-space-x1);
+			margin-block-end: var(--stratakit-space-x1);
+		}
+
+		&:where([data-_sk-middle]) {
+			margin-inline-start: 25%;
+			margin-inline-end: 25%;
+		}
 	}
 
 	&:where(.MuiDivider-vertical[data-_sk-margin]) {

--- a/packages/mui/src/~components/MuiDivider.css
+++ b/packages/mui/src/~components/MuiDivider.css
@@ -10,8 +10,8 @@
 		}
 
 		&:where(.MuiDivider-middle) {
-			margin-inline-start: 25%;
-			margin-inline-end: 25%;
+			margin-inline-start: var(--stratakit-space-x2);
+			margin-inline-end: var(--stratakit-space-x2);
 		}
 	}
 
@@ -22,29 +22,8 @@
 		}
 
 		&:where(.MuiDivider-middle) {
-			/** 
-				CSS computes the margin percentage values based on the containing block
-				width so margin-block-start: 25% will not work.  See
-				https://drafts.csswg.org/css-box-3/#margin-physical.  
-				Instead of trying to set a percentage top/bottom margin, use an
-				absolutely positioned pseudo element with top/bottom set to get the same effect.
-			*/
-			position: relative;
-			margin-block: 0;
-			/** 
-				Reserve space for the child element's border. Otherwise the width is 0
-			 	and the child pseudo element ends up drawing its border in the margin
-			*/
-			border-inline-end: thin solid transparent;
-
-			&::after {
-				position: absolute;
-				content: "";
-				display: block;
-				border-inline-end: thin solid var(--stratakit-mui-palette-divider);
-				top: 25%;
-				bottom: 25%;
-			}
+			margin-block-start: var(--stratakit-space-x2);
+			margin-block-end: var(--stratakit-space-x2);
 		}
 	}
 }

--- a/packages/mui/src/~components/MuiDivider.tsx
+++ b/packages/mui/src/~components/MuiDivider.tsx
@@ -16,8 +16,7 @@ interface MuiDividerProps
 		Pick<DividerOwnProps, "children" | "margin" | "variant"> {}
 
 const MuiDivider = forwardRef<"hr", MuiDividerProps>((props, forwardedRef) => {
-	const { children, margin, className, ...rest } = props;
-	const middle = className?.split(/\s+/).includes("MuiDivider-middle");
+	const { children, margin, ...rest } = props;
 	const defaultRender = (() => {
 		if (
 			children ||
@@ -32,9 +31,7 @@ const MuiDivider = forwardRef<"hr", MuiDividerProps>((props, forwardedRef) => {
 		<Role
 			render={defaultRender}
 			data-_sk-margin={margin ? "" : undefined}
-			data-_sk-middle={middle ? "" : undefined}
 			{...rest}
-			className={className}
 			ref={forwardedRef}
 		>
 			{children}

--- a/packages/mui/src/~components/MuiDivider.tsx
+++ b/packages/mui/src/~components/MuiDivider.tsx
@@ -13,11 +13,11 @@ import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
 interface MuiDividerProps
 	extends BaseProps<"hr">,
-		Pick<DividerOwnProps, "children" | "margin"> {}
+		Pick<DividerOwnProps, "children" | "margin" | "variant"> {}
 
 const MuiDivider = forwardRef<"hr", MuiDividerProps>((props, forwardedRef) => {
-	const { children, margin, ...rest } = props;
-
+	const { children, margin, className, ...rest } = props;
+	const middle = className?.split(/\s+/).includes("MuiDivider-middle");
 	const defaultRender = (() => {
 		if (
 			children ||
@@ -32,7 +32,9 @@ const MuiDivider = forwardRef<"hr", MuiDividerProps>((props, forwardedRef) => {
 		<Role
 			render={defaultRender}
 			data-_sk-margin={margin ? "" : undefined}
+			data-_sk-middle={middle ? "" : undefined}
 			{...rest}
+			className={className}
 			ref={forwardedRef}
 		>
 			{children}

--- a/packages/mui/src/~components/MuiDivider.tsx
+++ b/packages/mui/src/~components/MuiDivider.tsx
@@ -13,10 +13,11 @@ import type { BaseProps } from "@stratakit/foundations/secret-internals";
 
 interface MuiDividerProps
 	extends BaseProps<"hr">,
-		Pick<DividerOwnProps, "children" | "margin" | "variant"> {}
+		Pick<DividerOwnProps, "children" | "margin"> {}
 
 const MuiDivider = forwardRef<"hr", MuiDividerProps>((props, forwardedRef) => {
 	const { children, margin, ...rest } = props;
+
 	const defaultRender = (() => {
 		if (
 			children ||


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Fixes https://github.com/iTwin/stratakit/issues/1620 by making `variant="middle"` use only 8px instead of 16px  margins.  This allows it to work in toolbars that only have 32 px of space.

Also adds documentation about `variant`

| Before | After | 
| --- |---| 
|  <img width="185" height="441" alt="image" src="https://github.com/user-attachments/assets/b78db0b5-4a9f-419e-b2c9-c51d6a755194" /> |  <img width="220" height="453" alt="image" src="https://github.com/user-attachments/assets/b4c19f8b-8f4f-4947-992b-7d2c7a377399" />  |
| <img alt="image" src="https://github.com/user-attachments/assets/e458ab76-c53b-4a16-9924-70bc6be4b4dd" />|<img  alt="image" src="https://github.com/user-attachments/assets/369170e3-317c-4feb-aa68-6e6bcf479d7d" />| 

### Testing

View the [toolbar docs](https://stratakit.bentley.com/1622/docs/components/toolbar/#orientation).  Make sure the divider in the toolbar is visible, and does not take up the same width as the icon.

Review the [new variant section in the Divider documentation](https://stratakit.bentley.com/1622/docs/components/divider/#variant).
