### PR TITLE
Typing for MUI-X date picker theme

### DIFF
--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -61,6 +61,7 @@
 	"devDependencies": {
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",
+		"@mui/x-date-pickers": "catalog:",
 		"esbuild": "catalog:",
 		"react": "catalog:",
 		"react-dom": "catalog:",

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -67,6 +67,7 @@ import {
 
 import type { RoleProps } from "@ariakit/react/role";
 import type { ColorSystemOptions } from "@mui/material/styles";
+import type {} from "@mui/x-date-pickers/themeAugmentation";
 
 interface CreateThemeArgs {
 	portalContainer?: HTMLElement | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.7)
     devDependencies:
+      "@mui/x-date-pickers":
+        specifier: "catalog:"
+        version: 9.6.0(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.0.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@types/react":
         specifier: "catalog:"
         version: 19.2.16
@@ -2526,6 +2529,12 @@ packages:
     resolution:
       {
         integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==,
+      }
+
+  "@stratakit/icons@0.4.1":
+    resolution:
+      {
+        integrity: sha512-IWCfOjdvtFMaNmb1itx1mTRZORw4bHuzrHnCg2NXQMxGLwaT6lnl4mDGKV1waBTuu7mNy2kQ1//d2GSqgb9umQ==,
       }
 
   "@tanstack/query-core@5.97.0":
@@ -7044,6 +7053,8 @@ snapshots:
       "@types/hast": 3.0.4
 
   "@shikijs/vscode-textmate@10.0.2": {}
+
+  "@stratakit/icons@0.4.1": {}
 
   "@tanstack/query-core@5.97.0": {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2531,12 +2531,6 @@ packages:
         integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==,
       }
 
-  "@stratakit/icons@0.4.1":
-    resolution:
-      {
-        integrity: sha512-IWCfOjdvtFMaNmb1itx1mTRZORw4bHuzrHnCg2NXQMxGLwaT6lnl4mDGKV1waBTuu7mNy2kQ1//d2GSqgb9umQ==,
-      }
-
   "@tanstack/query-core@5.97.0":
     resolution:
       {
@@ -7053,8 +7047,6 @@ snapshots:
       "@types/hast": 3.0.4
 
   "@shikijs/vscode-textmate@10.0.2": {}
-
-  "@stratakit/icons@0.4.1": {}
 
   "@tanstack/query-core@5.97.0": {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Adds types needed for using the date picker components as  `createTheme`.  This typing is only used in internal files and not exported so it should not be present in the compiled distribution.

This adds `@mui/x-date-pickers` as a dev dependency only to `stratakit/mui` to avoid having consumers install it.  [Optional peer dependencies are still installed by default.](https://github.com/npm/feedback/discussions/225). 


~~**Note** this merges in to https://github.com/iTwin/stratakit/pull/1586 so not sure if we want that PR to be merged first or not~~

### Testing

- Open packages/mui/src/~createTheme.tsx and make sure there are no type errors
- Run `pnpm run build` .  Inspect the contents of the `packages/mui/dist` and make sure there are no references to `@mui/x-date-pickers`.

<img width="436" height="221" alt="image" src="https://github.com/user-attachments/assets/44afb396-004b-4482-bb1c-f461f3d13ddb" />


