### PR TITLE
Allow changing typography on label

### DIFF
--- a/.changeset/sweet-towns-type.md
+++ b/.changeset/sweet-towns-type.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fix bug to allow typography overrides on `FormControlLabel`

--- a/packages/mui/src/~components/MuiForm.css
+++ b/packages/mui/src/~components/MuiForm.css
@@ -20,10 +20,6 @@
 	}
 }
 
-.MuiFormControlLabel-label {
-	@apply --typography("body-md");
-}
-
 .MuiFormLabel-root {
 	&:where(legend) {
 		margin-block-end: var(--stratakit-space-x1); /* legend does not support gap */

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -348,6 +348,9 @@ function createTheme(args: CreateThemeArgs) {
 				},
 			},
 			MuiFormControl: { defaultProps: { component: Role.div } },
+			MuiFormControlLabel: {
+				defaultProps: { slotProps: { typography: { variant: "body-md" } } },
+			},
 			MuiFormHelperText: { defaultProps: { component: Role.p } },
 			MuiFormLabel: { defaultProps: { component: Role.label as never } },
 			MuiGrid: { defaultProps: { component: Role.div } },

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -349,7 +349,11 @@ function createTheme(args: CreateThemeArgs) {
 			},
 			MuiFormControl: { defaultProps: { component: Role.div } },
 			MuiFormControlLabel: {
-				defaultProps: { slotProps: { typography: { variant: "body-md" } } },
+				defaultProps: {
+					slotProps: {
+						typography: { variant: "body-md" },
+					},
+				},
 			},
 			MuiFormHelperText: { defaultProps: { component: Role.p } },
 			MuiFormLabel: { defaultProps: { component: Role.label as never } },


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Fixes https://github.com/iTwin/stratakit/issues/1634 to allow `FormControlLabel`  `slotProps.typography.variant` styling to be visible by styling with the default slotProps instead of a blanket rule against a CCS class.

The cause was that variant styling was being overriden by a style rule applied to all labels.

<img width="1055" height="284" alt="image" src="https://github.com/user-attachments/assets/0f10e708-117e-4715-9ca2-264c542f4a67" />

**Overriding typography**
| Before | After |
| --- | --- |
| <img width="134" height="105" alt="image" src="https://github.com/user-attachments/assets/15eb8e80-486d-496b-8165-143c9c03f035" /> | <img width="250" height="137" alt="image" src="https://github.com/user-attachments/assets/ea5935cd-5f7b-428b-8646-d52c5d0e7a5a" />|

**no typography set**
| Before | After |
| --- |---|
| <img width="311" height="128" alt="image" src="https://github.com/user-attachments/assets/527a0efa-7a0e-421a-a0d4-4d5ad4195bb2" /> | <img width="296" height="130" alt="image" src="https://github.com/user-attachments/assets/bee94bc6-ec65-4f61-857d-4846b43e12c6" />



### Testing

Use this JSX in the test app and make sure that the two switches have different text sizes

```tsx
		<Stack>
			<FormControl>
				<FormControlLabel
					slotProps={{ typography: { variant: "caption-sm" } }}
					control={<Switch size="small" />}
					label="Display"
					labelPlacement="top"
				/>
			</FormControl>
			<FormControl>
				<FormControlLabel
					control={<Switch size="small" />}
					label="Body"
					labelPlacement="top"
				/>
			</FormControl>
		</Stack>
```

Also check the http://localhost:1800/mui#checkbox examples to insure they are unchanged.  That was the test for the [PR where the rule was added](https://github.com/iTwin/stratakit/pull/1208)
