### PR TITLE
remove `role` from `Divider` when used with `children`

### DIFF
--- a/.changeset/fifty-zoos-agree.md
+++ b/.changeset/fifty-zoos-agree.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Removed `role="separator"` from `Divider` when `children` is passed.

--- a/apps/test-app/app/mui/Divider.showcase.tsx
+++ b/apps/test-app/app/mui/Divider.showcase.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import Stack from "@mui/material/Stack";
+import DividerChildren from "examples/mui/Divider.children.tsx";
 import DividerDefault from "examples/mui/Divider.default.tsx";
 import DividerMargin from "examples/mui/Divider.margin.tsx";
 import DividerPresentational from "examples/mui/Divider.presentational.tsx";
@@ -12,8 +13,9 @@ import DividerVertical from "examples/mui/Divider.vertical.tsx";
 export default function DividerExamples() {
 	return (
 		<>
-			<Stack sx={{ alignSelf: "stretch" }}>
+			<Stack sx={{ alignSelf: "stretch" }} spacing={1}>
 				<DividerDefault />
+				<DividerChildren />
 			</Stack>
 			<DividerVertical />
 			<DividerPresentational />

--- a/apps/website/src/content/docs/components/mui/Divider.md
+++ b/apps/website/src/content/docs/components/mui/Divider.md
@@ -20,7 +20,8 @@ The **Divider** comes in two forms: _semantic_ and _presentational_. By default,
 
 ## StrataKit MUI modifications
 
-- Renders a semantic [`<hr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hr) by default, switching to a `<div>` when it has children, is [vertical](#orientation), or is [presentational](#presentational-dividers).
+- Renders a semantic [`<hr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hr) by default, switching to a `<div>` when it has [children](#children), is [vertical](#orientation), or is [presentational](#presentational-dividers).
+- Added [`margin`](#margin) prop.
 
 ## Examples
 
@@ -61,6 +62,12 @@ The `margin` prop can be set to include some space before and after the **Divide
 The variant can control how much of the container the **Divider** spans. The default is `"fullWidth"`.
 
 ::example{src="mui/Divider.variant"}
+
+### Children
+
+When the `children` prop is passed, the **Divider** will render as a generic `<div>` (without [`separator`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/separator_role) semantics). It is recommended to supplement the **Divider** with alternative semantics, such as a heading.
+
+::example{src="mui/Divider.children" min-width="300px"}
 
 ## ✅ Do
 

--- a/examples/mui/Divider.children.tsx
+++ b/examples/mui/Divider.children.tsx
@@ -10,7 +10,7 @@ export default () => {
 	return (
 		<Divider>
 			<Typography variant="subtitle-md" render={<h3 />} noWrap>
-				Last unread
+				New messages
 			</Typography>
 		</Divider>
 	);

--- a/examples/mui/Divider.children.tsx
+++ b/examples/mui/Divider.children.tsx
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import Divider from "@mui/material/Divider";
+import Typography from "@mui/material/Typography";
+
+export default () => {
+	return (
+		<Divider>
+			<Typography variant="subtitle-md" render={<h3 />} noWrap>
+				Last unread
+			</Typography>
+		</Divider>
+	);
+};

--- a/packages/mui/src/~components/MuiDivider.tsx
+++ b/packages/mui/src/~components/MuiDivider.tsx
@@ -33,6 +33,9 @@ const MuiDivider = forwardRef<"hr", MuiDividerProps>((props, forwardedRef) => {
 			render={defaultRender}
 			data-_sk-margin={margin ? "" : undefined}
 			{...rest}
+			// Remove separator semantics when children is passed, to prevent the content from being suppressed.
+			role={children ? undefined : props.role}
+			aria-orientation={children ? undefined : props["aria-orientation"]}
 			ref={forwardedRef}
 		>
 			{children}


### PR DESCRIPTION
### Changes

Changed the implementation of `Divider` so that it renders without `role` or `aria-orientation` when used with the `children` prop. (Previously, `role="separator"` was used)

This allows children to be exposed by assistive technologies[^1]. Fixes #1621.

Added an example + docs, recommending alternative semantics (e.g. a heading) to be supplied from outside.

[^1]: The `role="separator"` pattern, as documented on [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/separator_role#all_descendants_are_presentational), is not supported by at least NVDA and VoiceOver. The children of `role="separator"` are skipped _entirely_ (not just flattened), even though they're present in the accessibility tree.

### Testing

Confirmed that `role` and `aria-orientation` are not present in the DOM, and that the Divider content is announced properly by screen readers (NVDA, VoiceOver).

<img width="287" height="88" alt="screenshot of a divider with text in the middle" src="https://github.com/user-attachments/assets/599814d1-21de-4e03-b860-ec8cd46f232c" />

[Deploy preview](https://stratakit.bentley.com/1642/docs/components/divider/#children)
