### PR TITLE
Target custom `Tooltip` class instead of MUI class

### DIFF
--- a/packages/mui/src/~components/MuiSlider.css
+++ b/packages/mui/src/~components/MuiSlider.css
@@ -199,7 +199,7 @@
 	font-variant-numeric: tabular-nums;
 	user-select: none; /* Disabled because tooltip is inside the thumb which intercepts all pointer events */
 
-	&:is(.MuiTooltip-tooltip) {
+	&:is(.🥝MuiTooltip) {
 		margin: 0;
 
 		:where(.MuiSlider-root:not(.MuiSlider-vertical)) & {

--- a/packages/mui/src/~components/MuiTooltip.css
+++ b/packages/mui/src/~components/MuiTooltip.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.🥝MuiTooltip-tooltip {
+.🥝MuiTooltip {
 	--✨border-width: 1px;
 	--✨margin: var(--stratakit-space-x05);
 

--- a/packages/mui/src/~components/MuiTooltip.css
+++ b/packages/mui/src/~components/MuiTooltip.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.MuiTooltip-tooltip {
+.🥝MuiTooltip-tooltip {
 	--✨border-width: 1px;
 	--✨margin: var(--stratakit-space-x05);
 

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -471,7 +471,7 @@ function createTheme(args: CreateThemeArgs) {
 					component: Role.span,
 					slotProps: {
 						valueLabel: {
-							className: "🥝MuiTooltip-tooltip",
+							className: "🥝MuiTooltip",
 						},
 					},
 				},
@@ -574,7 +574,7 @@ function createTheme(args: CreateThemeArgs) {
 					describeChild: true,
 					slotProps: {
 						tooltip: {
-							className: "🥝MuiTooltip-tooltip",
+							className: "🥝MuiTooltip",
 						},
 						popper: {
 							modifiers: [

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -471,7 +471,7 @@ function createTheme(args: CreateThemeArgs) {
 					component: Role.span,
 					slotProps: {
 						valueLabel: {
-							className: "MuiTooltip-tooltip",
+							className: "🥝MuiTooltip-tooltip",
 						},
 					},
 				},
@@ -573,6 +573,9 @@ function createTheme(args: CreateThemeArgs) {
 					placement: "top",
 					describeChild: true,
 					slotProps: {
+						tooltip: {
+							className: "🥝MuiTooltip-tooltip",
+						},
 						popper: {
 							modifiers: [
 								{


### PR DESCRIPTION
### Changes

In https://github.com/iTwin/stratakit/pull/1608#discussion_r3639022011 it was observed that we should not be applying MUI classes to other components.  This PR addresses where `.MuiTooltip-tooltip` was being applied to `Slider` by instead using a custom class of `.🥝MuiTooltip`.

I'd like to address this instance first because it is simpler than the work ahead in #1608.

### Testing

- Confirmed `.🥝MuiTooltip` is being applied.
- Confirmed `border` is appearing in `forced-colors` on both `Tooltip` and `Slider` (a good indicator that the custom class is being applied, without the class no `border` appears in `forced-colors`.