### PR TITLE
Update Badge color props to remove primary

### DIFF
--- a/.changeset/yummy-coats-shave.md
+++ b/.changeset/yummy-coats-shave.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+The `color` prop of `Badge` no longer supports the `"primary"` value. Use `"success"` instead.

--- a/.changeset/yummy-coats-shave.md
+++ b/.changeset/yummy-coats-shave.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-The `color` prop of `Badge` no longer supports the `"primary"` value. Use `"success"` instead.
+The `color` prop of `Badge` no longer supports the `"primary"` value.

--- a/apps/website/src/content/docs/components/mui/Badge.md
+++ b/apps/website/src/content/docs/components/mui/Badge.md
@@ -22,7 +22,7 @@ Make sure the **Badge** is suitable for your use case. There may be other, more 
 - Added [`type`](#type) prop.
 - Added [`inline`](#inline) prop.
 - Added [`size`](#sizes) prop.
-- The `"default"` color has been removed. The default color is now `"secondary"`.
+- The `"default"` and `"primary"` colors have been removed. The default color is now `"secondary"`.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Badge.md
+++ b/apps/website/src/content/docs/components/mui/Badge.md
@@ -36,6 +36,8 @@ Use `variant="dot"` to display the badge without a count inside.
 
 Set the `inline` prop to display the badge in normal document flow instead of positioned relative to its child.
 
+When `inline` is used, the `color="primary"` option is not valid.
+
 ::example{src="mui/Badge.inline"}
 
 ### Sizes
@@ -50,6 +52,7 @@ The `size` prop can only be set when [`inline`](#inline).
 ### Colors
 
 - **Secondary:** The default.
+- **Primary** Used only with the non-inline badge to avoid confusion with an call to action button.
 - **Info:** Use to call out an object or action as having an important attribute.
 - **Success:** Use to indicate a successful or completed state when it's important to provide positive reinforcement.
 - **Warning:** Use for warnings and time-sensitive issues that require attention and potential action.

--- a/apps/website/src/content/docs/components/mui/Badge.md
+++ b/apps/website/src/content/docs/components/mui/Badge.md
@@ -22,7 +22,7 @@ Make sure the **Badge** is suitable for your use case. There may be other, more 
 - Added [`type`](#type) prop.
 - Added [`inline`](#inline) prop.
 - Added [`size`](#sizes) prop.
-- The `"default"` color has been removed. The default color is now `"secondary"`.
+- The `"default"` and `"primary"` colors have been removed. The default color is now `"secondary"`.
 
 ## Examples
 
@@ -35,8 +35,6 @@ Use `variant="dot"` to display the badge without a count inside.
 ### Inline
 
 Set the `inline` prop to display the badge in normal document flow instead of positioned relative to its child.
-
-When `inline` is used, the `color="primary"` option is not valid.
 
 ::example{src="mui/Badge.inline"}
 
@@ -52,7 +50,6 @@ The `size` prop can only be set when [`inline`](#inline).
 ### Colors
 
 - **Secondary:** The default.
-- **Primary** Used only with the non-inline badge to avoid confusion with an call to action button.
 - **Info:** Use to call out an object or action as having an important attribute.
 - **Success:** Use to indicate a successful or completed state when it's important to provide positive reinforcement.
 - **Warning:** Use for warnings and time-sensitive issues that require attention and potential action.

--- a/apps/website/src/content/docs/components/mui/Badge.md
+++ b/apps/website/src/content/docs/components/mui/Badge.md
@@ -22,7 +22,7 @@ Make sure the **Badge** is suitable for your use case. There may be other, more 
 - Added [`type`](#type) prop.
 - Added [`inline`](#inline) prop.
 - Added [`size`](#sizes) prop.
-- The `"default"` and `"primary"` colors have been removed. The default color is now `"secondary"`.
+- The `"default"` color has been removed. The default color is now `"secondary"`.
 
 ## Examples
 

--- a/examples/mui/Badge.default.tsx
+++ b/examples/mui/Badge.default.tsx
@@ -14,7 +14,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<IconButton label="Notifications" aria-describedby={descriptionId}>
-			<Badge badgeContent={4} color="primary">
+			<Badge badgeContent={4} color="success">
 				<Icon href={`${svgNotifications}#icon-large`} size="large" />
 				<span id={descriptionId} hidden>
 					You have 4 unread notifications

--- a/examples/mui/Badge.default.tsx
+++ b/examples/mui/Badge.default.tsx
@@ -14,7 +14,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<IconButton label="Notifications" aria-describedby={descriptionId}>
-			<Badge badgeContent={4} color="success">
+			<Badge badgeContent={4}>
 				<Icon href={`${svgNotifications}#icon-large`} size="large" />
 				<span id={descriptionId} hidden>
 					You have 4 unread notifications

--- a/examples/mui/Badge.default.tsx
+++ b/examples/mui/Badge.default.tsx
@@ -14,7 +14,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<IconButton label="Notifications" aria-describedby={descriptionId}>
-			<Badge badgeContent={4} color="primary">
+			<Badge badgeContent={4}>
 				<Icon href={`${svgNotifications}#icon-large`} size="large" />
 				<span id={descriptionId} hidden>
 					You have 4 unread notifications

--- a/examples/mui/Badge.default.tsx
+++ b/examples/mui/Badge.default.tsx
@@ -14,7 +14,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<IconButton label="Notifications" aria-describedby={descriptionId}>
-			<Badge badgeContent={4}>
+			<Badge badgeContent={4} color="primary">
 				<Icon href={`${svgNotifications}#icon-large`} size="large" />
 				<span id={descriptionId} hidden>
 					You have 4 unread notifications

--- a/examples/mui/Badge.dot.tsx
+++ b/examples/mui/Badge.dot.tsx
@@ -14,7 +14,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<IconButton label="Notifications" aria-describedby={descriptionId}>
-			<Badge variant="dot" color="primary">
+			<Badge variant="dot">
 				<Icon href={`${svgNotifications}#icon-large`} size="large" />
 				<span id={descriptionId} hidden>
 					You have 4 unread notifications

--- a/examples/mui/Badge.dot.tsx
+++ b/examples/mui/Badge.dot.tsx
@@ -14,7 +14,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<IconButton label="Notifications" aria-describedby={descriptionId}>
-			<Badge variant="dot" color="primary">
+			<Badge variant="dot" color="success">
 				<Icon href={`${svgNotifications}#icon-large`} size="large" />
 				<span id={descriptionId} hidden>
 					You have 4 unread notifications

--- a/examples/mui/Badge.dot.tsx
+++ b/examples/mui/Badge.dot.tsx
@@ -14,7 +14,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<IconButton label="Notifications" aria-describedby={descriptionId}>
-			<Badge variant="dot" color="success">
+			<Badge variant="dot">
 				<Icon href={`${svgNotifications}#icon-large`} size="large" />
 				<span id={descriptionId} hidden>
 					You have 4 unread notifications

--- a/examples/mui/Badge.dot.tsx
+++ b/examples/mui/Badge.dot.tsx
@@ -14,7 +14,7 @@ export default () => {
 	const descriptionId = React.useId();
 	return (
 		<IconButton label="Notifications" aria-describedby={descriptionId}>
-			<Badge variant="dot">
+			<Badge variant="dot" color="primary">
 				<Icon href={`${svgNotifications}#icon-large`} size="large" />
 				<span id={descriptionId} hidden>
 					You have 4 unread notifications

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -226,7 +226,6 @@ declare module "@mui/material/Backdrop" {
 declare module "@mui/material/Badge" {
 	interface BadgePropsColorOverrides {
 		default: false;
-		primary: false;
 	}
 
 	interface BadgeOwnProps {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -226,6 +226,7 @@ declare module "@mui/material/Backdrop" {
 declare module "@mui/material/Badge" {
 	interface BadgePropsColorOverrides {
 		default: false;
+		primary: false;
 	}
 
 	interface BadgeOwnProps {

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -46,7 +46,10 @@ DEV: MuiBadge.displayName = "MuiBadge";
 const MuiBadgeBadge = forwardRef<"span", BaseProps>((props, forwardedRef) => {
 	const { inline } = useSafeContext(MuiBadgeContext);
 
-	if (inline && props.className?.match(/(^|\s)MuiBadge-colorPrimary($|\s)/)) {
+	if (
+		inline &&
+		(props.className ?? "").split(/\s+/).includes("MuiBadge-colorPrimary")
+	) {
 		throw new Error(
 			'inline cannot be used with color="primary" for Badge component',
 		);

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -45,16 +45,6 @@ DEV: MuiBadge.displayName = "MuiBadge";
 
 const MuiBadgeBadge = forwardRef<"span", BaseProps>((props, forwardedRef) => {
 	const { inline } = useSafeContext(MuiBadgeContext);
-
-	if (
-		inline &&
-		(props.className ?? "").split(/\s+/).includes("MuiBadge-colorPrimary")
-	) {
-		throw new Error(
-			'inline cannot be used with color="primary" for Badge component',
-		);
-	}
-
 	return (
 		<Role.span
 			{...props}

--- a/packages/mui/src/~components/MuiBadge.tsx
+++ b/packages/mui/src/~components/MuiBadge.tsx
@@ -45,6 +45,13 @@ DEV: MuiBadge.displayName = "MuiBadge";
 
 const MuiBadgeBadge = forwardRef<"span", BaseProps>((props, forwardedRef) => {
 	const { inline } = useSafeContext(MuiBadgeContext);
+
+	if (inline && props.className?.match(/(^|\s)MuiBadge-colorPrimary($|\s)/)) {
+		throw new Error(
+			'inline cannot be used with color="primary" for Badge component',
+		);
+	}
+
 	return (
 		<Role.span
 			{...props}


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Removes `"primary"` color from `Badge` 

See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17766928

### Testing

Edit `examples/mui/Badge.colors.tsx` to change one of the color values to `"primary"` make sure it shows as an error

View  the [preview ](https://stratakit.bentley.com/1650/docs/components/badge/)and verify that it:
-  no longer includes primary in the colors section
- remove default and primary from colors in modification section