### PR TITLE
Deprecate SvgIcon

### DIFF
--- a/.changeset/young-worlds-report.md
+++ b/.changeset/young-worlds-report.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-Deprecate `SvgIcon` in favor of `Icon`
+Deprecated MUI `SvgIcon` in favor of StrataKit `Icon`.

--- a/.changeset/young-worlds-report.md
+++ b/.changeset/young-worlds-report.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Deprecate `SvgIcon` in favor of `Icon`

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -402,7 +402,7 @@ declare module "@mui/material/Slider" {
 }
 
 declare module "@mui/material/SvgIcon" {
-	/** @deprecated Use `Icon` from `@stratakit/foundations` instead */
+	/** @deprecated Use `Icon` from `@stratakit/mui` instead. */
 	// @ts-expect-error -- Default exports cannot be augmented, but the `@deprecated` above still takes effect.
 	export default function SvgIcon(
 		props: SvgIconProps,

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -16,6 +16,7 @@ import type {
 	DefaultComponentProps,
 	OverridableTypeMap,
 } from "@mui/material/OverridableComponent";
+import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";
@@ -398,6 +399,14 @@ declare module "@mui/material/Slider" {
 		warning: false;
 		error: false;
 	}
+}
+
+declare module "@mui/material/SvgIcon" {
+	/** @deprecated Use `Icon` from `@stratakit/foundations` instead */
+	// @ts-expect-error -- Default exports cannot be augmented (https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation), but the `@deprecated` above still takes effect.
+	export default function SvgIcon(
+		props: SvgIconProps,
+	): React.JSX.Element | null;
 }
 
 declare module "@mui/material/Switch" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -403,7 +403,7 @@ declare module "@mui/material/Slider" {
 
 declare module "@mui/material/SvgIcon" {
 	/** @deprecated Use `Icon` from `@stratakit/foundations` instead */
-	// @ts-expect-error -- Default exports cannot be augmented (https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation), but the `@deprecated` above still takes effect.
+	// @ts-expect-error -- Default exports cannot be augmented, but the `@deprecated` above still takes effect.
 	export default function SvgIcon(
 		props: SvgIconProps,
 	): React.JSX.Element | null;


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecate MUI `SvgIcon` in favor of `Icon` from  `@stratakit/foundations`. See [discussion on deprecating props for version 1](https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17589182)

### Testing

Update the `Icon.default.tsx` to use `SvgIcon` from MUI.  Make sure it shows up as deprecated


<img width="2091" height="598" alt="image" src="https://github.com/user-attachments/assets/7fff7332-9481-4291-a9a3-318384da92f5" />
