### PR TITLE
add `Typography` props to Accordion's `heading` slot

### DIFF
--- a/.changeset/chubby-ways-relax.md
+++ b/.changeset/chubby-ways-relax.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Added `render` prop to `Accordion`'s `slotProps.heading`.

--- a/apps/website/src/content/docs/components/mui/Accordion.md
+++ b/apps/website/src/content/docs/components/mui/Accordion.md
@@ -74,7 +74,7 @@ Use the `markerPlacement` prop to control the **AccordionSummary** marker placem
 
 Multiple adjacent **Accordions** make a set. To make this set programmatically determinable and enumerable, use ARIA list semantics. Each individual `<Accordion>` must take `role="listitem"` and the set must belong to an element with `role="list"`.
 
-**Accordions** commonly represent major sections of a page and are rendered with an [`<h3>` heading element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) by default. Use the [`heading` slot](https://mui.com/material-ui/api/accordion/#slots) via the `slots` prop to change the heading level.
+**Accordions** commonly represent major sections of a page and are rendered with an [`<h3>` heading element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) by default. Use the `render` prop on [`slotProps.heading`](https://mui.com/material-ui/api/accordion/#accordion-prop-slotProps) to change the heading level.
 
 ::example{src="mui/Accordion.multiple"}
 

--- a/apps/website/src/content/docs/guides/component-customization.md
+++ b/apps/website/src/content/docs/guides/component-customization.md
@@ -80,19 +80,13 @@ Some StrataKit components are also designed specifically to leverage the `render
 
 Some more complex components, constituting subcomponents, support an object syntax for changing HTML elements through [MUI's `slots` and `slotProps` props](https://mui.com/material-ui/customization/overriding-component-structure/#interior-slots).
 
-Where needed, change your [**Accordion**](/components/accordion) item’s heading via the `heading` slot:
+Where needed, change your [**Accordion**](/components/accordion) item’s heading by passing the `render` prop via `slotProps.heading`:
 
 ```jsx
-<Accordion
-	variant="outlined"
-	role="listitem"
-	slots={{
-		heading: "h2",
-	}}
->
+<Accordion slotProps={{ heading: { render: <h2 /> } }}>
 ```
 
-The `slotProps` alternative gives you finer grained control. For each element, you can set multiple props, including a `render` prop where applicable. For example, the [**NativeSelect**](/components/select/#native)’s input needs both `name` and `id` set:
+For each element, you can set multiple props. For example, the [**NativeSelect**](/components/select/#native)’s input needs both `name` and `id` set:
 
 ```jsx
 <FormControl>

--- a/examples/mui/Accordion._multiple-outlined.tsx
+++ b/examples/mui/Accordion._multiple-outlined.tsx
@@ -7,7 +7,6 @@ import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Link from "@mui/material/Link";
-import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
@@ -15,13 +14,9 @@ export default () => {
 			<Accordion
 				variant="outlined"
 				role="listitem"
-				slots={{
-					heading: "h2",
-				}}
+				slotProps={{ heading: { render: <h2 /> } }}
 			>
-				<AccordionSummary>
-					<Typography render={<span />}>What is StrataKit?</Typography>
-				</AccordionSummary>
+				<AccordionSummary>What is StrataKit?</AccordionSummary>
 				<AccordionDetails>
 					StrataKit is Bentley Systems' open source design system and the
 					successor to iTwinUI.
@@ -31,13 +26,9 @@ export default () => {
 			<Accordion
 				variant="outlined"
 				role="listitem"
-				slots={{
-					heading: "h2",
-				}}
+				slotProps={{ heading: { render: <h2 /> } }}
 			>
-				<AccordionSummary>
-					<Typography render={<span />}>What is a design system?</Typography>
-				</AccordionSummary>
+				<AccordionSummary>What is a design system?</AccordionSummary>
 				<AccordionDetails>
 					A design system is a comprehensive framework of standards, reusable
 					components, and documentation that guides the consistent development
@@ -48,13 +39,9 @@ export default () => {
 			<Accordion
 				variant="outlined"
 				role="listitem"
-				slots={{
-					heading: "h2",
-				}}
+				slotProps={{ heading: { render: <h2 /> } }}
 			>
-				<AccordionSummary>
-					<Typography render={<span />}>What is design?</Typography>
-				</AccordionSummary>
+				<AccordionSummary>What is design?</AccordionSummary>
 				<AccordionDetails>
 					“Design is when designers design a design to produce a design.” —{" "}
 					<Link href="https://academic.oup.com/book/790">

--- a/examples/mui/Accordion.actions.tsx
+++ b/examples/mui/Accordion.actions.tsx
@@ -8,14 +8,11 @@ import AccordionActions from "@mui/material/AccordionActions";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Button from "@mui/material/Button";
-import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
 		<Accordion>
-			<AccordionSummary>
-				<Typography render={<span />}>What is a design system?</Typography>
-			</AccordionSummary>
+			<AccordionSummary>What is a design system?</AccordionSummary>
 			<AccordionDetails>
 				A design system is a comprehensive framework of standards, reusable
 				components, and documentation that guides the consistent development of

--- a/examples/mui/Accordion.decoration.tsx
+++ b/examples/mui/Accordion.decoration.tsx
@@ -16,7 +16,7 @@ export default () => {
 		<Accordion>
 			<AccordionSummary>
 				<Icon href={svgInfo} />
-				<Typography render={<span />}>What is StrataKit?</Typography>
+				<Typography>What is StrataKit?</Typography>
 			</AccordionSummary>
 			<AccordionDetails>
 				StrataKit is Bentley Systems' open source design system and the

--- a/examples/mui/Accordion.default.tsx
+++ b/examples/mui/Accordion.default.tsx
@@ -6,14 +6,11 @@
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
 		<Accordion>
-			<AccordionSummary>
-				<Typography render={<span />}>What is StrataKit?</Typography>
-			</AccordionSummary>
+			<AccordionSummary>What is StrataKit?</AccordionSummary>
 			<AccordionDetails>
 				StrataKit is Bentley Systems' open source design system and the
 				successor to iTwinUI.

--- a/examples/mui/Accordion.expanded.tsx
+++ b/examples/mui/Accordion.expanded.tsx
@@ -6,14 +6,11 @@
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
 		<Accordion defaultExpanded>
-			<AccordionSummary>
-				<Typography render={<span />}>What is StrataKit?</Typography>
-			</AccordionSummary>
+			<AccordionSummary>What is StrataKit?</AccordionSummary>
 			<AccordionDetails>
 				StrataKit is Bentley Systems' open source design system and the
 				successor to iTwinUI.

--- a/examples/mui/Accordion.marker-placement.tsx
+++ b/examples/mui/Accordion.marker-placement.tsx
@@ -6,7 +6,6 @@
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
@@ -14,9 +13,7 @@ export default () => {
 			<div>
 				<Accordion>
 					<AccordionSummary markerPlacement="start">
-						<Typography render={<span />}>
-							Marker placement <code>start</code>
-						</Typography>
+						Marker placement <code>start</code>
 					</AccordionSummary>
 					<AccordionDetails>
 						<code>start</code> aligns the marker with the inline-start edge:
@@ -28,9 +25,7 @@ export default () => {
 			<div>
 				<Accordion>
 					<AccordionSummary markerPlacement="end">
-						<Typography render={<span />}>
-							Marker placement <code>end</code>
-						</Typography>
+						Marker placement <code>end</code>
 					</AccordionSummary>
 					<AccordionDetails>
 						<code>end</code> aligns the marker with the inline-end edge: right

--- a/examples/mui/Accordion.multiple.tsx
+++ b/examples/mui/Accordion.multiple.tsx
@@ -7,35 +7,20 @@ import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Link from "@mui/material/Link";
-import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
 		<div role="list">
-			<Accordion
-				role="listitem"
-				slots={{
-					heading: "h2",
-				}}
-			>
-				<AccordionSummary>
-					<Typography render={<span />}>What is StrataKit?</Typography>
-				</AccordionSummary>
+			<Accordion role="listitem" slotProps={{ heading: { render: <h2 /> } }}>
+				<AccordionSummary>What is StrataKit?</AccordionSummary>
 				<AccordionDetails>
 					StrataKit is Bentley Systems' open source design system and the
 					successor to iTwinUI.
 				</AccordionDetails>
 			</Accordion>
 
-			<Accordion
-				role="listitem"
-				slots={{
-					heading: "h2",
-				}}
-			>
-				<AccordionSummary>
-					<Typography render={<span />}>What is a design system?</Typography>
-				</AccordionSummary>
+			<Accordion role="listitem" slotProps={{ heading: { render: <h2 /> } }}>
+				<AccordionSummary>What is a design system?</AccordionSummary>
 				<AccordionDetails>
 					A design system is a comprehensive framework of standards, reusable
 					components, and documentation that guides the consistent development
@@ -43,15 +28,8 @@ export default () => {
 				</AccordionDetails>
 			</Accordion>
 
-			<Accordion
-				role="listitem"
-				slots={{
-					heading: "h2",
-				}}
-			>
-				<AccordionSummary>
-					<Typography render={<span />}>What is design?</Typography>
-				</AccordionSummary>
+			<Accordion role="listitem" slotProps={{ heading: { render: <h2 /> } }}>
+				<AccordionSummary>What is design?</AccordionSummary>
 				<AccordionDetails>
 					“Design is when designers design a design to produce a design.” —{" "}
 					<Link href="https://academic.oup.com/book/790">

--- a/examples/mui/Accordion.responsive.tsx
+++ b/examples/mui/Accordion.responsive.tsx
@@ -6,7 +6,6 @@
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import Typography from "@mui/material/Typography";
 
 import styles from "./Accordion.responsive.module.css";
 
@@ -14,9 +13,7 @@ export default () => {
 	return (
 		<div className={styles.container}>
 			<Accordion variant="outlined">
-				<AccordionSummary>
-					<Typography render={<span />}>What is responsive design?</Typography>
-				</AccordionSummary>
+				<AccordionSummary>What is responsive design?</AccordionSummary>
 				<AccordionDetails>
 					Responsive design is a web development approach that ensures a
 					website's layout, images, and text automatically adjust and scale to

--- a/examples/mui/Accordion.variants.tsx
+++ b/examples/mui/Accordion.variants.tsx
@@ -7,7 +7,6 @@ import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
@@ -15,9 +14,7 @@ export default () => {
 			<div>
 				<Accordion variant="elevation">
 					<AccordionSummary>
-						<Typography render={<span />}>
-							<code>elevation</code> variant
-						</Typography>
+						<code>elevation</code> variant
 					</AccordionSummary>
 					<AccordionDetails>
 						An elevation accordion does not include a border around its content
@@ -28,9 +25,7 @@ export default () => {
 			<div>
 				<Accordion variant="outlined">
 					<AccordionSummary>
-						<Typography render={<span />}>
-							<code>outlined</code> variant
-						</Typography>
+						<code>outlined</code> variant
 					</AccordionSummary>
 					<AccordionDetails>
 						An outlined accordion includes a border around its content with

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -60,6 +60,10 @@ declare module "@mui/material/OverridableComponent" {
 	}
 }
 
+declare module "@mui/material/Accordion" {
+	interface AccordionHeadingSlotPropsOverrides extends TypographyProps {}
+}
+
 declare module "@mui/material/AccordionSummary" {
 	interface AccordionSummaryOwnProps {
 		/**

--- a/packages/mui/src/~components/MuiAccordion.tsx
+++ b/packages/mui/src/~components/MuiAccordion.tsx
@@ -5,6 +5,7 @@
 
 import { Role } from "@ariakit/react/role";
 import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
 import { forwardRef } from "@stratakit/foundations/secret-internals";
 
 import type { AccordionOwnerState } from "@mui/material/Accordion";
@@ -34,6 +35,21 @@ DEV: MuiAccordionRootSlot.displayName = "MuiAccordionRootSlot";
 
 // ----------------------------------------------------------------------------
 
+interface MuiAccordionHeadingSlotProps {
+	ownerState?: AccordionOwnerState;
+}
+
+const MuiAccordionHeadingSlot = forwardRef<"div", MuiAccordionHeadingSlotProps>(
+	(props, forwardedRef) => {
+		const { ownerState: _, ...rest } = props;
+
+		return <Typography render={<h3 />} {...rest} ref={forwardedRef} />;
+	},
+);
+DEV: MuiAccordionHeadingSlot.displayName = "MuiAccordionHeadingSlot";
+
+// ----------------------------------------------------------------------------
+
 interface MuiAccordionSummaryProps
 	extends BaseProps,
 		Pick<AccordionSummaryOwnProps, "markerPlacement"> {}
@@ -56,4 +72,4 @@ DEV: MuiAccordionSummary.displayName = "MuiAccordionSummary";
 
 // ----------------------------------------------------------------------------
 
-export { MuiAccordionRootSlot, MuiAccordionSummary };
+export { MuiAccordionHeadingSlot, MuiAccordionRootSlot, MuiAccordionSummary };

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -10,6 +10,7 @@ import StepConnector from "@mui/material/StepConnector";
 import { createTheme as createMuiTheme } from "@mui/material/styles";
 import cx from "classnames";
 import {
+	MuiAccordionHeadingSlot,
 	MuiAccordionRootSlot,
 	MuiAccordionSummary,
 } from "./~components/MuiAccordion.js";
@@ -145,6 +146,7 @@ function createTheme(args: CreateThemeArgs) {
 					disableGutters: true,
 					slots: {
 						root: MuiAccordionRootSlot,
+						heading: MuiAccordionHeadingSlot,
 					},
 					slotProps: {
 						region: {


### PR DESCRIPTION
_Follow-up to https://github.com/iTwin/stratakit/pull/1514#discussion_r3359028289, https://github.com/iTwin/stratakit/pull/1582#discussion_r3605766806 and https://github.com/iTwin/stratakit/pull/1454#discussion_r3209016967._

### Changes


- **[Theme]**: Changed Accordion's [`heading` slot](https://mui.com/material-ui/api/accordion/#Accordion-css-MuiAccordion-heading) to use `<Typography render={<h3 />}>` instead of `<h3>`.
  - This unlocks runtime support for `render` prop within `slotProps.heading`, similar to other components that internally render `Typography` (such as `CardHeader`).
- **[Types]**: Updated `slotProps.heading` to support all `Typography` props (including `render`).
- **[Docs]**: Changed guidance to recommend `slotProps` over `slots`, making it consistent with [`Card` docs](https://stratakit.bentley.com/docs/components/card/#heading-levels).
- **[Examples]**: Updated to use `slotProps.heading.render` + also simplified usage by removing redundant `Typography` element.

### Testing

Confirm that:
- `Accordion` examples output `<h3>` elements by default (unless overridden by `render` prop).
- `Accordion.multiple` example outputs `<h2>` elements (set via `render` prop).
- `Accordion.multiple` does _not_ output the `MuiPaper-rounded` class (originally seen in https://github.com/iTwin/stratakit/pull/1454#discussion_r3209016967).

[Deploy preview](https://stratakit.bentley.com/1657/docs/components/accordion/#multiple-accordions)