### PR TITLE
Fix race condition when creating the portal container

### DIFF
--- a/.changeset/curly-numbers-wait.md
+++ b/.changeset/curly-numbers-wait.md
@@ -3,4 +3,4 @@
 "@stratakit/mui": patch
 ---
 
-Update portal container rendering to fix an issue with initially open Dialogs incorrectly being aria-hidden
+Updated portal container rendering to prevent initially open `Dialog` incorrectly being `aria-hidden`

--- a/.changeset/curly-numbers-wait.md
+++ b/.changeset/curly-numbers-wait.md
@@ -1,0 +1,6 @@
+---
+"@stratakit/foundations": patch
+"@stratakit/mui": patch
+---
+
+Update portal container rendering to fix an issue with initially open Dialogs incorrectly being aria-hidden

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -265,7 +265,13 @@ function PortalProvider(props: React.PropsWithChildren<PortalProviderProps>) {
 
 	return (
 		<PortalContext.Provider value={portalContainer}>
-			{props.children}
+			{/*
+			 * Rendered *before* `children` so that its ref is attached before any descendant's
+			 * layout effect runs in the same commit. This allows portals (e.g. MUI `Modal`) that are
+			 * already open on the very first commit to resolve this container instead of falling back
+			 * to `<body>`. The rendered DOM position is unaffected, since this is portaled to the end
+			 * of the root node either way.
+			 */}
 			<PortalContainer
 				colorScheme={props.colorScheme}
 				unstable_accentColor={props.unstable_accentColor}
@@ -273,6 +279,7 @@ function PortalProvider(props: React.PropsWithChildren<PortalProviderProps>) {
 				ref={setPortalContainer}
 				render={props.portalContainerProp}
 			/>
+			{props.children}
 		</PortalContext.Provider>
 	);
 }

--- a/packages/foundations/src/Root.tsx
+++ b/packages/foundations/src/Root.tsx
@@ -265,13 +265,6 @@ function PortalProvider(props: React.PropsWithChildren<PortalProviderProps>) {
 
 	return (
 		<PortalContext.Provider value={portalContainer}>
-			{/*
-			 * Rendered *before* `children` so that its ref is attached before any descendant's
-			 * layout effect runs in the same commit. This allows portals (e.g. MUI `Modal`) that are
-			 * already open on the very first commit to resolve this container instead of falling back
-			 * to `<body>`. The rendered DOM position is unaffected, since this is portaled to the end
-			 * of the root node either way.
-			 */}
 			<PortalContainer
 				colorScheme={props.colorScheme}
 				unstable_accentColor={props.unstable_accentColor}

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -54,20 +54,6 @@ const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 
 	// The container is passed as a function so that MUI resolves it lazily (inside `Portal`'s layout
 	// effect), by which point the ref is guaranteed to be attached.
-	//
-	// Storing the element in state and passing directly instead would leave the container `undefined` for the first
-	// commit, which permanently breaks any `Modal` that is already open on that commit:
-	//
-	//   1. `Portal` has no container, so it falls back to `document.body`.
-	//   2. `ModalManager.add(modal, document.body)` calls `ariaHiddenSiblings`, which sets
-	//      `aria-hidden="true"` on every child of `<body>` other than the modal itself — including
-	//      our portal container.
-	//   3. The ref attaches, the theme is recreated, and on the next commit the modal moves into
-	//      the portal container. `ariaHiddenSiblings` only runs when a modal is added or removed,
-	//      so nothing re-evaluates it: the container keeps `aria-hidden="true"` for as long as the
-	//      modal is open, and the modal is now *inside* it.
-	//
-	// The modal is then visible on screen but absent from the accessibility tree.
 	const theme = React.useMemo(
 		() => createTheme({ portalContainer: () => portalContainerRef.current }),
 		[],

--- a/packages/mui/src/Root.tsx
+++ b/packages/mui/src/Root.tsx
@@ -50,12 +50,27 @@ interface RootProps
 const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 	const { children, colorScheme, unstable_accentColor, ...rest } = props;
 
-	const [portalContainer, setPortalContainer] =
-		React.useState<HTMLDivElement | null>();
+	const portalContainerRef = React.useRef<HTMLDivElement | null>(null);
 
+	// The container is passed as a function so that MUI resolves it lazily (inside `Portal`'s layout
+	// effect), by which point the ref is guaranteed to be attached.
+	//
+	// Storing the element in state and passing directly instead would leave the container `undefined` for the first
+	// commit, which permanently breaks any `Modal` that is already open on that commit:
+	//
+	//   1. `Portal` has no container, so it falls back to `document.body`.
+	//   2. `ModalManager.add(modal, document.body)` calls `ariaHiddenSiblings`, which sets
+	//      `aria-hidden="true"` on every child of `<body>` other than the modal itself — including
+	//      our portal container.
+	//   3. The ref attaches, the theme is recreated, and on the next commit the modal moves into
+	//      the portal container. `ariaHiddenSiblings` only runs when a modal is added or removed,
+	//      so nothing re-evaluates it: the container keeps `aria-hidden="true"` for as long as the
+	//      modal is open, and the modal is now *inside* it.
+	//
+	// The modal is then visible on screen but absent from the accessibility tree.
 	const theme = React.useMemo(
-		() => createTheme({ portalContainer }),
-		[portalContainer],
+		() => createTheme({ portalContainer: () => portalContainerRef.current }),
+		[],
 	);
 	return (
 		<StyledEngineProvider>
@@ -71,7 +86,7 @@ const Root = forwardRef<"div", RootProps>((props, forwardedRef) => {
 					{...rest}
 					colorScheme={colorScheme}
 					unstable_accentColor={unstable_accentColor}
-					portalContainerRef={setPortalContainer}
+					portalContainerRef={portalContainerRef}
 					ref={forwardedRef}
 				>
 					<Styles />

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -71,7 +71,14 @@ import type { ColorSystemOptions } from "@mui/material/styles";
 import type {} from "@mui/x-date-pickers/themeAugmentation";
 
 interface CreateThemeArgs {
-	portalContainer?: HTMLElement | null;
+	/**
+	 * The container to use for all portaled components.
+	 *
+	 * Prefer passing a function, which is lazily resolved by MUI when the portal mounts. Passing the
+	 * element directly requires the theme to be recreated once the element becomes available, which
+	 * leaves a one-commit window where portals fall back to `<body>`.
+	 */
+	portalContainer?: HTMLElement | null | (() => HTMLElement | null);
 }
 
 /** Creates a StrataKit theme for MUI. Should be used with MUI's `ThemeProvider`. */


### PR DESCRIPTION
### Changes

Fixes https://github.com/iTwin/stratakit/issues/1659 by changing the `Root` component in two places:

- In `@stratakit/mui`: Used ref instead of state for `portalContainer` to avoid the `container` being `undefined` initially, which was causing `aria-hidden` to be incorrectly applied to the modal. (This is because state is not updated till the second render pass and MUI doesn't react to future updates.) This ref is passed into MUI components using the functional form of `container` prop.

- In `@stratakit/foundations`: Updated `PortalContainer` to render before `children` so that its ref is already attached before other components (e.g. `Dialog`) try to read it.

### Testing

1. I set up the minimal example to be part of the workspace and use the workspace packages.  The docs and MUI example page had too much other stuff set up to reliably reproduce the original issue.  Not sure if there is a better way to do this

3. Updated App.tsx to render
```tsx
		<Dialog open>
			<DialogTitle>Deep-linked dialog</DialogTitle>
			<DialogContent>
				<DialogContentText>
					<span data-testid="dialog-content">
						This dialog is open on the first commit of Root.
					</span>
				</DialogContentText>
			</DialogContent>
		</Dialog>
```

4. Run the minimal app.
5. Make sure the portal div is not marked aria-hidden in the browser..  This is directly under `body` not under `div#root`.  It has classname="🥝Root 🥝MuiRoot".  When run on main this will be marked as aria-hidden
