### PR TITLE
Fix icon size of `NavigationRail.Button` and `NavigationRail.Anchor`

### DIFF
--- a/.changeset/yummy-crabs-post.md
+++ b/.changeset/yummy-crabs-post.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/structures": patch
+---
+
+Fix icon size of `NavigationRail.Button` and `NavigationRail.Anchor` components when a React element is passed to the `icon` prop.

--- a/packages/structures/src/NavigationRail.css
+++ b/packages/structures/src/NavigationRail.css
@@ -227,6 +227,12 @@
 	}
 }
 
+.🥝NavigationRailItemActionIcon {
+	@layer base {
+		--🥝Icon-size: 1.5rem;
+	}
+}
+
 .🥝NavigationRailItemActionLabel {
 	@layer base {
 		flex: 1;

--- a/packages/structures/src/NavigationRail.css
+++ b/packages/structures/src/NavigationRail.css
@@ -227,7 +227,7 @@
 	}
 }
 
-.🥝NavigationRailItemActionIcon {
+.🥝NavigationRailItemActionIcon:is(.🥝Icon) {
 	@layer base {
 		--🥝Icon-size: 1.5rem;
 	}

--- a/packages/structures/src/NavigationRail.tsx
+++ b/packages/structures/src/NavigationRail.tsx
@@ -563,6 +563,7 @@ const NavigationRailItemActionIcon = forwardRef<
 			href={typeof icon === "string" ? icon : undefined}
 			render={React.isValidElement(icon) ? icon : undefined}
 			{...rest}
+			className={cx("🥝NavigationRailItemActionIcon", props.className)}
 			ref={forwardedRef}
 		/>
 	);


### PR DESCRIPTION
## Changes

This PR addresses icon size issues of `NavigationRail.Button` and `NavigationRail.Anchor` components described in #1624.

Both of the issues are related to how the `data-_sk-size` attribute is merged (or rather always overridden), see:

- https://github.com/iTwin/stratakit/issues/1624#issuecomment-4985191136
- https://github.com/iTwin/stratakit/issues/1624#issuecomment-5106080669

The fix utilizes the `render` prop usage in `NavigationRailItemActionIcon` and the correct `className` merging - `--🥝Icon-size` is set on `🥝NavigationRailItemActionIcon`. **NOTE:** this might result in specificity issues in the future, but currently is a non-issue due to `base` and `modifiers` layers.

<img width="354" height="179" alt="Screenshot 2026-07-29 at 12 22 20" src="https://github.com/user-attachments/assets/df230bd1-4e7c-4fad-bb74-0ca1cf4b9610" />

### Icon w/o explicit size

Restores previous behavior, where a large icon is rendered when a React element is passed to the `icon` prop without an explicit `size` prop.

**Note to consumers:** it is still recommended to pass an explicit `size` prop to the `Icon` component.

```
// Renders a large icon after this PR
<NavigationRail.Button
  icon={<Icon href={`${svgSettings}#icon-large`} />}
  label="Settings"
/>
```

### Dot badge

Restores previous behavior, where a large icon is rendered when a dot `Badge` wraps the `Icon`.

```
// Renders a large icon after this PR
<Badge variant="dot" color="error" invisible={expanded}>
  <Icon href={`${svgNotifications}#icon-large`} size="large" />
</Badge>
```

**Note to reviewers:** when `Badge` wraps a `size="regular"` icon, the badge will still be positioned for the large icon. This can be "fixed" consumer side by setting an explicit `width: 1rem` on a badge.

<img width="84" height="84" alt="localhost_4321_docs_examples_structures_NavigationRail comprehensive" src="https://github.com/user-attachments/assets/1e1a90a4-8f21-40c0-8320-61a92948cccf" />

## Testing

https://stratakit.bentley.com/1664/docs/components/navigationrail/#comprehensive

Ensured that the following examples render correctly after this PR:

```tsx
// Renders a large icon
<NavigationRail.Button icon={<Icon />} />

// Renders a large icon
<NavigationRail.Button icon={<Icon size="large" />} />

// Renders a regular (small) icon
<NavigationRail.Button icon={<Icon size="regular" />} />

// Renders a large icon
<Badge variant="dot">
  <Icon />
</Badge>

// Renders a large icon
<Badge variant="dot">
  <Icon size="large" />
</Badge>

// Renders a regular (small) icon
// Badge is positioned for the large icon
<Badge variant="dot">
  <Icon size="regular" />
</Badge>
```
