### PR TITLE
Add `useCloseWatcher` hook

### DIFF
--- a/.changeset/brave-rings-appear.md
+++ b/.changeset/brave-rings-appear.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Removed [`CloseWatcher`](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) responsible for device-specific close actions from the `Tooltip` component.

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { useStoreState } from "@ariakit/react/store";
 import * as AkTooltip from "@ariakit/react/tooltip";
 import {
+	useCloseWatcher,
 	useEventHandlers,
 	usePopoverApi,
 	useStableCallback,
@@ -105,6 +106,9 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, forwardedRef) => {
 
 	const popoverProps = usePopoverApi({
 		element: popoverElement,
+		open,
+	});
+	useCloseWatcher({
 		open,
 		setOpen,
 	});

--- a/packages/bricks/src/Tooltip.tsx
+++ b/packages/bricks/src/Tooltip.tsx
@@ -7,10 +7,8 @@ import * as React from "react";
 import { useStoreState } from "@ariakit/react/store";
 import * as AkTooltip from "@ariakit/react/tooltip";
 import {
-	useCloseWatcher,
 	useEventHandlers,
 	usePopoverApi,
-	useStableCallback,
 } from "@stratakit/internal-utils/hooks";
 import { forwardRef } from "@stratakit/internal-utils/react";
 import cx from "classnames";
@@ -102,15 +100,10 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, forwardedRef) => {
 	const store = AkTooltip.useTooltipStore();
 	const open = useStoreState(store, "open");
 	const popoverElement = useStoreState(store, "popoverElement");
-	const setOpen = useStableCallback(store.setOpen);
 
 	const popoverProps = usePopoverApi({
 		element: popoverElement,
 		open,
-	});
-	useCloseWatcher({
-		open,
-		setOpen,
 	});
 
 	return (

--- a/packages/internal-utils/src/hooks.ts
+++ b/packages/internal-utils/src/hooks.ts
@@ -222,6 +222,10 @@ interface CloseWatcher {
 	destroy: () => void;
 }
 
+declare const CloseWatcher: {
+	new (): CloseWatcher;
+};
+
 /**
  * Hook that makes it easy to use the [CloseWatcher API](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) consistently.
  * This hook will call the `setOpen` argument to automatically handle "light dismiss" behavior when the component is open.
@@ -237,8 +241,7 @@ function useCloseWatcher({
 		if (!open) return;
 		if (!("CloseWatcher" in window)) return;
 
-		// @ts-expect-error -- new API, types missing
-		const closeWatcher: CloseWatcher = new CloseWatcher();
+		const closeWatcher = new CloseWatcher();
 		closeWatcher.onclose = () => {
 			setOpen(false);
 		};

--- a/packages/internal-utils/src/hooks.ts
+++ b/packages/internal-utils/src/hooks.ts
@@ -181,37 +181,24 @@ function useSafeContext<C>(context: React.Context<C>) {
 
 /**
  * Hook that makes it easy to use the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) consistently.
- *
- * Internally, this hook will sync the `open` state with the `element`'s "popover-open" state. It will also create a `CloseWatcher`
- * to automatically handle "light dismiss" behavior when the popover is open.
+ * This hook will sync the `open` state with the `element`'s "popover-open" state.
  *
  * Returns a set of DOM props that should be passed back to the element.
  */
 function usePopoverApi({
 	element,
 	open,
-	setOpen,
 }: {
 	element: HTMLElement | null | undefined;
 	open: boolean | undefined;
-	setOpen: (open: boolean) => void;
 }) {
 	React.useEffect(
 		function syncPopoverWithOpenState() {
 			if (element?.popover && element?.isConnected && open !== undefined) {
 				element?.togglePopover?.(open);
-
-				// https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher
-				if (open && "CloseWatcher" in window) {
-					// @ts-expect-error -- new API, types missing
-					const closeWatcher = new CloseWatcher();
-					closeWatcher.onclose = () => {
-						if (open) setOpen(false);
-					};
-				}
 			}
 		},
-		[open, element, setOpen],
+		[open, element],
 	);
 
 	return React.useMemo(
@@ -222,6 +209,43 @@ function usePopoverApi({
 			}) as const,
 		[],
 	);
+}
+
+// ----------------------------------------------------------------------------
+
+/**
+ * Minimal subset of the [`CloseWatcher`](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) types.
+ * Used by `useCloseWatcher` until API types are available in TypeScript.
+ */
+interface CloseWatcher {
+	onclose: () => void;
+	destroy: () => void;
+}
+
+/**
+ * Hook that makes it easy to use the [CloseWatcher API](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) consistently.
+ * This hook will call the `setOpen` argument to automatically handle "light dismiss" behavior when the component is open.
+ */
+function useCloseWatcher({
+	open,
+	setOpen,
+}: {
+	open: boolean | undefined;
+	setOpen: (open: boolean) => void;
+}) {
+	React.useEffect(() => {
+		if (!open) return;
+		if (!("CloseWatcher" in window)) return;
+
+		// @ts-expect-error -- new API, types missing
+		const closeWatcher: CloseWatcher = new CloseWatcher();
+		closeWatcher.onclose = () => {
+			setOpen(false);
+		};
+		return () => {
+			closeWatcher.destroy();
+		};
+	}, [open, setOpen]);
 }
 
 // ----------------------------------------------------------------------------
@@ -243,6 +267,7 @@ function useIsClient() {
 // ----------------------------------------------------------------------------
 
 export {
+	useCloseWatcher,
 	useControlledState,
 	useEventHandlers,
 	useIsClient,

--- a/packages/internal-utils/src/hooks.ts
+++ b/packages/internal-utils/src/hooks.ts
@@ -217,14 +217,10 @@ function usePopoverApi({
  * Minimal subset of the [`CloseWatcher`](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) types.
  * Used by `useCloseWatcher` until API types are available in TypeScript.
  */
-interface CloseWatcher {
+declare class CloseWatcher {
 	onclose: () => void;
 	destroy: () => void;
 }
-
-declare const CloseWatcher: {
-	new (): CloseWatcher;
-};
 
 /**
  * Hook that makes it easy to use the [CloseWatcher API](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) consistently.

--- a/packages/mui/src/~components/MuiTooltip.tsx
+++ b/packages/mui/src/~components/MuiTooltip.tsx
@@ -5,7 +5,6 @@
 
 import * as React from "react";
 import Popper from "@mui/material/Popper";
-import { identity } from "@stratakit/internal-utils/common";
 import { useMergedRefs, usePopoverApi } from "@stratakit/internal-utils/hooks";
 import { forwardRef } from "@stratakit/internal-utils/react";
 
@@ -23,7 +22,6 @@ const MuiTooltipPopper = forwardRef<"div", MuiTooltipPopperProps>(
 		const popoverProps = usePopoverApi({
 			element: popoverElement,
 			open: props.open,
-			setOpen: identity,
 		});
 
 		return (

--- a/packages/structures/src/Dialog.tsx
+++ b/packages/structures/src/Dialog.tsx
@@ -11,6 +11,7 @@ import { useStoreState } from "@ariakit/react/store";
 import { IconButton, Text } from "@stratakit/bricks";
 import { GhostAligner } from "@stratakit/bricks/secret-internals";
 import {
+	useCloseWatcher,
 	usePopoverApi,
 	useStableCallback,
 } from "@stratakit/internal-utils/hooks";
@@ -125,6 +126,9 @@ function DialogWrapper(props: DialogWrapperProps) {
 
 	const popoverProps = usePopoverApi({
 		element: wrapper,
+		open,
+	});
+	useCloseWatcher({
 		open,
 		setOpen,
 	});

--- a/packages/structures/src/DropdownMenu.tsx
+++ b/packages/structures/src/DropdownMenu.tsx
@@ -25,6 +25,7 @@ import {
 } from "@stratakit/bricks/secret-internals";
 import { Icon } from "@stratakit/foundations";
 import {
+	useCloseWatcher,
 	usePopoverApi,
 	useSafeContext,
 	useStableCallback,
@@ -113,6 +114,9 @@ const DropdownMenuContent = forwardRef<"div", DropdownMenuContentProps>(
 
 		const popoverProps = usePopoverApi({
 			element: popoverElement,
+			open,
+		});
+		useCloseWatcher({
 			open,
 			setOpen,
 		});

--- a/packages/structures/src/Popover.tsx
+++ b/packages/structures/src/Popover.tsx
@@ -9,6 +9,7 @@ import { PortalContext } from "@ariakit/react/portal";
 import { useStoreState } from "@ariakit/react/store";
 import { Button } from "@stratakit/bricks";
 import {
+	useCloseWatcher,
 	usePopoverApi,
 	useStableCallback,
 } from "@stratakit/internal-utils/hooks";
@@ -82,6 +83,9 @@ const PopoverRoot = forwardRef<"div", PopoverRootProps>(
 
 		const popoverProps = usePopoverApi({
 			element: popoverElement,
+			open,
+		});
+		useCloseWatcher({
 			open,
 			setOpen,
 		});


### PR DESCRIPTION
### Changes

This PR ~changes internal `usePopoverApi` hook to make the `setOpen` optional.~ extracts `useCloseWatcher` hook from `usePopoverApi`.  See https://github.com/iTwin/stratakit/pull/1665#discussion_r3674795303, https://github.com/iTwin/stratakit/pull/1670#discussion_r3682253423, https://github.com/iTwin/stratakit/pull/1670#discussion_r3683210284

Additionally, this fixes the cleanup of `CloseWatcher`.

### Testing

Tested manually after adding `hideOnEscape` prop to `AkTooltip.Tooltip` in `Tooltip.tsx` and some logging:
```js
// Open legacy Tooltip
creating closeWatcher
// Hit ESC
closeWatcher.onclose
destroying closeWatcher
```