### PR TITLE
`Checkbox` prop deprecation

### DIFF
--- a/.changeset/hungry-snakes-judge.md
+++ b/.changeset/hungry-snakes-judge.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-`Checkbox` component props `checkedIcon`, `color`, `disableRipple`, `icon`, and `indeterminateIcon` have been deprecated.
+`Checkbox` component props `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `icon`, `indeterminateIcon`, and `size` have been deprecated.

--- a/.changeset/hungry-snakes-judge.md
+++ b/.changeset/hungry-snakes-judge.md
@@ -1,5 +1,5 @@
 ---
-"@stratakit/mui": patch
+"@stratakit/mui": minor
 ---
 
 `Checkbox` component props `checkedIcon`, `color`, `disableRipple`, `icon`, and `indeterminateIcon` have been deprecated.

--- a/.changeset/hungry-snakes-judge.md
+++ b/.changeset/hungry-snakes-judge.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+`Checkbox` component props `checkedIcon`, `color`, `disableRipple`, `icon`, and `indeterminateIcon` have been deprecated.

--- a/.changeset/hungry-snakes-judge.md
+++ b/.changeset/hungry-snakes-judge.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `icon`, `indeterminateIcon`, and `size` props of `Checkbox`.
+Deprecated `action`, `centerRipple`, `checkedIcon`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `indeterminateIcon`, `LinkComponent`, `size`, `TouchRippleProps`, and `touchRippleRef` props of `Checkbox`.

--- a/.changeset/hungry-snakes-judge.md
+++ b/.changeset/hungry-snakes-judge.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-`Checkbox` component props `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `icon`, `indeterminateIcon`, and `size` have been deprecated.
+Deprecated `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `icon`, `indeterminateIcon`, and `size` props of `Checkbox`.

--- a/apps/website/src/content/docs/components/mui/Checkbox.md
+++ b/apps/website/src/content/docs/components/mui/Checkbox.md
@@ -21,9 +21,8 @@ Make sure the **Checkbox** is suitable for your use case. There may be other, mo
 
 ## StrataKit MUI modifications
 
-- The `checkedIcon`, `disableRipple`, `icon`, and `indeterminateIcon` props are deprecated and should not be used.
+- The `checkedIcon`, `disableRipple`, `icon`, `indeterminateIcon`, and `size` props are not supported.
 - The `color` prop is deprecated. Color is applied automatically based on state (e.g., checked, disabled, error).
-- The `size` prop defaults to `"medium"`, and does not support `"small"` or `"large"`.
 - The checkbox implementation and styling differ from the default `svg` approach and use custom pseudo-elements.
 - The interactive hit area extends beyond the visual bounds of the checkbox. The additional hit area does not consume layout space, so be mindful when placing the checkbox next to adjacent elements or container boundaries.
 - Includes full `forced-colors` support.

--- a/apps/website/src/content/docs/components/mui/Checkbox.md
+++ b/apps/website/src/content/docs/components/mui/Checkbox.md
@@ -21,8 +21,9 @@ Make sure the **Checkbox** is suitable for your use case. There may be other, mo
 
 ## StrataKit MUI modifications
 
-- The `checkedIcon`, `disableRipple`, `icon`, `indeterminateIcon`, and `size` props are not supported.
+- The `action`, `checkedIcon`, `icon`, `indeterminateIcon`, `LinkComponent`, and `size` props are not supported.
 - The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled, error).
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - The checkbox implementation and styling differ from the default `svg` approach and use custom pseudo-elements.
 - The interactive hit area extends beyond the visual bounds of the checkbox. The additional hit area does not consume layout space, so be mindful when placing the checkbox next to adjacent elements or container boundaries.
 - Includes full `forced-colors` support.

--- a/apps/website/src/content/docs/components/mui/Checkbox.md
+++ b/apps/website/src/content/docs/components/mui/Checkbox.md
@@ -22,7 +22,7 @@ Make sure the **Checkbox** is suitable for your use case. There may be other, mo
 ## StrataKit MUI modifications
 
 - The `checkedIcon`, `disableRipple`, `icon`, `indeterminateIcon`, and `size` props are not supported.
-- The `color` prop is deprecated. Color is applied automatically based on state (e.g., checked, disabled, error).
+- The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled, error).
 - The checkbox implementation and styling differ from the default `svg` approach and use custom pseudo-elements.
 - The interactive hit area extends beyond the visual bounds of the checkbox. The additional hit area does not consume layout space, so be mindful when placing the checkbox next to adjacent elements or container boundaries.
 - Includes full `forced-colors` support.

--- a/apps/website/src/content/docs/components/mui/Checkbox.md
+++ b/apps/website/src/content/docs/components/mui/Checkbox.md
@@ -21,8 +21,8 @@ Make sure the **Checkbox** is suitable for your use case. There may be other, mo
 
 ## StrataKit MUI modifications
 
-- The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled, error).
-- The `icon` prop is not supported.
+- The `checkedIcon`, `disableRipple`, `icon`, and `indeterminateIcon` props are deprecated and should not be used.
+- The `color` prop is deprecated. Color is applied automatically based on state (e.g., checked, disabled, error).
 - The `size` prop defaults to `"medium"`, and does not support `"small"` or `"large"`.
 - The checkbox implementation and styling differ from the default `svg` approach and use custom pseudo-elements.
 - The interactive hit area extends beyond the visual bounds of the checkbox. The additional hit area does not consume layout space, so be mindful when placing the checkbox next to adjacent elements or container boundaries.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -281,6 +281,12 @@ declare module "@mui/material/Checkbox" {
 		disableRipple?: CheckboxProps["disableRipple"];
 
 		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableTouchRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
 		icon?: CheckboxProps["icon"];
 
 		/** @deprecated StrataKit does not support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -11,6 +11,7 @@ import type { RoleProps } from "@ariakit/react/role";
 import type { AlertProps } from "@mui/material/Alert";
 import type { BadgeProps } from "@mui/material/Badge";
 import type { ButtonBaseProps } from "@mui/material/ButtonBase";
+import type { CheckboxProps } from "@mui/material/Checkbox";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type {
@@ -270,7 +271,7 @@ declare module "@mui/material/CardActionArea" {
 }
 
 declare module "@mui/material/Checkbox" {
-	interface CheckboxProps {
+	interface CheckboxProps extends CheckboxDeprecatedProps {
 		/** @deprecated StrataKit does not support this prop. */
 		checkedIcon?: CheckboxProps["checkedIcon"];
 
@@ -309,6 +310,37 @@ declare module "@mui/material/Checkbox" {
 		small: false;
 		large: false;
 	}
+
+	export default function Checkbox(
+		props: Omit<CheckboxProps, keyof CheckboxDeprecatedProps> &
+			CheckboxDeprecatedProps,
+	): React.JSX.Element;
+}
+
+interface CheckboxDeprecatedProps extends ButtonBaseDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	checkedIcon?: CheckboxProps["checkedIcon"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	color?: CheckboxProps["color"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableRipple?: CheckboxProps["disableRipple"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableFocusRipple?: boolean;
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableTouchRipple?: boolean;
+
+	/** @deprecated StrataKit does not support this prop. */
+	icon?: CheckboxProps["icon"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	indeterminateIcon?: CheckboxProps["indeterminateIcon"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	size?: CheckboxProps["size"];
 }
 
 declare module "@mui/material/Chip" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -270,13 +270,21 @@ declare module "@mui/material/CardActionArea" {
 }
 
 declare module "@mui/material/Checkbox" {
-	interface CheckboxPropsColorOverrides {
-		secondary: false;
-		default: false;
-		info: false;
-		success: false;
-		warning: false;
-		error: false;
+	interface CheckboxProps {
+		/** @deprecated DO NOT USE. */
+		checkedIcon?: CheckboxProps["checkedIcon"];
+
+		/** @deprecated DO NOT USE. */
+		color?: CheckboxProps["color"];
+
+		/** @deprecated DO NOT USE. */
+		disableRipple?: CheckboxProps["disableRipple"];
+
+		/** @deprecated DO NOT USE. */
+		icon?: CheckboxProps["icon"];
+
+		/** @deprecated DO NOT USE. */
+		indeterminateIcon?: CheckboxProps["indeterminateIcon"];
 	}
 
 	interface CheckboxPropsSizeOverrides {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -290,6 +290,15 @@ declare module "@mui/material/Checkbox" {
 		size?: CheckboxProps["size"];
 	}
 
+	interface CheckboxPropsColorOverrides {
+		secondary: false;
+		default: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+
 	interface CheckboxPropsSizeOverrides {
 		small: false;
 		large: false;

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -285,9 +285,6 @@ declare module "@mui/material/Checkbox" {
 		disableFocusRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableTouchRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
 		icon?: CheckboxProps["icon"];
 
 		/** @deprecated StrataKit does not support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -325,13 +325,7 @@ interface CheckboxDeprecatedProps extends ButtonBaseDeprecatedProps {
 	color?: CheckboxProps["color"];
 
 	/** @deprecated StrataKit does not support this prop. */
-	disableRipple?: CheckboxProps["disableRipple"];
-
-	/** @deprecated StrataKit does not support this prop. */
-	disableFocusRipple?: boolean;
-
-	/** @deprecated StrataKit does not support this prop. */
-	disableTouchRipple?: boolean;
+	disableFocusRipple?: CheckboxProps["disableFocusRipple"];
 
 	/** @deprecated StrataKit does not support this prop. */
 	icon?: CheckboxProps["icon"];

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -285,6 +285,9 @@ declare module "@mui/material/Checkbox" {
 
 		/** @deprecated StrataKit does not support this prop. */
 		indeterminateIcon?: CheckboxProps["indeterminateIcon"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		size?: CheckboxProps["size"];
 	}
 
 	interface CheckboxPropsSizeOverrides {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -271,19 +271,19 @@ declare module "@mui/material/CardActionArea" {
 
 declare module "@mui/material/Checkbox" {
 	interface CheckboxProps {
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		checkedIcon?: CheckboxProps["checkedIcon"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		color?: CheckboxProps["color"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		disableRipple?: CheckboxProps["disableRipple"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		icon?: CheckboxProps["icon"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		indeterminateIcon?: CheckboxProps["indeterminateIcon"];
 	}
 


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17623701.

- `action`
- `centerRipple`
- `checkedIcon`
- `color`
- `disableFocusRipple`
- `disableRipple`
- `disableTouchRipple`
- `focusRipple`
- `icon`
- `indeterminateIcon`
- `LinkComponent`
- `size`
- `TouchRippleProps`
- `touchRippleRef`

### Testing

- Confirmed deprecated props when applied have a strikethrough in VSCode. 
<img width="335" height="553" alt="Screenshot 2026-08-19 at 1 56 07 PM" src="https://github.com/user-attachments/assets/8510c0c1-1d2c-4d5a-86e9-c4e2da8f87ae" />


```tsx
export default () => {
	return (
		<Checkbox
			checkedIcon={undefined}
			color={undefined}
			disableRipple={true}
			disableFocusRipple={undefined}
			disableTouchRipple={true}
			icon={undefined}
			indeterminateIcon={undefined}
			size="medium"
			action={undefined}
			centerRipple={undefined}
			focusRipple={true}
			LinkComponent={undefined}
			TouchRippleProps={undefined}
			touchRippleRef={undefined}
		/>
	);
};

const x: CheckboxProps = {};
x.disableFocusRipple;
x.disableRipple;
x.disableTouchRipple;
```