### PR TITLE
`Radio` prop deprecation

### DIFF
--- a/.changeset/fuzzy-radios-listen.md
+++ b/.changeset/fuzzy-radios-listen.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `action`, `centerRipple`, `checkedIcon`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `LinkComponent`, `size`, `TouchRippleProps`, and `touchRippleRef` props of `Radio`.

--- a/.changeset/solid-cars-peel.md
+++ b/.changeset/solid-cars-peel.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+`Radio` component props `checkedIcon`, `color`, `disableRipple`, and `icon` have been deprecated.

--- a/.changeset/solid-cars-peel.md
+++ b/.changeset/solid-cars-peel.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-`Radio` component props `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `icon`, and `size` have been deprecated.
+Deprecated `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `icon`, and `size` props of `Radio`.

--- a/.changeset/solid-cars-peel.md
+++ b/.changeset/solid-cars-peel.md
@@ -1,5 +1,5 @@
 ---
-"@stratakit/mui": patch
+"@stratakit/mui": minor
 ---
 
 `Radio` component props `checkedIcon`, `color`, `disableRipple`, and `icon` have been deprecated.

--- a/.changeset/solid-cars-peel.md
+++ b/.changeset/solid-cars-peel.md
@@ -1,5 +1,0 @@
----
-"@stratakit/mui": minor
----
-
-Deprecated `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `icon`, and `size` props of `Radio`.

--- a/.changeset/solid-cars-peel.md
+++ b/.changeset/solid-cars-peel.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-`Radio` component props `checkedIcon`, `color`, `disableRipple`, and `icon` have been deprecated.
+`Radio` component props `checkedIcon`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `icon`, and `size` have been deprecated.

--- a/apps/website/src/content/docs/components/mui/Radio.md
+++ b/apps/website/src/content/docs/components/mui/Radio.md
@@ -21,9 +21,8 @@ Make sure the **Radio** is suitable for your use case. There may be other, more 
 
 ## StrataKit MUI modifications
 
-- The `checkedIcon`, `disableRipple`, and `icon` props are deprecated and should not be used.
+- The `checkedIcon`, `disableRipple`, `icon`, and `size` props are not supported.
 - The `color` prop is deprecated. Color is applied automatically based on state (e.g., checked, disabled, error).
-- The `size` prop defaults to `"medium"` and does not support `"small"`.
 - The radio implementation and styling differ from the default `svg` approach and use custom pseudo-elements.
 - The interactive hit area extends beyond the visual bounds of the radio. The additional hit area does not consume layout space, so be mindful when placing the radio next to adjacent elements or container boundaries.
 - Includes full `forced-colors` support.

--- a/apps/website/src/content/docs/components/mui/Radio.md
+++ b/apps/website/src/content/docs/components/mui/Radio.md
@@ -22,7 +22,7 @@ Make sure the **Radio** is suitable for your use case. There may be other, more 
 ## StrataKit MUI modifications
 
 - The `checkedIcon`, `disableRipple`, `icon`, and `size` props are not supported.
-- The `color` prop is deprecated. Color is applied automatically based on state (e.g., checked, disabled, error).
+- The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled, error).
 - The radio implementation and styling differ from the default `svg` approach and use custom pseudo-elements.
 - The interactive hit area extends beyond the visual bounds of the radio. The additional hit area does not consume layout space, so be mindful when placing the radio next to adjacent elements or container boundaries.
 - Includes full `forced-colors` support.

--- a/apps/website/src/content/docs/components/mui/Radio.md
+++ b/apps/website/src/content/docs/components/mui/Radio.md
@@ -21,8 +21,9 @@ Make sure the **Radio** is suitable for your use case. There may be other, more 
 
 ## StrataKit MUI modifications
 
-- The `checkedIcon`, `disableRipple`, `icon`, and `size` props are not supported.
+- The `action`, `checkedIcon`, `icon`, `LinkComponent`, and `size` props are not supported.
 - The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled, error).
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - The radio implementation and styling differ from the default `svg` approach and use custom pseudo-elements.
 - The interactive hit area extends beyond the visual bounds of the radio. The additional hit area does not consume layout space, so be mindful when placing the radio next to adjacent elements or container boundaries.
 - Includes full `forced-colors` support.

--- a/apps/website/src/content/docs/components/mui/Radio.md
+++ b/apps/website/src/content/docs/components/mui/Radio.md
@@ -21,7 +21,8 @@ Make sure the **Radio** is suitable for your use case. There may be other, more 
 
 ## StrataKit MUI modifications
 
-- The `color` prop is not supported. Color is determined automatically based on state (e.g., checked, disabled, error).
+- The `checkedIcon`, `disableRipple`, and `icon` props are deprecated and should not be used.
+- The `color` prop is deprecated. Color is applied automatically based on state (e.g., checked, disabled, error).
 - The `size` prop defaults to `"medium"` and does not support `"small"`.
 - The radio implementation and styling differ from the default `svg` approach and use custom pseudo-elements.
 - The interactive hit area extends beyond the visual bounds of the radio. The additional hit area does not consume layout space, so be mindful when placing the radio next to adjacent elements or container boundaries.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -505,16 +505,16 @@ declare module "@mui/material/PaginationItem" {
 
 declare module "@mui/material/Radio" {
 	interface RadioProps {
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		checkedIcon?: RadioProps["checkedIcon"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		color?: RadioProps["color"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		disableRipple?: RadioProps["disableRipple"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		icon?: RadioProps["icon"];
 	}
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -515,6 +515,12 @@ declare module "@mui/material/Radio" {
 		disableRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableTouchRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
 		icon?: RadioProps["icon"];
 
 		/** @deprecated StrataKit does not support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -19,6 +19,7 @@ import type {
 	DefaultComponentProps,
 	OverridableTypeMap,
 } from "@mui/material/OverridableComponent";
+import type { RadioProps } from "@mui/material/Radio";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
@@ -504,7 +505,7 @@ declare module "@mui/material/PaginationItem" {
 }
 
 declare module "@mui/material/Radio" {
-	interface RadioProps {
+	interface RadioProps extends RadioDeprecatedProps {
 		/** @deprecated StrataKit does not support this prop. */
 		checkedIcon?: RadioProps["checkedIcon"];
 
@@ -539,6 +540,33 @@ declare module "@mui/material/Radio" {
 	interface RadioPropsSizeOverrides {
 		small: false;
 	}
+
+	export default function Radio(
+		props: Omit<RadioProps, keyof RadioDeprecatedProps> & RadioDeprecatedProps,
+	): React.JSX.Element;
+}
+
+interface RadioDeprecatedProps extends ButtonBaseDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	checkedIcon?: RadioProps["checkedIcon"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	color?: RadioProps["color"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableRipple?: boolean;
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableFocusRipple?: boolean;
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableTouchRipple?: boolean;
+
+	/** @deprecated StrataKit does not support this prop. */
+	icon?: RadioProps["icon"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	size?: RadioProps["size"];
 }
 
 declare module "@mui/material/Slider" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -518,6 +518,15 @@ declare module "@mui/material/Radio" {
 		icon?: RadioProps["icon"];
 	}
 
+	interface RadioPropsColorOverrides {
+		secondary: false;
+		default: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+
 	interface RadioPropsSizeOverrides {
 		small: false;
 	}

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -504,13 +504,18 @@ declare module "@mui/material/PaginationItem" {
 }
 
 declare module "@mui/material/Radio" {
-	interface RadioPropsColorOverrides {
-		secondary: false;
-		default: false;
-		info: false;
-		success: false;
-		warning: false;
-		error: false;
+	interface RadioProps {
+		/** @deprecated DO NOT USE. */
+		checkedIcon?: RadioProps["checkedIcon"];
+
+		/** @deprecated DO NOT USE. */
+		color?: RadioProps["color"];
+
+		/** @deprecated DO NOT USE. */
+		disableRipple?: RadioProps["disableRipple"];
+
+		/** @deprecated DO NOT USE. */
+		icon?: RadioProps["icon"];
 	}
 
 	interface RadioPropsSizeOverrides {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -516,6 +516,9 @@ declare module "@mui/material/Radio" {
 
 		/** @deprecated StrataKit does not support this prop. */
 		icon?: RadioProps["icon"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		size?: RadioProps["size"];
 	}
 
 	interface RadioPropsColorOverrides {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -513,15 +513,6 @@ declare module "@mui/material/Radio" {
 		color?: RadioProps["color"];
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
-		disableFocusRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
-		disableTouchRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
 		icon?: RadioProps["icon"];
 
 		/** @deprecated StrataKit does not support this prop. */
@@ -554,13 +545,7 @@ interface RadioDeprecatedProps extends ButtonBaseDeprecatedProps {
 	color?: RadioProps["color"];
 
 	/** @deprecated StrataKit does not support this prop. */
-	disableRipple?: boolean;
-
-	/** @deprecated StrataKit does not support this prop. */
-	disableFocusRipple?: boolean;
-
-	/** @deprecated StrataKit does not support this prop. */
-	disableTouchRipple?: boolean;
+	disableFocusRipple?: RadioProps["disableFocusRipple"];
 
 	/** @deprecated StrataKit does not support this prop. */
 	icon?: RadioProps["icon"];

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -513,6 +513,15 @@ declare module "@mui/material/Radio" {
 		color?: RadioProps["color"];
 
 		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableTouchRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
 		icon?: RadioProps["icon"];
 
 		/** @deprecated StrataKit does not support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -516,9 +516,6 @@ declare module "@mui/material/Radio" {
 		disableRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableFocusRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
 		disableTouchRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -512,7 +512,7 @@ declare module "@mui/material/Radio" {
 		color?: RadioProps["color"];
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: RadioProps["disableRipple"];
+		disableRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
 		icon?: RadioProps["icon"];


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17623701.

- `action`
- `centerRipple`
- `checkedIcon`
- `color`
- `disableFocusRipple`
- `disableRipple`
- `disableTouchRipple`
- `focusRipple`
- `icon`
- `LinkComponent`
- `size`
- `TouchRippleProps`
- `touchRippleRef`

### Testing

- Confirmed deprecated props when applied have a strikethrough in VSCode. 
<img width="337" height="524" alt="Screenshot 2026-08-19 at 4 05 43 PM" src="https://github.com/user-attachments/assets/3b90ceaf-eec7-4716-8023-1984f950baf8" />

```tsx
export default () => {
	return (
		<Radio
			checkedIcon={undefined}
			color={undefined}
			disableRipple={true}
			disableFocusRipple={undefined}
			disableTouchRipple={true}
			icon={undefined}
			size="medium"
			action={undefined}
			centerRipple={undefined}
			focusRipple={true}
			LinkComponent={undefined}
			TouchRippleProps={undefined}
			touchRippleRef={undefined}
		/>
	);
};

const x: RadioProps = {};
x.disableFocusRipple;
x.disableRipple;
x.disableTouchRipple;
```
