### PR TITLE
Deprecate props from autocomplete

### DIFF
--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -125,6 +125,23 @@ declare module "@mui/material/Avatar" {
 	}
 }
 
+declare module "@mui/material/Autocomplete" {
+	interface AutocompleteProps<
+		Value,
+		Multiple extends boolean | undefined,
+		DisableClearable extends boolean | undefined,
+		FreeSolo extends boolean | undefined,
+		ChipComponent extends React.ElementType,
+	> {
+		/** @deprecated StrataKit does not support customizing the clear icon*/
+		clearIcon?: React.ReactNode;
+		/** @deprecated StrataKit does not support this prop */
+		forcePopupIcon?: boolean | "auto";
+		/** @deprecated StrataKit does not support customizing the popup icon */
+		popupIcon?: React.ReactNode;
+	}
+}
+
 declare module "@mui/material/AvatarGroup" {
 	interface AvatarGroupPropsVariantOverrides {
 		circular: false;


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecates props from Autocomplete from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17573111

### Testing

Check in VS code to make sure there is a strikethrough

<img width="709" height="597" alt="image" src="https://github.com/user-attachments/assets/c2626577-041d-414d-b781-9af6320b801d" />
