### PR TITLE
update deprecation wording

### DIFF
--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -245,7 +245,7 @@ declare module "@mui/material/Chip" {
 		 */
 		deleteLabel?: string;
 
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		color?: never;
 	}
 
@@ -364,7 +364,7 @@ declare module "@mui/material/InputBase" {
 
 declare module "@mui/material/Link" {
 	interface LinkOwnProps {
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		underline?: "none" | "hover" | "always";
 	}
 }
@@ -463,13 +463,13 @@ declare module "@mui/material/Tabs" {
 		 */
 		size?: "small" | "medium";
 
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		indicatorColor?: TabsProps["indicatorColor"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		allowScrollButtonsMobile?: boolean;
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		scrollButtons?: TabsProps["scrollButtons"];
 	}
 }
@@ -499,7 +499,7 @@ declare module "@mui/material/TextField" {
 
 	export default function TextField(
 		props: {
-			/** @deprecated DO NOT USE */ variant?: TextFieldVariants;
+			/** @deprecated StrataKit does not support this prop. */ variant?: TextFieldVariants;
 		} & Omit<TextFieldProps, "variant">,
 	): React.JSX.Element;
 }


### PR DESCRIPTION
### Changes

Updates all instances of `@deprecated` jsdoc comments to use the wording decided in https://github.com/iTwin/stratakit/pull/1678#discussion_r3691182031.

Merging into `next`, not `main`.

### Testing

N/A