### PR TITLE
Deprecate alert color

### DIFF
--- a/.changeset/goofy-birds-retire.md
+++ b/.changeset/goofy-birds-retire.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color` prop of `Alert`.

--- a/apps/website/src/content/docs/components/mui/Alert.md
+++ b/apps/website/src/content/docs/components/mui/Alert.md
@@ -14,7 +14,7 @@ links:
 - The `"standard"` variant has been removed. The default variant is now `"outlined"`.
 - The default severity is now a new `"none"` value instead of `"success"`.
 - The **Alert** will no longer create a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) by default. It now uses [`role="group"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role) instead of [`role="alert"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role).
-- The `color` props is deprecated. Color is based on `severity`.
+- The `color` prop is deprecated. Color is applied automatically based on `severity`.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Alert.md
+++ b/apps/website/src/content/docs/components/mui/Alert.md
@@ -14,6 +14,7 @@ links:
 - The `"standard"` variant has been removed. The default variant is now `"outlined"`.
 - The default severity is now a new `"none"` value instead of `"success"`.
 - The **Alert** will no longer create a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) by default. It now uses [`role="group"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role) instead of [`role="alert"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role).
+- The `color` props is deprecated. Color is based on `severity`.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -8,7 +8,6 @@
 // See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
 
 import type { RoleProps } from "@ariakit/react/role";
-import type { AlertProps } from "@mui/material/Alert";
 import type { BadgeProps } from "@mui/material/Badge";
 import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { CheckboxProps } from "@mui/material/Checkbox";
@@ -93,7 +92,7 @@ declare module "@mui/material/Alert" {
 		none: true;
 	}
 
-	interface AlertOwnProps {
+	interface AlertProps {
 		/**
 		 * The default variant with `@stratakit/mui` is `"outlined"`.
 		 *
@@ -107,6 +106,11 @@ declare module "@mui/material/Alert" {
 		 * @default 'none'
 		 */
 		severity?: AlertProps["severity"];
+
+		/**
+		 * @deprecated Color is determined by severity
+		 */
+		color?: AlertProps["color"];
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecate color props of Alert. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17586832

Also fixes mistake in the typing. `AlertOwnProps` does not exist.

<img width="2089" height="603" alt="image" src="https://github.com/user-attachments/assets/92262aea-8f09-46e2-bb92-c37c411a7257" />


### Testing

- Verify color prop has  strikethrough in VS code
- Review documentation to make sure it mentions deprecating