### PR TITLE
start the 1.0 release stack

### DIFF
--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -245,7 +245,7 @@ declare module "@mui/material/Chip" {
 		 */
 		deleteLabel?: string;
 
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		color?: never;
 	}
 
@@ -382,7 +382,7 @@ declare module "@mui/material/InputBase" {
 
 declare module "@mui/material/Link" {
 	interface LinkOwnProps {
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		underline?: "none" | "hover" | "always";
 	}
 }
@@ -481,13 +481,13 @@ declare module "@mui/material/Tabs" {
 		 */
 		size?: "small" | "medium";
 
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		indicatorColor?: TabsProps["indicatorColor"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		allowScrollButtonsMobile?: boolean;
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		scrollButtons?: TabsProps["scrollButtons"];
 	}
 }
@@ -517,7 +517,7 @@ declare module "@mui/material/TextField" {
 
 	export default function TextField(
 		props: {
-			/** @deprecated DO NOT USE */ variant?: TextFieldVariants;
+			/** @deprecated StrataKit does not support this prop. */ variant?: TextFieldVariants;
 		} & Omit<TextFieldProps, "variant">,
 	): React.JSX.Element;
 }


### PR DESCRIPTION
This is a PR from the [`next`](https://github.com/iTwin/stratakit/tree/next) branch targeting `main`. While this PR itself currently only contains https://github.com/iTwin/stratakit/pull/1684, it is the start of a big [stack](https://github.github.com/gh-stack/) of PRs containing all the breaking API changes that are planned for `@stratakit/mui@1.0`. The entire stack is intended to merge together, directly into `main`.

<details>
<summary>PR list</summary>

Stack #1755:

1. https://github.com/iTwin/stratakit/pull/1686
1. https://github.com/iTwin/stratakit/pull/1701
1. https://github.com/iTwin/stratakit/pull/1677
1. https://github.com/iTwin/stratakit/pull/1678
1. https://github.com/iTwin/stratakit/pull/1685
1. https://github.com/iTwin/stratakit/pull/1612
1. https://github.com/iTwin/stratakit/pull/1699
1. https://github.com/iTwin/stratakit/pull/1703
1. https://github.com/iTwin/stratakit/pull/1702
1. https://github.com/iTwin/stratakit/pull/1704
1. https://github.com/iTwin/stratakit/pull/1705
1. https://github.com/iTwin/stratakit/pull/1712
1. https://github.com/iTwin/stratakit/pull/1720
1. https://github.com/iTwin/stratakit/pull/1732
1. https://github.com/iTwin/stratakit/pull/1741
1. https://github.com/iTwin/stratakit/pull/1743
1. https://github.com/iTwin/stratakit/pull/1745
1. https://github.com/iTwin/stratakit/pull/1753
1. https://github.com/iTwin/stratakit/pull/1708
1. https://github.com/iTwin/stratakit/pull/1723
1. https://github.com/iTwin/stratakit/pull/1724
1. https://github.com/iTwin/stratakit/pull/1727
1. https://github.com/iTwin/stratakit/pull/1737
1. https://github.com/iTwin/stratakit/pull/1738
1. https://github.com/iTwin/stratakit/pull/1695
1. https://github.com/iTwin/stratakit/pull/1714
1. https://github.com/iTwin/stratakit/pull/1715
1. https://github.com/iTwin/stratakit/pull/1733
1. https://github.com/iTwin/stratakit/pull/1716
1. https://github.com/iTwin/stratakit/pull/1717
1. https://github.com/iTwin/stratakit/pull/1722
1. https://github.com/iTwin/stratakit/pull/1725
1. https://github.com/iTwin/stratakit/pull/1757
1. https://github.com/iTwin/stratakit/pull/1748
1. https://github.com/iTwin/stratakit/pull/1711
1. https://github.com/iTwin/stratakit/pull/1726
1. https://github.com/iTwin/stratakit/pull/1728
1. https://github.com/iTwin/stratakit/pull/1746
1. https://github.com/iTwin/stratakit/pull/1747
1. https://github.com/iTwin/stratakit/pull/1742
1. https://github.com/iTwin/stratakit/pull/1735
1. https://github.com/iTwin/stratakit/pull/1729
1. https://github.com/iTwin/stratakit/pull/1763
1. https://github.com/iTwin/stratakit/pull/1764
1. https://github.com/iTwin/stratakit/pull/1766
1. https://github.com/iTwin/stratakit/pull/1767
1. https://github.com/iTwin/stratakit/pull/1768
1. https://github.com/iTwin/stratakit/pull/1650
1. https://github.com/iTwin/stratakit/pull/1776
1. https://github.com/iTwin/stratakit/pull/1779
1. https://github.com/iTwin/stratakit/pull/1780

</details>

This branch/stack served as a useful place to collect breaking changes without blocking non-breaking changes from merging independently into `main` (the last of such non-breaking changes were released in #1687). Unlike a traditional "release branch" workflow, using the gh PR stack feature allows us to keep a clean linear history (no merge commits) and preserves individual verified commits (no rebase, no squash).

Once this PR merges, the `main` branch will be locked out of releasing any further patch versions for `@stratakit/mui`.