### PR TITLE
Deprecate props on Button

### DIFF
--- a/.changeset/tricky-drinks-lose.md
+++ b/.changeset/tricky-drinks-lose.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecate `action`, `centerRipple`, `disableElevation`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `TouchRippleProps`, `touchRippleRef`, and `LinkComponent` props of `Button`

--- a/apps/website/src/content/docs/components/mui/Button.md
+++ b/apps/website/src/content/docs/components/mui/Button.md
@@ -25,7 +25,8 @@ Make sure the **Button** is suitable for your use case. There may be other, more
 Modifications to `ButtonBase` (applies to all MUI components that extend `ButtonBase`):
 
 - The `LinkComponent` prop is not supported. Use the more flexible `render` prop instead.
-- Ripple effect removed.
+- Ripple effect removed. Props related to ripple are deprecated.
+- The `action` prop is not supported. Use `ref` prop instead.
 
 Modifications specific to `Button`:
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -245,7 +245,7 @@ declare module "@mui/material/Chip" {
 		 */
 		deleteLabel?: string;
 
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		color?: never;
 	}
 
@@ -364,7 +364,7 @@ declare module "@mui/material/InputBase" {
 
 declare module "@mui/material/Link" {
 	interface LinkOwnProps {
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		underline?: "none" | "hover" | "always";
 	}
 }
@@ -463,13 +463,13 @@ declare module "@mui/material/Tabs" {
 		 */
 		size?: "small" | "medium";
 
-		/** @deprecated DO NOT USE */
+		/** @deprecated StrataKit does not support this prop. */
 		indicatorColor?: TabsProps["indicatorColor"];
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		allowScrollButtonsMobile?: boolean;
 
-		/** @deprecated DO NOT USE. */
+		/** @deprecated StrataKit does not support this prop. */
 		scrollButtons?: TabsProps["scrollButtons"];
 	}
 }
@@ -499,7 +499,7 @@ declare module "@mui/material/TextField" {
 
 	export default function TextField(
 		props: {
-			/** @deprecated DO NOT USE */ variant?: TextFieldVariants;
+			/** @deprecated StrataKit does not support this prop. */ variant?: TextFieldVariants;
 		} & Omit<TextFieldProps, "variant">,
 	): React.JSX.Element;
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -10,6 +10,11 @@
 import type { RoleProps } from "@ariakit/react/role";
 import type { AlertProps } from "@mui/material/Alert";
 import type { BadgeProps } from "@mui/material/Badge";
+import type {
+	ButtonBaseActions,
+	TouchRippleActions,
+	TouchRippleProps,
+} from "@mui/material/ButtonBase";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type {
@@ -186,7 +191,35 @@ declare module "@mui/material/Button" {
 	}
 
 	interface ButtonOwnProps {
+		/** @deprecated Use the `ref` prop instead. */
+		action?: React.Ref<ButtonBaseActions> | undefined;
+
+		/** @deprecated StrataKit does not support this prop. */
+		centerRipple?: boolean;
+
+		/** @deprecated Use `variant` instead. */
+		disableElevation?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: boolean | undefined;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: boolean | undefined;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableTouchRipple?: boolean | undefined;
+
+		/** @deprecated StrataKit does not support this prop. */
+		focusRipple?: boolean | undefined;
+
+		/** @deprecated Use the `render` prop instead. */
 		LinkComponent?: never;
+
+		/** @deprecated StrataKit does not support this prop. */
+		TouchRippleProps?: Partial<TouchRippleProps> | undefined;
+
+		/** @deprecated StrataKit does not support this prop. */
+		touchRippleRef?: React.Ref<TouchRippleActions> | undefined;
 
 		/**
 		 * The default variant with `@stratakit/mui` is `"contained"`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -201,10 +201,10 @@ declare module "@mui/material/Button" {
 		disableElevation?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: boolean | undefined;
+		disableFocusRipple?: boolean | undefined;
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableFocusRipple?: boolean | undefined;
+		disableRipple?: boolean | undefined;
 
 		/** @deprecated StrataKit does not support this prop. */
 		disableTouchRipple?: boolean | undefined;


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecate the following props on Button:

- action
- centerRipple
- disableElevation
- disableRipple
- disableFocusRipple
- disableTouchRipple
- TouchRippleProps
- touchRippleRef
- LinkComponent - was set to never but this also deprecates in docs

These deprecations occur on `ButtonOwnProps` instead of `ButtonBaseOwnProps` where they are originally defined. VS Code only does the strikethrough on deprecated props if all of the JS Doc instances agree that it is deprecated and ButtonBaseOwnProps includes docs that don't deprecate them. So I bumped them up to `ButtonOwnProps` which doesn't explicitly document them instead.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17857139


<img width="751" height="381" alt="image" src="https://github.com/user-attachments/assets/ead7a3f1-96a3-4a02-afc1-212c8387bc7b" />

### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
