### PR TITLE
`Link` `color` prop value deprecations

### DIFF
--- a/.changeset/odd-baths-drop.md
+++ b/.changeset/odd-baths-drop.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Removed the following values from the `color` prop of `Link`: `"textSecondary"` and `"textDisabled"`.
+Removed the following values from the `color` prop of `Link`: `"textSecondary"`, `"textTertiary"`, and `"textDisabled"`.

--- a/.changeset/odd-baths-drop.md
+++ b/.changeset/odd-baths-drop.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Removed the following values from the `color` prop of `Link`: `"textSecondary"` and `"textDisabled"`.

--- a/apps/website/src/content/docs/components/mui/Link.md
+++ b/apps/website/src/content/docs/components/mui/Link.md
@@ -12,6 +12,7 @@ links:
 
 - Restyled using StrataKit's visual language.
 - The `underline` prop is not supported. Links are always underlined.
+- The `"textSecondary"` and `"textDisabled"` colors have been removed.
 
 ## Use cases
 

--- a/apps/website/src/content/docs/components/mui/Link.md
+++ b/apps/website/src/content/docs/components/mui/Link.md
@@ -12,7 +12,7 @@ links:
 
 - Restyled using StrataKit's visual language.
 - The `underline` prop is not supported. Links are always underlined.
-- The `"textSecondary"` and `"textDisabled"` colors have been removed.
+- The `"textSecondary"`, `"textTertiary"`, and `"textDisabled"` colors have been removed.
 
 ## Use cases
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1119,19 +1119,33 @@ type TypographyHeadingVariantProps = {
 	render: NonNullable<RoleProps["render"]>;
 };
 
+// These are defined separately so that they only get added to `Typography`,
+// and not to inherited components like `Link`.
+type TypographyColorProps = {
+	color?:
+		| TypographyProps["color"]
+		| "textSecondary"
+		| "textTertiary"
+		| "textDisabled";
+};
+
 type TypographyOverridableComponentProps<TypeMap extends OverridableTypeMap> =
 	TypeMap extends TypographyTypeMap
-		? Omit<
-				DefaultComponentProps<TypeMap>,
-				keyof TypographyHeadingVariantProps
-			> &
-				TypographyHeadingVariantProps
+		?
+				| (Omit<
+						DefaultComponentProps<TypeMap>,
+						keyof TypographyHeadingVariantProps | "color"
+				  > &
+						TypographyHeadingVariantProps &
+						TypographyColorProps)
+				| (Omit<DefaultComponentProps<TypeMap>, "color"> & TypographyColorProps)
 		: never;
 
 declare module "@mui/material/Typography" {
 	interface TypographyPropsColorOverrides {
 		secondary: false;
-		textTertiary: true;
+		textSecondary: false;
+		textDisabled: false;
 	}
 
 	interface TypographyPropsVariantOverrides {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -710,6 +710,7 @@ declare module "@mui/material/Link" {
 
 	interface LinkPropsColorOverrides {
 		textSecondary: false;
+		textTertiary: false;
 		textDisabled: false;
 	}
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -707,12 +707,6 @@ declare module "@mui/material/Link" {
 		/** @deprecated StrataKit does not support this prop. */
 		underline?: "none" | "hover" | "always";
 	}
-
-	interface LinkPropsColorOverrides {
-		textSecondary: false;
-		textTertiary: false;
-		textDisabled: false;
-	}
 }
 
 declare module "@mui/material/ListItemButton" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1125,7 +1125,7 @@ type TypographyColorProps = {
 	color?:
 		| TypographyProps["color"]
 		| "textSecondary"
-		| "textTertiary"
+		| "textTertiary" // New
 		| "textDisabled";
 };
 
@@ -1144,8 +1144,8 @@ type TypographyOverridableComponentProps<TypeMap extends OverridableTypeMap> =
 declare module "@mui/material/Typography" {
 	interface TypographyPropsColorOverrides {
 		secondary: false;
-		textSecondary: false;
-		textDisabled: false;
+		textSecondary: false; // Re-added above via TypographyColorProps.
+		textDisabled: false; // Re-added above via TypographyColorProps.
 	}
 
 	interface TypographyPropsVariantOverrides {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -707,6 +707,11 @@ declare module "@mui/material/Link" {
 		/** @deprecated StrataKit does not support this prop. */
 		underline?: "none" | "hover" | "always";
 	}
+
+	interface LinkPropsColorOverrides {
+		textSecondary: false;
+		textDisabled: false;
+	}
 }
 
 declare module "@mui/material/ListItemButton" {


### PR DESCRIPTION
### Changes

From https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17884960.

- Remove options from `color`:
	- `"textSecondary"`
	- `"textTertiary"`
	- `"textDisabled"`

Required redefining the `color` prop for `Typography`. https://github.com/iTwin/stratakit/pull/1695#discussion_r3737155358

### Testing

| Before | After |
| - | - |
| <img width="654" height="256" alt="Screenshot 2026-08-07 at 2 02 03 PM" src="https://github.com/user-attachments/assets/38534042-f950-4191-a597-fe5740c5c52c" /> | <img width="658" height="193" alt="Screenshot 2026-08-07 at 1 59 02 PM" src="https://github.com/user-attachments/assets/fc328058-31b8-4f23-8b5e-ac3ef2ad9dfe" /> |
