### PR TITLE
`ToggleButton` prop deprecation

### DIFF
--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -178,9 +178,56 @@ declare module "@mui/material/Badge" {
 
 declare module "@mui/material/ButtonBase" {
 	interface ButtonBaseOwnProps {
+		/** @deprecated Use `ref` instead. */
+		action?: ButtonBaseOwnProps["action"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		centerRipple?: ButtonBaseOwnProps["centerRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: ButtonBaseOwnProps["disableRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableTouchRipple?: ButtonBaseOwnProps["disableTouchRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		focusRipple?: ButtonBaseOwnProps["focusRipple"];
+
 		/** @deprecated Use the `render` prop instead. */
-		LinkComponent?: React.ElementType;
+		LinkComponent?: ButtonBaseOwnProps["LinkComponent"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		TouchRippleProps?: ButtonBaseOwnProps["TouchRippleProps"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		touchRippleRef?: ButtonBaseOwnProps["touchRippleRef"];
 	}
+}
+
+interface ButtonBaseDeprecatedProps {
+	/** @deprecated Use `ref` prop instead. */
+	action?: ButtonBaseProps["action"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	centerRipple?: ButtonBaseProps["centerRipple"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableRipple?: ButtonBaseProps["disableRipple"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableTouchRipple?: ButtonBaseProps["disableTouchRipple"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	focusRipple?: ButtonBaseProps["focusRipple"];
+
+	/** @deprecated Use the `render` prop instead. */
+	LinkComponent?: ButtonBaseProps["LinkComponent"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	TouchRippleProps?: ButtonBaseProps["TouchRippleProps"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	touchRippleRef?: ButtonBaseProps["touchRippleRef"];
 }
 
 declare module "@mui/material/Button" {
@@ -552,7 +599,7 @@ declare module "@mui/material/TextField" {
 }
 
 declare module "@mui/material/ToggleButton" {
-	interface ToggleButtonOwnProps {
+	interface ToggleButtonOwnProps extends ButtonBaseDeprecatedProps {
 		/** @deprecated `color` is unnecessary. Only `"standard"` is supported and already the default. */
 		color?: ToggleButtonProps["color"];
 
@@ -560,11 +607,9 @@ declare module "@mui/material/ToggleButton" {
 		disableFocusRipple?: ToggleButtonProps["disableFocusRipple"];
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: ButtonBaseProps["disableRipple"];
-
-		/** @deprecated StrataKit does not support this prop. */
 		fullWidth?: ToggleButtonProps["fullWidth"];
 
+		/** @deprecated Use the `render` prop instead. */
 		LinkComponent?: never;
 
 		/**

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -9,6 +9,7 @@
 
 import type { RoleProps } from "@ariakit/react/role";
 import type { BadgeProps } from "@mui/material/Badge";
+import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type {
@@ -24,6 +25,7 @@ import type {
 	TextFieldProps,
 	TextFieldVariants,
 } from "@mui/material/TextField";
+import type { ToggleButtonProps } from "@mui/material/ToggleButton";
 import type { TooltipProps } from "@mui/material/Tooltip";
 import type {
 	TypographyProps,
@@ -468,7 +470,6 @@ declare module "@mui/material/Switch" {
 	interface SwitchProps {
 		/** @deprecated StrataKit does not support this prop. */
 		checkedIcon?: SwitchProps["checkedIcon"];
-
 		/** @deprecated StrataKit does not support this prop. */
 		disableRipple?: boolean;
 
@@ -552,6 +553,18 @@ declare module "@mui/material/TextField" {
 
 declare module "@mui/material/ToggleButton" {
 	interface ToggleButtonOwnProps {
+		/** @deprecated `color` is unnecessary. Only `"standard"` is supported and already the default. */
+		color?: ToggleButtonProps["color"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: ToggleButtonProps["disableFocusRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: ButtonBaseProps["disableRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		fullWidth?: ToggleButtonProps["fullWidth"];
+
 		LinkComponent?: never;
 
 		/**
@@ -567,6 +580,13 @@ declare module "@mui/material/ToggleButton" {
 		 * @default 'top'
 		 */
 		labelPlacement?: TooltipProps["placement"];
+	}
+}
+
+declare module "@mui/material/ToggleButtonGroup" {
+	interface ToggleButtonGroupProps {
+		/** @deprecated `color` is unnecessary. Only `"standard"` is supported and already the default. */
+		color?: ToggleButtonProps["color"];
 	}
 }
 


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17584641.

- `ToggleButton` component
  - `color` prop
  - `disableFocusRipple` prop
  - `disableRipple` prop
  - `fullWidth` prop
- `ToggleButtonGroup` component
  - `color` prop

### Testing

Tested by adding deprecated props to the `ToggleButton.default.tsx` example
<img width="415" height="311" alt="Screenshot 2026-08-04 at 16 06 02" src="https://github.com/user-attachments/assets/e4da2857-58f2-4d32-a6dc-26c9d3bbcdf8" />
