### PR TITLE
Deprecate popover props

### DIFF
--- a/.changeset/eleven-sides-laugh.md
+++ b/.changeset/eleven-sides-laugh.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `elevation` and `marginThreshold` props of `Popover` component.

--- a/apps/website/src/content/docs/components/mui/Popover.md
+++ b/apps/website/src/content/docs/components/mui/Popover.md
@@ -14,6 +14,8 @@ links:
 - Added fallback mechanism for automatically labelling the `paper` slot using the trigger element (`anchorEl`).
 - `disableScrollLock` is used to prevent scroll locking when the popover is open.
 - The default [`container`](https://mui.com/material-ui/api/popover/#popover-prop-container) is now the [root portal container](/components/root/#portal-container).
+- `elevation` is deprecated.
+- `marginThreshold` is deprecated.
 
 ## ✅ Do
 

--- a/examples/mui/Popover.default.tsx
+++ b/examples/mui/Popover.default.tsx
@@ -29,6 +29,8 @@ export default () => {
 			</Button>
 			<Popover
 				open={open}
+				elevation={5}
+				marginThreshold={10}
 				anchorEl={anchorEl}
 				onClose={() => setOpen(false)}
 				anchorOrigin={{

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -483,6 +483,15 @@ declare module "@mui/material/PaginationItem" {
 	}
 }
 
+declare module "@mui/material/Popover" {
+	interface PopoverProps {
+		/** @deprecated StrataKit does not support this prop. */
+		elevation?: number | undefined;
+		/** @deprecated StrataKit does not support this prop. */
+		marginThreshold?: number | null | undefined;
+	}
+}
+
 declare module "@mui/material/Radio" {
 	interface RadioProps {
 		/** @deprecated StrataKit does not support this prop. */


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecate `elevation` and `marginThreshold` from `Popover`.  See [discussion](https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17705026)

<img width="585" height="226" alt="image" src="https://github.com/user-attachments/assets/cccd9d5e-2cf8-4d51-bc7c-011bf89f3238" />


### Testing

`pnpm run build` and then make sure the props are shown with strike-through in VS Code

