### PR TITLE
Deprecate Accordion props

### DIFF
--- a/.changeset/rich-bobcats-follow.md
+++ b/.changeset/rich-bobcats-follow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated the `disableGutters` prop of `Accordion` and the `expandIcon` prop of `AccordionSummary`

--- a/apps/website/src/content/docs/components/mui/Accordion.md
+++ b/apps/website/src/content/docs/components/mui/Accordion.md
@@ -32,12 +32,12 @@ Make sure the **Accordion** is suitable for your use case. There may be other, m
 - Added [responsive design](#responsive-design) that reorients the marker placement based on container width.
 - Added [`markerPlacement`](#marker-placement) prop to `AccordionSummary` to override responsive design.
 - Added details indentation when the `markerPlacement` is set to `"start"`.
-- `disableGutters` is deprecated and always defaults to `true`.
+- `disableGutters` is not supported and always defaults to `true`.
 - The default value of the `root` slot's [`square`](https://mui.com/material-ui/api/paper/#paper-prop-square) prop defaults to true except when `variant="outlined"`.
 - You are not required to attribute `<AccordionSummary>` with `aria-controls`.
 - Removed [`role="region"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/region_role) semantics. The **Accordion** no longer creates a region landmark.
 - Includes full `forced-colors` support.
-- The `expandIcon` prop of `AccordionSummary` is deprecated.
+- The `expandIcon` prop of `AccordionSummary` is not supported.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Accordion.md
+++ b/apps/website/src/content/docs/components/mui/Accordion.md
@@ -32,11 +32,12 @@ Make sure the **Accordion** is suitable for your use case. There may be other, m
 - Added [responsive design](#responsive-design) that reorients the marker placement based on container width.
 - Added [`markerPlacement`](#marker-placement) prop to `AccordionSummary` to override responsive design.
 - Added details indentation when the `markerPlacement` is set to `"start"`.
-- The default `disableGutters` is now `true`.
+- `disableGutters` is deprecated and always defaults to `true`.
 - The default value of the `root` slot's [`square`](https://mui.com/material-ui/api/paper/#paper-prop-square) prop defaults to true except when `variant="outlined"`.
 - You are not required to attribute `<AccordionSummary>` with `aria-controls`.
 - Removed [`role="region"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/region_role) semantics. The **Accordion** no longer creates a region landmark.
 - Includes full `forced-colors` support.
+- The `expandIcon` prop of `AccordionSummary` is deprecated.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -67,6 +67,11 @@ declare module "@mui/material/OverridableComponent" {
 
 declare module "@mui/material/Accordion" {
 	interface AccordionHeadingSlotPropsOverrides extends TypographyProps {}
+
+	interface AccordionOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disableGutters?: boolean | undefined;
+	}
 }
 
 declare module "@mui/material/AccordionSummary" {
@@ -81,6 +86,9 @@ declare module "@mui/material/AccordionSummary" {
 		 * @default 'auto'
 		 */
 		markerPlacement?: "auto" | "start" | "end";
+
+		/** @deprecated StrataKit does not support this prop. */
+		expandIcon?: React.ReactNode;
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated the `disableGutters` prop of `Accordion` and the `expandIcon` prop of `AccordionSummary`.  See [discussion](https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17599976)


<img width="401" height="70" alt="image" src="https://github.com/user-attachments/assets/f4e2eb86-8a54-4fc0-900b-e315d3d8f7ad" />


### Testing

Run `pnpm` build and add the props to the example and make sure they get the strikethrough in VS Code
