### PR TITLE
`ToggleButton` prop deprecation

### DIFF
--- a/.changeset/smooth-meteors-tease.md
+++ b/.changeset/smooth-meteors-tease.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `action`, `centerRipple`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `fullWidth`, `TouchRippleProps` and `touchRippleRef` props of `ToggleButton` component.

--- a/.changeset/smooth-meteors-tease.md
+++ b/.changeset/smooth-meteors-tease.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `color`, `disableFocusRipple` and `fullWidth` props of `ToggleButton` component.
+Deprecated `action`, `centerRipple`, `color`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `focusRipple`, `fullWidth`, `TouchRippleProps` and `touchRippleRef` props of `ToggleButton` component.

--- a/.changeset/smooth-meteors-tease.md
+++ b/.changeset/smooth-meteors-tease.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `action`, `centerRipple`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `fullWidth`, `TouchRippleProps` and `touchRippleRef` props of `ToggleButton` component.
+Deprecated `color`, `disableFocusRipple` and `fullWidth` props of `ToggleButton` component.

--- a/.changeset/tidy-jobs-sell.md
+++ b/.changeset/tidy-jobs-sell.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `ButtonBase` component.
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `ButtonBase` component (applies to `Button` and other MUI components that extend `ButtonBase`).

--- a/.changeset/tidy-jobs-sell.md
+++ b/.changeset/tidy-jobs-sell.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `ButtonBase` component.

--- a/.changeset/whole-taxes-share.md
+++ b/.changeset/whole-taxes-share.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color` prop of `ToggleButtonGroup` component.

--- a/apps/website/src/content/docs/components/mui/Button.md
+++ b/apps/website/src/content/docs/components/mui/Button.md
@@ -24,8 +24,9 @@ Make sure the **Button** is suitable for your use case. There may be other, more
 
 Modifications to `ButtonBase` (applies to all MUI components that extend `ButtonBase`):
 
+- The `action` prop is deprecated and should not be used.
 - The `LinkComponent` prop is not supported. Use the more flexible `render` prop instead.
-- Ripple effect removed.
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are deprecated.
 
 Modifications specific to `Button`:
 

--- a/apps/website/src/content/docs/components/mui/Button.md
+++ b/apps/website/src/content/docs/components/mui/Button.md
@@ -24,9 +24,9 @@ Make sure the **Button** is suitable for your use case. There may be other, more
 
 Modifications to `ButtonBase` (applies to all MUI components that extend `ButtonBase`):
 
-- The `action` prop is deprecated and should not be used.
+- The `action` prop is not supported.
 - The `LinkComponent` prop is not supported. Use the more flexible `render` prop instead.
-- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are deprecated.
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 
 Modifications specific to `Button`:
 

--- a/apps/website/src/content/docs/components/mui/ToggleButton.md
+++ b/apps/website/src/content/docs/components/mui/ToggleButton.md
@@ -12,7 +12,7 @@ links:
 
 Modifications to `ToggleButton`:
 
-- The `color`, `disableFocusRipple` and `fullWidth` props are deprecated and should not be used.
+- The `color`, `disableFocusRipple` and `fullWidth` props are not supported.
 - A `label` prop has been added. When specified, it is used as the **ToggleButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 - **ToggleButtons** are styled to match the visual appearance of the [**IconButton**](/components/iconbutton) component. Borders are displayed only when the buttons are wrapped in a `ToggleButtonGroup`. [Standalone](#standalone) **ToggleButtons** do not have borders.
@@ -20,7 +20,7 @@ Modifications to `ToggleButton`:
 
 Modifications specific to `ToggleButtonGroup`:
 
-- The `color` prop is deprecated and should not be used.
+- The `color` prop is not supported.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/ToggleButton.md
+++ b/apps/website/src/content/docs/components/mui/ToggleButton.md
@@ -10,6 +10,7 @@ links:
 
 ## StrataKit MUI modifications
 
+- The `action`, `centerRipple`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `fullWidth`, `LinkComponent`, `TouchRippleProps` and `touchRippleRef` props are deprecated and should not be used.
 - A `label` prop has been added. When specified, it is used as the **ToggleButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 - **ToggleButtons** are styled to match the visual appearance of the [**IconButton**](/components/iconbutton) component. Borders are displayed only when the buttons are wrapped in a `ToggleButtonGroup`. [Standalone](#standalone) **ToggleButtons** do not have borders.

--- a/apps/website/src/content/docs/components/mui/ToggleButton.md
+++ b/apps/website/src/content/docs/components/mui/ToggleButton.md
@@ -12,9 +12,9 @@ links:
 
 Modifications to `ToggleButton`:
 
-- Ripple effect removed. The `centerRipple`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
-- The `LinkComponent` prop is not supported. Use the more flexible `render` prop instead.
 - The `action`, `color` and `fullWidth` props are not supported.
+- The `LinkComponent` prop is not supported. Use the more flexible `render` prop instead.
+- Ripple effect removed. The `centerRipple`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - A `label` prop has been added. When specified, it is used as the **ToggleButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 - **ToggleButtons** are styled to match the visual appearance of the [**IconButton**](/components/iconbutton) component. Borders are displayed only when the buttons are wrapped in a `ToggleButtonGroup`. [Standalone](#standalone) **ToggleButtons** do not have borders.

--- a/apps/website/src/content/docs/components/mui/ToggleButton.md
+++ b/apps/website/src/content/docs/components/mui/ToggleButton.md
@@ -10,11 +10,17 @@ links:
 
 ## StrataKit MUI modifications
 
-- The `action`, `centerRipple`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `fullWidth`, `LinkComponent`, `TouchRippleProps` and `touchRippleRef` props are deprecated and should not be used.
+Modifications to `ToggleButton`:
+
+- The `color`, `disableFocusRipple` and `fullWidth` props are deprecated and should not be used.
 - A `label` prop has been added. When specified, it is used as the **ToggleButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 - **ToggleButtons** are styled to match the visual appearance of the [**IconButton**](/components/iconbutton) component. Borders are displayed only when the buttons are wrapped in a `ToggleButtonGroup`. [Standalone](#standalone) **ToggleButtons** do not have borders.
 - **ToggleButtons** can now be rendered as regular [**Buttons**](/components/button) to [display text](#text).
+
+Modifications specific to `ToggleButtonGroup`:
+
+- The `color` prop is deprecated and should not be used.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/ToggleButton.md
+++ b/apps/website/src/content/docs/components/mui/ToggleButton.md
@@ -12,7 +12,9 @@ links:
 
 Modifications to `ToggleButton`:
 
-- The `color`, `disableFocusRipple` and `fullWidth` props are not supported.
+- Ripple effect removed. The `centerRipple`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
+- The `LinkComponent` prop is not supported. Use the more flexible `render` prop instead.
+- The `action`, `color` and `fullWidth` props are not supported.
 - A `label` prop has been added. When specified, it is used as the **ToggleButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 - **ToggleButtons** are styled to match the visual appearance of the [**IconButton**](/components/iconbutton) component. Borders are displayed only when the buttons are wrapped in a `ToggleButtonGroup`. [Standalone](#standalone) **ToggleButtons** do not have borders.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -10,6 +10,7 @@
 import type { RoleProps } from "@ariakit/react/role";
 import type { AlertProps } from "@mui/material/Alert";
 import type { BadgeProps } from "@mui/material/Badge";
+import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type {
@@ -25,6 +26,7 @@ import type {
 	TextFieldProps,
 	TextFieldVariants,
 } from "@mui/material/TextField";
+import type { ToggleButtonProps } from "@mui/material/ToggleButton";
 import type { TooltipProps } from "@mui/material/Tooltip";
 import type {
 	TypographyProps,
@@ -524,6 +526,18 @@ declare module "@mui/material/TextField" {
 
 declare module "@mui/material/ToggleButton" {
 	interface ToggleButtonOwnProps {
+		/** @deprecated `color` is unnecessary. Only `"standard"` is supported and already the default. */
+		color?: ToggleButtonProps["color"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: ToggleButtonProps["disableFocusRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: ButtonBaseProps["disableRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		fullWidth?: ToggleButtonProps["fullWidth"];
+
 		LinkComponent?: never;
 
 		/**
@@ -539,6 +553,13 @@ declare module "@mui/material/ToggleButton" {
 		 * @default 'top'
 		 */
 		labelPlacement?: TooltipProps["placement"];
+	}
+}
+
+declare module "@mui/material/ToggleButtonGroup" {
+	interface ToggleButtonGroupProps {
+		/** @deprecated `color` is unnecessary. Only `"standard"` is supported and already the default. */
+		color?: ToggleButtonProps["color"];
 	}
 }
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -572,6 +572,15 @@ declare module "@mui/material/TextField" {
 }
 
 declare module "@mui/material/ToggleButton" {
+	interface ToggleButtonPropsColorOverrides {
+		error: false;
+		info: false;
+		primary: false;
+		secondary: false;
+		success: false;
+		warning: false;
+	}
+
 	interface ToggleButtonOwnProps extends ButtonBaseDeprecatedProps {
 		/** @deprecated `color` is unnecessary. Only `"standard"` is supported and already the default. */
 		color?: ToggleButtonProps["color"];
@@ -602,9 +611,18 @@ declare module "@mui/material/ToggleButton" {
 }
 
 declare module "@mui/material/ToggleButtonGroup" {
+	interface ToggleButtonGroupPropsColorOverrides {
+		error: false;
+		info: false;
+		primary: false;
+		secondary: false;
+		success: false;
+		warning: false;
+	}
+
 	interface ToggleButtonGroupProps {
 		/** @deprecated `color` is unnecessary. Only `"standard"` is supported and already the default. */
-		color?: ToggleButtonProps["color"];
+		color?: ToggleButtonGroupProps["color"];
 	}
 }
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -174,9 +174,56 @@ declare module "@mui/material/Badge" {
 
 declare module "@mui/material/ButtonBase" {
 	interface ButtonBaseOwnProps {
+		/** @deprecated Use `ref` instead. */
+		action?: ButtonBaseOwnProps["action"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		centerRipple?: ButtonBaseOwnProps["centerRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: ButtonBaseOwnProps["disableRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableTouchRipple?: ButtonBaseOwnProps["disableTouchRipple"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		focusRipple?: ButtonBaseOwnProps["focusRipple"];
+
 		/** @deprecated Use the `render` prop instead. */
-		LinkComponent?: React.ElementType;
+		LinkComponent?: ButtonBaseOwnProps["LinkComponent"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		TouchRippleProps?: ButtonBaseOwnProps["TouchRippleProps"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		touchRippleRef?: ButtonBaseOwnProps["touchRippleRef"];
 	}
+}
+
+interface ButtonBaseDeprecatedProps {
+	/** @deprecated Use `ref` prop instead. */
+	action?: ButtonBaseProps["action"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	centerRipple?: ButtonBaseProps["centerRipple"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableRipple?: ButtonBaseProps["disableRipple"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableTouchRipple?: ButtonBaseProps["disableTouchRipple"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	focusRipple?: ButtonBaseProps["focusRipple"];
+
+	/** @deprecated Use the `render` prop instead. */
+	LinkComponent?: ButtonBaseProps["LinkComponent"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	TouchRippleProps?: ButtonBaseProps["TouchRippleProps"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	touchRippleRef?: ButtonBaseProps["touchRippleRef"];
 }
 
 declare module "@mui/material/Button" {
@@ -525,7 +572,7 @@ declare module "@mui/material/TextField" {
 }
 
 declare module "@mui/material/ToggleButton" {
-	interface ToggleButtonOwnProps {
+	interface ToggleButtonOwnProps extends ButtonBaseDeprecatedProps {
 		/** @deprecated `color` is unnecessary. Only `"standard"` is supported and already the default. */
 		color?: ToggleButtonProps["color"];
 
@@ -533,11 +580,9 @@ declare module "@mui/material/ToggleButton" {
 		disableFocusRipple?: ToggleButtonProps["disableFocusRipple"];
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: ButtonBaseProps["disableRipple"];
-
-		/** @deprecated StrataKit does not support this prop. */
 		fullWidth?: ToggleButtonProps["fullWidth"];
 
+		/** @deprecated Use the `render` prop instead. */
 		LinkComponent?: never;
 
 		/**


### PR DESCRIPTION
_Re-opened #1696_

### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17584641.

- `ButtonBase` component
  -  `action` prop
  - `centerRipple` prop
  - `disableRipple` prop
  - `disableTouchRipple` prop
  - `focusRipple` prop
  - `TouchRippleProps` prop
  - `touchRippleRef` prop
- `ToggleButton` component
  - `color` prop
  - `disableFocusRipple` prop
  - `disableRipple` prop
  - `fullWidth` prop
- `ToggleButtonGroup` component
  - `color` prop

### Testing

Tested by adding deprecated props to the `ToggleButton.default.tsx` example
<img width="415" height="311" alt="Screenshot 2026-08-04 at 16 06 02" src="https://github.com/user-attachments/assets/e4da2857-58f2-4d32-a6dc-26c9d3bbcdf8" />
