### PR TITLE
Deprecate props from autocomplete

### DIFF
--- a/.changeset/dull-readers-worry.md
+++ b/.changeset/dull-readers-worry.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `clearIcon`, `popupIcon` and `forcePopupIcon` props of `Autocomplete`.

--- a/apps/website/src/content/docs/components/mui/Autocomplete.md
+++ b/apps/website/src/content/docs/components/mui/Autocomplete.md
@@ -17,6 +17,7 @@ links:
 - Added [`role="list"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/list_role) and [`role="listitem"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listitem_role) semantics to [**Chips**](/components/chip) ("tags") used in [multiple selection](#multiple-values).
 - Tags are now focusable. Input is the first focusable element, followed by tags in the order they were added.
 - The default portal container is now the [root portal container](/components/root/#portal-container).
+- The icons is not customizable. `clearIcon`, `popupIcon` and `forcePopupIcon` are deprecated.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Autocomplete.md
+++ b/apps/website/src/content/docs/components/mui/Autocomplete.md
@@ -17,7 +17,7 @@ links:
 - Added [`role="list"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/list_role) and [`role="listitem"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listitem_role) semantics to [**Chips**](/components/chip) ("tags") used in [multiple selection](#multiple-values).
 - Tags are now focusable. Input is the first focusable element, followed by tags in the order they were added.
 - The default portal container is now the [root portal container](/components/root/#portal-container).
-- The icons is not customizable. `clearIcon`, `popupIcon` and `forcePopupIcon` are deprecated.
+- The icons is not customizable. `clearIcon`, `popupIcon` and `forcePopupIcon` are not supported.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Autocomplete.md
+++ b/apps/website/src/content/docs/components/mui/Autocomplete.md
@@ -17,7 +17,7 @@ links:
 - Added [`role="list"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/list_role) and [`role="listitem"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listitem_role) semantics to [**Chips**](/components/chip) ("tags") used in [multiple selection](#multiple-values).
 - Tags are now focusable. Input is the first focusable element, followed by tags in the order they were added.
 - The default portal container is now the [root portal container](/components/root/#portal-container).
-- The icons is not customizable. `clearIcon`, `popupIcon` and `forcePopupIcon` are not supported.
+- The icons are not customizable. `clearIcon`, `popupIcon` and `forcePopupIcon` are not supported.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -143,7 +143,7 @@ declare module "@mui/material/Autocomplete" {
 		FreeSolo extends boolean | undefined,
 		ChipComponent extends React.ElementType,
 	> {
-		/** @deprecated StrataKit does not support customizing the clear icon*/
+		/** @deprecated StrataKit does not support this prop. */
 		clearIcon?: React.ReactNode;
 		/** @deprecated StrataKit does not support this prop */
 		forcePopupIcon?: boolean | "auto";

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -20,6 +20,7 @@ import type {
 } from "@mui/material/OverridableComponent";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
+import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -136,6 +136,23 @@ declare module "@mui/material/Avatar" {
 	}
 }
 
+declare module "@mui/material/Autocomplete" {
+	interface AutocompleteProps<
+		Value,
+		Multiple extends boolean | undefined,
+		DisableClearable extends boolean | undefined,
+		FreeSolo extends boolean | undefined,
+		ChipComponent extends React.ElementType,
+	> {
+		/** @deprecated StrataKit does not support customizing the clear icon*/
+		clearIcon?: React.ReactNode;
+		/** @deprecated StrataKit does not support this prop */
+		forcePopupIcon?: boolean | "auto";
+		/** @deprecated StrataKit does not support customizing the popup icon */
+		popupIcon?: React.ReactNode;
+	}
+}
+
 declare module "@mui/material/AvatarGroup" {
 	interface AvatarGroupPropsVariantOverrides {
 		circular: false;

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -145,7 +145,7 @@ declare module "@mui/material/Autocomplete" {
 	> {
 		/** @deprecated StrataKit does not support this prop. */
 		clearIcon?: React.ReactNode;
-		/** @deprecated StrataKit does not support this prop */
+		/** @deprecated StrataKit does not support this prop. */
 		forcePopupIcon?: boolean | "auto";
 		/** @deprecated StrataKit does not support customizing the popup icon */
 		popupIcon?: React.ReactNode;

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -147,7 +147,7 @@ declare module "@mui/material/Autocomplete" {
 		clearIcon?: React.ReactNode;
 		/** @deprecated StrataKit does not support this prop. */
 		forcePopupIcon?: boolean | "auto";
-		/** @deprecated StrataKit does not support customizing the popup icon */
+		/** @deprecated StrataKit does not support this prop. */
 		popupIcon?: React.ReactNode;
 	}
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -20,7 +20,6 @@ import type {
 } from "@mui/material/OverridableComponent";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
-import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecates props from Autocomplete from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17573111

Redo of https://github.com/iTwin/stratakit/pull/1683

### Testing

Check in VS code to make sure there is a strikethrough

<img width="709" height="597" alt="image" src="https://github.com/user-attachments/assets/c2626577-041d-414d-b781-9af6320b801d" />
