### PR TITLE
Deprecate Table related props

### DIFF
--- a/.changeset/wet-numbers-jam.md
+++ b/.changeset/wet-numbers-jam.md
@@ -1,0 +1,8 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated props on `Table`, `TableCell` and `TableSortLabel`
+
+- `padding` was deprecated from `Table` and `TableCell`
+- `hideSortIcon` and `IconComponent` were deprecated from `TableSortLabel`

--- a/.changeset/wet-numbers-jam.md
+++ b/.changeset/wet-numbers-jam.md
@@ -2,7 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated props on `Table`, `TableCell` and `TableSortLabel`
-
-- `padding` was deprecated from `Table` and `TableCell`
-- `hideSortIcon` and `IconComponent` were deprecated from `TableSortLabel`
+Deprecated `hideSortIcon` and `IconComponent` props on `TableSortLabel`.

--- a/.changeset/wet-numbers-jam.md
+++ b/.changeset/wet-numbers-jam.md
@@ -2,4 +2,7 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `hideSortIcon` and `IconComponent` props on `TableSortLabel`.
+Deprecated props related to `Table`.
+
+- `hideSortIcon` and `IconComponent` props on `TableSortLabel`.
+- `size` prop on `TableCell`.

--- a/apps/website/src/content/docs/components/mui/Table.md
+++ b/apps/website/src/content/docs/components/mui/Table.md
@@ -13,6 +13,7 @@ links:
 - Removed `role="rowgroup"` semantics from `TableBody`, as it is not necessary and can cause issues with some assistive technologies.
 - Enabled `TableRow`'s [`hover`](https://mui.com/material-ui/api/table-row/#table-row-prop-hover) prop by default, except when used inside `TableHead`.
 - Deprecated `hideSortIcon` and `IconComponent` property of `TableSortLabel`. The icon is not customizable.
+- Deprecated `size` prop of `TableCell`
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Table.md
+++ b/apps/website/src/content/docs/components/mui/Table.md
@@ -12,7 +12,6 @@ links:
 
 - Removed `role="rowgroup"` semantics from `TableBody`, as it is not necessary and can cause issues with some assistive technologies.
 - Enabled `TableRow`'s [`hover`](https://mui.com/material-ui/api/table-row/#table-row-prop-hover) prop by default, except when used inside `TableHead`.
-- Deprecated the `padding` property of `Table` and `TableCell`.
 - Deprecated `hideSortIcon` and `IconComponent` property of `TableSortLabel`. The icon is not customizable.
 
 ## Examples

--- a/apps/website/src/content/docs/components/mui/Table.md
+++ b/apps/website/src/content/docs/components/mui/Table.md
@@ -12,6 +12,8 @@ links:
 
 - Removed `role="rowgroup"` semantics from `TableBody`, as it is not necessary and can cause issues with some assistive technologies.
 - Enabled `TableRow`'s [`hover`](https://mui.com/material-ui/api/table-row/#table-row-prop-hover) prop by default, except when used inside `TableHead`.
+- Deprecated the `padding` property of `Table` and `TableCell`.
+- Deprecated `hideSortIcon` and `IconComponent` property of `TableSortLabel`. The icon is not customizable.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -685,6 +685,13 @@ declare module "@mui/material/Tab" {
 	}
 }
 
+declare module "@mui/material/TableCell" {
+	interface TableCellProps {
+		/** @deprecated StrataKit does not support this prop on `TableCell`. Set on `Table` instead. */
+		size?: MuiTableCellProps["size"];
+	}
+}
+
 declare module "@mui/material/TableSortLabel" {
 	interface TableSortLabelOwnProps {
 		/** @deprecated StrataKit does not currently support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -685,20 +685,6 @@ declare module "@mui/material/Tab" {
 	}
 }
 
-declare module "@mui/material/Table" {
-	interface TableOwnProps {
-		/** @deprecated StrataKit does not currently support this prop. */
-		padding?: "normal" | "checkbox" | "none" | undefined;
-	}
-}
-
-declare module "@mui/material/TableCell" {
-	interface TableCellProps {
-		/** @deprecated StrataKit does not currently support this prop. */
-		padding?: "normal" | "checkbox" | "none" | undefined;
-	}
-}
-
 declare module "@mui/material/TableSortLabel" {
 	interface TableSortLabelOwnProps {
 		/** @deprecated StrataKit does not currently support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -685,6 +685,34 @@ declare module "@mui/material/Tab" {
 	}
 }
 
+declare module "@mui/material/Table" {
+	interface TableOwnProps {
+		/** @deprecated StrataKit does not currently support this prop. */
+		padding?: "normal" | "checkbox" | "none" | undefined;
+	}
+}
+
+declare module "@mui/material/TableCell" {
+	interface TableCellProps {
+		/** @deprecated StrataKit does not currently support this prop. */
+		padding?: "normal" | "checkbox" | "none" | undefined;
+	}
+}
+
+declare module "@mui/material/TableSortLabel" {
+	interface TableSortLabelOwnProps {
+		/** @deprecated StrataKit does not currently support this prop. */
+		hideSortIcon?: boolean | undefined;
+
+		/** @deprecated StrataKit does not currently support this prop. */
+		IconComponent?:
+			| React.JSXElementConstructor<{
+					className: string;
+			  }>
+			| undefined;
+	}
+}
+
 declare module "@mui/material/Tabs" {
 	interface TabsPropsTextColorOverrides {
 		inherit: false;


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecates props on table related components from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17588109

- `hideSortIcon` and `IconComponent` were deprecated from `TableSortLabel`
- `size` from `TableCell`


<img width="472" height="54" alt="image" src="https://github.com/user-attachments/assets/bfed3bb0-ca7e-4706-a53e-46bbbaaafc99" />

<img width="679" height="519" alt="image" src="https://github.com/user-attachments/assets/0b3942ff-0d61-4935-9ce6-5724cf9e12ab" />


Redo of https://github.com/iTwin/stratakit/pull/1693


### Testing

`pnpm run build` then edit the `Table.sort.tsx` example to include those props and make sure they get a strike through