### PR TITLE
remove "info" and "inherit" colors from `LinearProgress`

### DIFF
--- a/.changeset/full-mails-follow.md
+++ b/.changeset/full-mails-follow.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Removed the following values from the `color` prop of `LinearProgress`: `"info"`, and `"inherit"`.

--- a/apps/website/src/content/docs/components/mui/LinearProgress.md
+++ b/apps/website/src/content/docs/components/mui/LinearProgress.md
@@ -10,6 +10,7 @@ links:
 
 ## StrataKit MUI modifications
 
+- The `color` prop does not support `"inherit"` or `"info"`.
 - Added an end marker when the `variant` prop is set to `"determinate"` or `"buffer"`.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -389,6 +389,13 @@ declare module "@mui/material/Chip" {
 	}
 }
 
+declare module "@mui/material/LinearProgress" {
+	interface LinearProgressPropsColorOverrides {
+		inherit: false;
+		info: false;
+	}
+}
+
 declare module "@mui/material/CircularProgress" {
 	interface CircularProgressOwnProps {
 		/**

--- a/packages/mui/src/~components/MuiLinearProgress.css
+++ b/packages/mui/src/~components/MuiLinearProgress.css
@@ -27,10 +27,6 @@
 		--_MuiLinearProgress-color: var(--stratakit-color-icon-attention-base);
 	}
 
-	&:where(.MuiLinearProgress-colorInfo) {
-		--_MuiLinearProgress-color: var(--stratakit-color-icon-info-base);
-	}
-
 	&:where(.MuiLinearProgress-colorSuccess) {
 		--_MuiLinearProgress-color: var(--stratakit-color-icon-positive-base);
 	}


### PR DESCRIPTION
### Changes

From https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17589074.

- Remove options from `color`:
	- `"info"`
	- `"inherit"`
- Removed CSS for `"info"`.
- Updated documentation.

### Testing

- Confirmed disabled prop values show red underline in VSCode. 
<img width="531" height="71" alt="Screenshot 2026-07-30 at 9 34 39 AM" src="https://github.com/user-attachments/assets/dfec2997-9b79-4716-bdc7-e25d40e7c59c" />
