### PR TITLE
Deprecate props on AppBar

### DIFF
--- a/.changeset/dark-rivers-judge.md
+++ b/.changeset/dark-rivers-judge.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color`, `elevation`, `enableColorOnDark`, `square` and `variant` props of `AppBar`.

--- a/apps/website/src/content/docs/components/mui/AppBar.md
+++ b/apps/website/src/content/docs/components/mui/AppBar.md
@@ -10,4 +10,5 @@ links:
 
 ## StrataKit MUI modifications
 
+- Deprecated `color`, `elevation`, `enableColorOnDark`, `square` and `variant` props
 - The use of MUI's `Toolbar` has been replaced with a styled `<div>` to avoid confusion with the [StrataKit `Toolbar`](/components/toolbar/).

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -8,6 +8,7 @@
 // See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
 
 import type { RoleProps } from "@ariakit/react/role";
+import type { AppBarOwnProps as MuiAppBarOwnProps } from "@mui/material/AppBar";
 import type { BadgeProps } from "@mui/material/Badge";
 import type { ButtonProps } from "@mui/material/Button";
 import type { ButtonBaseProps } from "@mui/material/ButtonBase";
@@ -130,6 +131,21 @@ declare module "@mui/material/Alert" {
 		 * @deprecated Color is determined by severity
 		 */
 		color?: AlertProps["color"];
+	}
+}
+
+declare module "@mui/material/AppBar" {
+	interface AppBarOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		color?: MuiAppBarOwnProps["color"];
+		/** @deprecated StrataKit does not support this prop. */
+		elevation?: MuiAppBarOwnProps["elevation"];
+		/** @deprecated StrataKit does not support this prop. */
+		enableColorOnDark?: MuiAppBarOwnProps["enableColorOnDark"];
+		/** @deprecated StrataKit does not support this prop. */
+		square?: MuiAppBarOwnProps["square"];
+		/** @deprecated StrataKit does not support this prop. */
+		variant?: PaperOwnProps["variant"];
 	}
 }
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -135,6 +135,18 @@ declare module "@mui/material/Alert" {
 }
 
 declare module "@mui/material/AppBar" {
+	interface AppBarPropsColorOverrides {
+		inherit: false;
+		primary: false;
+		secondary: false;
+		success: false;
+		error: false;
+		info: false;
+		warning: false;
+		default: false;
+		transparent: false;
+	}
+
 	interface AppBarOwnProps {
 		/** @deprecated StrataKit does not support this prop. */
 		color?: MuiAppBarOwnProps["color"];


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `color`, `elevation`, `enableColorOnDark`, `square` and `variant` props of `AppBar`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17637776

<img width="583" height="424" alt="image" src="https://github.com/user-attachments/assets/ed88de6e-071a-4835-9571-68684c761fed" />


### Testing

Run `pnpm run build` and then edit the default App Bar example to have the deprecated props and make sure they have the strikethrough