### PR TITLE
update `ToggleButton` borders

### DIFF
--- a/.changeset/lemon-rabbits-fold.md
+++ b/.changeset/lemon-rabbits-fold.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated borders for `ToggleButtonGroup`.

--- a/packages/mui/src/~components/MuiToggleButton.css
+++ b/packages/mui/src/~components/MuiToggleButton.css
@@ -3,6 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+.MuiToggleButtonGroup-root {
+	isolation: isolate;
+}
+
 .MuiToggleButton-root {
 	--✨bg--selected: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 	--✨bg--selected-hover: var(--stratakit-color-bg-glow-on-surface-accent-active-hover);
@@ -19,6 +23,18 @@
 	/* Rendered in a ToggleButtonGroup. */
 	&:where(.MuiToggleButtonGroup-grouped) {
 		border-radius: revert-layer; /* Let MUI handle border-radius. */
+		border-color: var(--stratakit-color-border-neutral-base);
+
+		/* Reduce double borders. */
+		&:where(:not(.MuiToggleButtonGroup-firstButton)) {
+			:where(.MuiToggleButtonGroup-root.MuiToggleButtonGroup-horizontal) & {
+				border-inline-start-color: transparent;
+			}
+
+			:where(.MuiToggleButtonGroup-root.MuiToggleButtonGroup-vertical) & {
+				border-block-start-color: transparent;
+			}
+		}
 	}
 
 	&:where(.Mui-selected) {
@@ -29,6 +45,8 @@
 		border-color: var(--_MuiToggleButton-border--selected);
 		color: var(--stratakit-color-text-accent-strong);
 		--🥝Icon-color: var(--stratakit-color-icon-accent-strong);
+
+		z-index: 1; /* Selected buttons should appear on top. */
 
 		@media (any-hover: hover) {
 			&:where(:hover) {


### PR DESCRIPTION
### Changes

This PR changes the `ToggleButton` borders, when used within a `ToggleButtonGroup`.

The border-color is now set to `--stratakit-color-border-neutral-base`, which is being updated in #1497. (I believe previously it was using `--stratakit-color-border-page-base` through MUI aliased tokens.)

Some additional reworking was necessary:
- negative margin + transparent left borders are used to prevent double borders between adjacent ToggleButtons.
- z-index is raised on the selected ToggleButton, since its border should always appear on top.

### Testing

There is already a slight improvement to contrast (with further improvements to come in #1497).

| Before | After |
| --- | --- |
| <img width="190" height="73" alt="image" src="https://github.com/user-attachments/assets/5913d508-50e9-4e98-91b2-963ff4fb3f78" /> | <img width="196" height="76" alt="image" src="https://github.com/user-attachments/assets/a6795e77-6594-42da-a503-3fb3a2a0057c" /> |

[Deploy preview](https://stratakit.bentley.com/1710/mui/#togglebutton)