### PR TITLE
Deprecate props on Backdrop

### DIFF
--- a/.changeset/frank-turtles-study.md
+++ b/.changeset/frank-turtles-study.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated inherited `in` and `timeout` props on `Backdrop` in favor of `open` and `transitionDuration` to avoid confusion

--- a/.changeset/frank-turtles-study.md
+++ b/.changeset/frank-turtles-study.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated inherited `in` and `timeout` props on `Backdrop` in favor of `open` and `transitionDuration` to avoid confusion
+Deprecated inherited `in` and `timeout` props on `Backdrop` in favor of `open` and `transitionDuration` to avoid confusion.

--- a/apps/website/src/content/docs/components/mui/Backdrop.md
+++ b/apps/website/src/content/docs/components/mui/Backdrop.md
@@ -7,3 +7,8 @@ links:
 ---
 
 ::example{src="mui/Backdrop.default"}
+
+## StrataKit MUI modifications
+
+- Deprecated `in` from `Fade`. Use `open` instead.
+- Deprecated `timeout` from `Fade` Use `transitionDuration` instead.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -208,6 +208,15 @@ declare module "@mui/material/AvatarGroup" {
 	}
 }
 
+declare module "@mui/material/Backdrop" {
+	interface BackdropOwnProps {
+		/** @deprecated Use `open` for `Backdrop`. */
+		in?: never;
+		/** @deprecated Use `transitionDuration` for `Backdrop`*/
+		timeout?: never;
+	}
+}
+
 declare module "@mui/material/Badge" {
 	interface BadgePropsColorOverrides {
 		default: false;

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -212,7 +212,7 @@ declare module "@mui/material/Backdrop" {
 	interface BackdropOwnProps {
 		/** @deprecated Use `open` for `Backdrop`. */
 		in?: never;
-		/** @deprecated Use `transitionDuration` for `Backdrop`*/
+		/** @deprecated Use `transitionDuration` for `Backdrop`. */
 		timeout?: never;
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes
Deprecate `in` and `timeout` on `Backdrop`. These now cause TS errors.
See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17638300

<img width="386" height="166" alt="image" src="https://github.com/user-attachments/assets/84c67667-bdb0-46e9-8d73-8f11f4301c73" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
