### PR TITLE
Deprecate `Button` props

### DIFF
--- a/.changeset/shiny-coins-jog.md
+++ b/.changeset/shiny-coins-jog.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `disableElevation` and `disableFocusRipple` props of `Button` component.

--- a/.changeset/shiny-coins-jog.md
+++ b/.changeset/shiny-coins-jog.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `disableElevation` and `disableFocusRipple` props of `Button` component.
+Deprecated `action`, `centerRipple`, `disableElevation`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `Button` component.

--- a/apps/website/src/content/docs/components/mui/Button.md
+++ b/apps/website/src/content/docs/components/mui/Button.md
@@ -30,6 +30,7 @@ Modifications to `ButtonBase` (applies to all MUI components that extend `Button
 
 Modifications specific to `Button`:
 
+- The `disableElevation` and `disableFocusRipple` props are deprecated and should not be used.
 - Restyled using StrataKit's visual language.
 - The default `variant` is now `"contained"`.
 - The `"info"`, `"success"`, `"warning"`, `"inherit"` colors have been removed. The default color is now `"secondary"`.

--- a/apps/website/src/content/docs/components/mui/Button.md
+++ b/apps/website/src/content/docs/components/mui/Button.md
@@ -30,7 +30,7 @@ Modifications to `ButtonBase` (applies to all MUI components that extend `Button
 
 Modifications specific to `Button`:
 
-- The `disableElevation` and `disableFocusRipple` props are deprecated and should not be used.
+- The `disableElevation` and `disableFocusRipple` props are not supported.
 - Restyled using StrataKit's visual language.
 - The default `variant` is now `"contained"`.
 - The `"info"`, `"success"`, `"warning"`, `"inherit"` colors have been removed. The default color is now `"secondary"`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -9,6 +9,7 @@
 
 import type { RoleProps } from "@ariakit/react/role";
 import type { BadgeProps } from "@mui/material/Badge";
+import type { ButtonProps } from "@mui/material/Button";
 import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { CheckboxProps } from "@mui/material/Checkbox";
 import type { IconProps } from "@mui/material/Icon";
@@ -266,7 +267,14 @@ declare module "@mui/material/Button" {
 		inherit: false;
 	}
 
-	interface ButtonOwnProps {
+	interface ButtonOwnProps extends ButtonBaseDeprecatedProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disableElevation?: ButtonProps["disableElevation"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: ButtonProps["disableFocusRipple"];
+
+		/** @deprecated Use the `render` prop instead. */
 		LinkComponent?: never;
 
 		/**


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17623545.

- `Button` component
  - `disableElevation` prop
  - `disableFocusRipple` prop
  - `disableRipple` prop (not in definitions file, inherited from `ButtonBase`)

Additionally, extended from `ButtonBaseDeprecatedProps` to correctly mark base deprecated props.

### Testing

<img width="565" height="163" alt="Screenshot 2026-08-06 at 15 56 25" src="https://github.com/user-attachments/assets/1e3a8068-9b04-40f8-829f-6d056630f085" />