### PR TITLE
Deprecate disablePrefersReducedMotion

### DIFF
--- a/.changeset/green-trains-wait.md
+++ b/.changeset/green-trains-wait.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `disablePrefersReduceMotion` prop of `Collapse`, `Fade`, `Grow`, and `Zoom`.
+Deprecated `disablePrefersReduceMotion` prop of `Collapse`, `Fade`, `Grow`, `Slide` and `Zoom`.

--- a/.changeset/green-trains-wait.md
+++ b/.changeset/green-trains-wait.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `disablePrefersReduceMotion` prop of `Collapse`, `Fade`, `Grow`, and `Zoom`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -18,6 +18,7 @@ import type { CheckboxProps } from "@mui/material/Checkbox";
 import type { CssBaselineProps } from "@mui/material/CssBaseline";
 import type { FilledInputProps } from "@mui/material/FilledInput";
 import type { FormControlProps } from "@mui/material/FormControl";
+import type {} from "@mui/material/Grow";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type { InputProps } from "@mui/material/Input";
@@ -43,6 +44,7 @@ import type {
 	TypographyProps,
 	TypographyTypeMap,
 } from "@mui/material/Typography";
+import type {} from "@mui/material/Zoom";
 import type * as React from "react";
 
 declare module "@mui/material/OverridableComponent" {
@@ -491,6 +493,13 @@ declare module "@mui/material/CircularProgress" {
 	}
 }
 
+declare module "@mui/material/Collapse" {
+	interface CollapseProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disablePrefersReducedMotion?: boolean;
+	}
+}
+
 declare module "@mui/material/CssBaseline" {
 	/** @deprecated StrataKit does not support this component.  Use `Root` from `@stratakit/mui` instead */
 	export default function CssBaseline(
@@ -540,6 +549,13 @@ declare module "@mui/material/Fab" {
 		 * @default 'primary'
 		 */
 		color?: "primary" | "secondary";
+	}
+}
+
+declare module "@mui/material/Fade" {
+	interface FadeProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disablePrefersReducedMotion?: boolean | undefined;
 	}
 }
 
@@ -606,6 +622,13 @@ declare module "@mui/material/FormLabel" {
 	interface FormLabelOwnProps {
 		/** @deprecated */
 		component?: never; // `@deprecated` marker is not showing up, so using `never` to prevent usage of this prop.
+	}
+}
+
+declare module "@mui/material/Grow" {
+	interface GrowProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disablePrefersReducedMotion?: boolean | undefined;
 	}
 }
 
@@ -1170,5 +1193,12 @@ declare module "@mui/material/Typography" {
 		 * @default "inherit"
 		 */
 		variant?: TypographyProps["variant"];
+	}
+}
+
+declare module "@mui/material/Zoom" {
+	interface ZoomProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disablePrefersReducedMotion?: boolean | undefined;
 	}
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1199,6 +1199,6 @@ declare module "@mui/material/Typography" {
 declare module "@mui/material/Zoom" {
 	interface ZoomProps {
 		/** @deprecated StrataKit does not support this prop. */
-		disablePrefersReducedMotion?: boolean | undefined;
+		disablePrefersReducedMotion?: boolean;
 	}
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -32,6 +32,7 @@ import type {
 import type { PaperOwnProps } from "@mui/material/Paper";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SelectProps } from "@mui/material/Select";
+import type {} from "@mui/material/Slide";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
@@ -870,6 +871,13 @@ declare module "@mui/material/Select" {
 		> &
 			OutlinedInputDeprecatedProps,
 	): React.JSX.Element;
+}
+
+declare module "@mui/material/Slide" {
+	interface SlideProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disablePrefersReducedMotion?: boolean;
+	}
 }
 
 declare module "@mui/material/Slider" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -555,7 +555,7 @@ declare module "@mui/material/Fab" {
 declare module "@mui/material/Fade" {
 	interface FadeProps {
 		/** @deprecated StrataKit does not support this prop. */
-		disablePrefersReducedMotion?: boolean | undefined;
+		disablePrefersReducedMotion?: boolean;
 	}
 }
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -628,7 +628,7 @@ declare module "@mui/material/FormLabel" {
 declare module "@mui/material/Grow" {
 	interface GrowProps {
 		/** @deprecated StrataKit does not support this prop. */
-		disablePrefersReducedMotion?: boolean | undefined;
+		disablePrefersReducedMotion?: boolean;
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecates `disablePrefersReducedMotion` on `Collapse`, `Fade`, `Grow` , `Slide` and `Zoom`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17923008 and https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17638300

These components are not documented on the StrataKit website

Note that these prop is not in MU 9.0.1 but appears in 9.1.0.

There were also issues with Typescript reporting that it could not find "@mui/material/Zoom" or "@mui/material/Grow" when just using the module augmentation.  Adding the imports resolve that.

<img width="816" height="72" alt="image" src="https://github.com/user-attachments/assets/ec31fc47-d81f-4b88-99ff-15c89ab71e32" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
