### PR TITLE
Deprecate showLabel on BottomNavigationAction

### DIFF
--- a/.changeset/puny-peas-know.md
+++ b/.changeset/puny-peas-know.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `showLabel` prop of `BottomNavigationAction`.

--- a/apps/website/src/content/docs/components/mui/BottomNavigation.md
+++ b/apps/website/src/content/docs/components/mui/BottomNavigation.md
@@ -13,4 +13,4 @@ links:
 - The _selected_ state of `BottomNavigationAction` has been visually reinforced, and semantically conveyed using the [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current) attribute.
 - The markup of `BottomNavigationAction` now includes a wrapper element around the icon and label.
 - Includes `forced-colors` support.
-- `showLabel` prop of `BottomNavigationAction` is deprecated. Set `showLabels` on `BottomNavigation` to have it applied consistently to all `BottomNavigationAction`
+- `showLabel` prop of `BottomNavigationAction` is not supported. Set `showLabels` on `BottomNavigation` to have it applied consistently to all `BottomNavigationAction`

--- a/apps/website/src/content/docs/components/mui/BottomNavigation.md
+++ b/apps/website/src/content/docs/components/mui/BottomNavigation.md
@@ -13,3 +13,4 @@ links:
 - The _selected_ state of `BottomNavigationAction` has been visually reinforced, and semantically conveyed using the [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current) attribute.
 - The markup of `BottomNavigationAction` now includes a wrapper element around the icon and label.
 - Includes `forced-colors` support.
+- `showLabel` prop of `BottomNavigationAction` is deprecated. Set `showLabels` on `BottomNavigation` to have it applied consistently to all `BottomNavigationAction`

--- a/examples/mui/BottomNavigation.default.tsx
+++ b/examples/mui/BottomNavigation.default.tsx
@@ -24,7 +24,6 @@ export default () => {
 		>
 			<BottomNavigationAction
 				label="Recents"
-				showLabel
 				icon={<Icon href={`${svgClock}#icon-large`} size="large" />}
 			/>
 			<BottomNavigationAction

--- a/examples/mui/BottomNavigation.default.tsx
+++ b/examples/mui/BottomNavigation.default.tsx
@@ -24,6 +24,7 @@ export default () => {
 		>
 			<BottomNavigationAction
 				label="Recents"
+				showLabel
 				icon={<Icon href={`${svgClock}#icon-large`} size="large" />}
 			/>
 			<BottomNavigationAction

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -10,6 +10,7 @@
 import type { RoleProps } from "@ariakit/react/role";
 import type { AppBarOwnProps as MuiAppBarOwnProps } from "@mui/material/AppBar";
 import type { BadgeProps } from "@mui/material/Badge";
+import type { BottomNavigationActionOwnProps as MuiBottomNavigationActionOwnProps } from "@mui/material/BottomNavigationAction";
 import type { ButtonProps } from "@mui/material/Button";
 import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { ButtonGroupProps } from "@mui/material/ButtonGroup";
@@ -344,6 +345,8 @@ declare module "@mui/material/ButtonGroup" {
 declare module "@mui/material/BottomNavigationAction" {
 	interface BottomNavigationActionOwnProps {
 		LinkComponent?: never;
+		/** @deprecated Set `showLabels` on `BottomNavigation` instead*/
+		showLabel?: MuiBottomNavigationActionOwnProps["showLabel"];
 	}
 }
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -345,7 +345,7 @@ declare module "@mui/material/ButtonGroup" {
 declare module "@mui/material/BottomNavigationAction" {
 	interface BottomNavigationActionOwnProps {
 		LinkComponent?: never;
-		/** @deprecated Set `showLabels` on `BottomNavigation` instead*/
+		/** @deprecated Set `showLabels` on `BottomNavigation` instead. */
 		showLabel?: MuiBottomNavigationActionOwnProps["showLabel"];
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `showLabel` prop of `BottomNavigationAction`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17663314

<img width="1362" height="244" alt="image" src="https://github.com/user-attachments/assets/2d98a8e4-17a0-478d-b28c-31d960089fd1" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
