### PR TITLE
Deprecate Typography.variantMapping

### DIFF
--- a/.changeset/bumpy-deer-melt.md
+++ b/.changeset/bumpy-deer-melt.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `variantMapping` prop of `Typography`.

--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -17,6 +17,7 @@ links:
 - The `render` prop is required to be set for all heading variants.
 - The stock MUI heading and subtitle `variant`s all map to `<h2>` elements by default, except for the `"h1"` variant which still maps to `<h1>`. In all these cases, the `render` prop is required.
 - The `"secondary"` color value has been removed. A `"textTertiary"` color value has been added.
+- The `variantMapping` prop has been deprecated.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Typography.md
+++ b/apps/website/src/content/docs/components/mui/Typography.md
@@ -17,7 +17,7 @@ links:
 - The `render` prop is required to be set for all heading variants.
 - The stock MUI heading and subtitle `variant`s all map to `<h2>` elements by default, except for the `"h1"` variant which still maps to `<h1>`. In all these cases, the `render` prop is required.
 - The `"secondary"` color value has been removed. A `"textTertiary"` color value has been added.
-- The `variantMapping` prop has been deprecated.
+- The `variantMapping` prop is not supported.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1204,6 +1204,9 @@ declare module "@mui/material/Typography" {
 		 * @default "inherit"
 		 */
 		variant?: TypographyProps["variant"];
+
+		/** @deprecated	StrataKit does not support this prop. */
+		variantMapping?: TypographyProps["variantMapping"];
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `variantMapping` prop of `Typography`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17636612

<img width="1145" height="68" alt="image" src="https://github.com/user-attachments/assets/13392af9-147e-46ee-ac9e-e385ea2cbeab" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
