### PR TITLE
`Fab` prop deprecation

### DIFF
--- a/.changeset/bumpy-tables-wink.md
+++ b/.changeset/bumpy-tables-wink.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `disableFocusRipple` and `disableRipple` props of `Fab`.
+Deprecated `disableRipple`, `disableFocusRipple`, and `disableTouchRipple` props of `Fab`.

--- a/.changeset/bumpy-tables-wink.md
+++ b/.changeset/bumpy-tables-wink.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `disableRipple`, `disableFocusRipple`, and `disableTouchRipple` props of `Fab`.
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `Fab`.

--- a/.changeset/bumpy-tables-wink.md
+++ b/.changeset/bumpy-tables-wink.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `disableFocusRipple` and `disableRipple` props of `Fab`.

--- a/apps/website/src/content/docs/components/mui/Fab.md
+++ b/apps/website/src/content/docs/components/mui/Fab.md
@@ -10,6 +10,6 @@ links:
 
 ## StrataKit MUI modifications
 
-- The `disableFocusRipple` and `disableRipple` props are deprecated and should not be used.
+- The `disableFocusRipple` and `disableRipple` props are not supported.
 - Only `"primary"` and `"secondary"` colors are supported.
 - The default `color` is now `"primary"`.

--- a/apps/website/src/content/docs/components/mui/Fab.md
+++ b/apps/website/src/content/docs/components/mui/Fab.md
@@ -10,6 +10,7 @@ links:
 
 ## StrataKit MUI modifications
 
-- The `disableRipple`, `disableFocusRipple` and `disableTouchRipple` props are not supported.
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
+- The `action` prop is not supported.
 - Only `"primary"` and `"secondary"` colors are supported.
 - The default `color` is now `"primary"`.

--- a/apps/website/src/content/docs/components/mui/Fab.md
+++ b/apps/website/src/content/docs/components/mui/Fab.md
@@ -10,5 +10,6 @@ links:
 
 ## StrataKit MUI modifications
 
+- The `disableFocusRipple` and `disableRipple` props are deprecated and should not be used.
 - Only `"primary"` and `"secondary"` colors are supported.
 - The default `color` is now `"primary"`.

--- a/apps/website/src/content/docs/components/mui/Fab.md
+++ b/apps/website/src/content/docs/components/mui/Fab.md
@@ -10,6 +10,6 @@ links:
 
 ## StrataKit MUI modifications
 
-- The `disableFocusRipple` and `disableRipple` props are not supported.
+- The `disableRipple`, `disableFocusRipple` and `disableTouchRipple` props are not supported.
 - Only `"primary"` and `"secondary"` colors are supported.
 - The default `color` is now `"primary"`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -544,17 +544,14 @@ declare module "@mui/material/Fab" {
 		inherit: false;
 	}
 
-	interface FabOwnProps {
+	interface FabOwnProps extends ButtonBaseDeprecatedProps {
 		LinkComponent?: never;
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: boolean;
+		disableRipple?: FabOwnProps["disableRipple"];
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableFocusRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
-		disableTouchRipple?: boolean;
+		disableFocusRipple?: FabOwnProps["disableFocusRipple"];
 
 		/**
 		 * The default color with `@stratakit/mui` is `"primary"`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -547,6 +547,12 @@ declare module "@mui/material/Fab" {
 	interface FabOwnProps {
 		LinkComponent?: never;
 
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: boolean;
+
 		/**
 		 * The default color with `@stratakit/mui` is `"primary"`.
 		 *

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -548,10 +548,13 @@ declare module "@mui/material/Fab" {
 		LinkComponent?: never;
 
 		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
 		disableFocusRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: boolean;
+		disableTouchRipple?: boolean;
 
 		/**
 		 * The default color with `@stratakit/mui` is `"primary"`.


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17624251.

- `disableRipple`
- `disableFocusRipple`
- `disableTouchRipple`

### Testing

<img width="247" height="154" alt="image" src="https://github.com/user-attachments/assets/9aef886c-0f17-4490-a56e-9e8313d8bb79" />
