### PR TITLE
update `Button` borders

### DIFF
--- a/.changeset/petite-symbols-know.md
+++ b/.changeset/petite-symbols-know.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated borders for `Button`.

--- a/packages/mui/src/~components/MuiButton.css
+++ b/packages/mui/src/~components/MuiButton.css
@@ -36,7 +36,7 @@
 	&:where(.MuiButton-sizeLarge) {
 		@apply --typography("body-lg");
 		--_MuiButton-height: var(--stratakit-size-control-field-height-large);
-		--_MuiButton-padding-block: var(--stratakit-space-x2);
+		--_MuiButton-padding-block: var(--stratakit-space-x1);
 		--_MuiButton-padding-inline: var(--stratakit-space-x4);
 	}
 
@@ -65,6 +65,13 @@
 	}
 
 	&:where(.MuiButton-contained) {
+		box-shadow: var(--stratakit-shadow-control-button-base-drop);
+
+		&:where(.MuiButton-colorSecondary:not(.Mui-disabled)) {
+			border: 1px solid;
+			border-color: var(--stratakit-color-border-neutral-base);
+		}
+
 		&:where(.Mui-disabled) {
 			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
 		}
@@ -75,6 +82,8 @@
 	}
 
 	&:where(.MuiButton-outlined, .MuiButton-text) {
+		--variant-outlinedBorder: var(--stratakit-color-border-neutral-base);
+
 		&:where(.MuiButton-colorPrimary) {
 			--_MuiButton-icon-color: var(--stratakit-color-icon-accent-strong);
 			--variant-outlinedBorder: var(--stratakit-color-border-accent-base);

--- a/packages/mui/src/~components/MuiButton.css
+++ b/packages/mui/src/~components/MuiButton.css
@@ -45,6 +45,7 @@
 		--variant-containedColor: var(--stratakit-color-text-neutral-primary);
 		--variant-outlinedColor: var(--stratakit-color-text-neutral-primary);
 		--variant-textColor: var(--stratakit-color-text-neutral-primary);
+		--variant-outlinedBorder: var(--stratakit-color-border-neutral-base);
 		--_MuiButton-icon-color: var(--stratakit-color-icon-neutral-base);
 
 		@media (any-hover: hover) {
@@ -60,8 +61,15 @@
 	}
 
 	&:where(.MuiButton-colorPrimary) {
-		--variant-outlinedColor: var(--stratakit-color-text-accent-strong);
 		--variant-textColor: var(--stratakit-color-text-accent-strong);
+		--variant-outlinedColor: var(--stratakit-color-text-accent-strong);
+		--variant-outlinedBorder: var(--stratakit-color-border-accent-base);
+	}
+
+	&:where(.MuiButton-colorError) {
+		--variant-textColor: var(--stratakit-color-text-critical-base);
+		--variant-outlinedColor: var(--stratakit-color-text-critical-base);
+		--variant-outlinedBorder: var(--stratakit-color-border-critical-base);
 	}
 
 	&:where(.MuiButton-contained) {
@@ -82,18 +90,12 @@
 	}
 
 	&:where(.MuiButton-outlined, .MuiButton-text) {
-		--variant-outlinedBorder: var(--stratakit-color-border-neutral-base);
-
 		&:where(.MuiButton-colorPrimary) {
 			--_MuiButton-icon-color: var(--stratakit-color-icon-accent-strong);
-			--variant-outlinedBorder: var(--stratakit-color-border-accent-base);
 		}
 
 		&:where(.MuiButton-colorError) {
 			--_MuiButton-icon-color: var(--stratakit-color-icon-critical-base);
-			--variant-textColor: var(--stratakit-color-text-critical-base);
-			--variant-outlinedColor: var(--stratakit-color-text-critical-base);
-			--variant-outlinedBorder: var(--stratakit-color-border-critical-base);
 		}
 	}
 

--- a/packages/mui/src/~components/MuiButton.css
+++ b/packages/mui/src/~components/MuiButton.css
@@ -75,13 +75,14 @@
 	&:where(.MuiButton-contained) {
 		box-shadow: var(--stratakit-shadow-control-button-base-drop);
 
-		&:where(.MuiButton-colorSecondary:not(.Mui-disabled)) {
+		&:where(.MuiButton-colorSecondary) {
 			border: 1px solid;
 			border-color: var(--stratakit-color-border-neutral-base);
 		}
 
 		&:where(.Mui-disabled) {
 			background-color: var(--stratakit-color-bg-glow-on-surface-disabled);
+			border-color: transparent;
 		}
 
 		&:where(.MuiButton-colorPrimary, .MuiButton-colorError) {


### PR DESCRIPTION
### Changes

This PR modifies the border/shadow styling for the `Button` in `@stratakit/mui`:

- There is now a proper drop shadow used for all three colors of the `"contained"` variant.
- The _secondary_ color of the `"contained"` variant uses a real™ `border`.
  - The `padding-block` had to be adjusted to preserve the _height_ in `"large"` size.
  - Note: This still increases the _width_ by 1px on both sides.
- The `border-color` for the _secondary_ color of both `"contained"` and `"outlined"` variants is set to `--stratakit-color-border-neutral-base`, which is being adjusted in [#1497](https://github.com/iTwin/stratakit/pull/1497) 
- Unlike the `Button` from `@stratakit/bricks`, there is _no_ inset shadow ("bevel" effect). See [comment](https://github.com/iTwin/stratakit/pull/1719#discussion_r3737786653).

Originally, this PR was also modifying the `Button` from `@stratakit/bricks`, but I've decided to defer that to speed this up.

### Testing

There is not a huge visual difference with the current tokens, but it's definitely noticeable when looking side-by-side in light mode.

| Before | After |
| --- | --- |
| <img width="342" height="127" alt="image" src="https://github.com/user-attachments/assets/f9dfad69-d3a9-4404-bd06-128857f82765" /> | <img width="339" height="133" alt="image" src="https://github.com/user-attachments/assets/1544868f-9032-49fb-9726-4ae9950b3c11" /> |

[Deploy preview](https://stratakit.bentley.com/1719/mui/#button)