### PR TITLE
Deprecate `ButtonGroup` props

### DIFF
--- a/.changeset/mighty-bats-drive.md
+++ b/.changeset/mighty-bats-drive.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color` prop of `ButtonGroup` component.

--- a/apps/website/src/content/docs/components/mui/ButtonGroup.md
+++ b/apps/website/src/content/docs/components/mui/ButtonGroup.md
@@ -10,7 +10,7 @@ links:
 
 ## StrataKit MUI modifications
 
-- Grouped buttons default to `color="secondary"`.
+- The `color` prop is not supported. Set `color` on the individual buttons instead.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -11,6 +11,7 @@ import type { RoleProps } from "@ariakit/react/role";
 import type { BadgeProps } from "@mui/material/Badge";
 import type { ButtonProps } from "@mui/material/Button";
 import type { ButtonBaseProps } from "@mui/material/ButtonBase";
+import type { ButtonGroupProps } from "@mui/material/ButtonGroup";
 import type { CheckboxProps } from "@mui/material/Checkbox";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
@@ -283,6 +284,23 @@ declare module "@mui/material/Button" {
 		 * @default 'contained'
 		 */
 		variant?: "contained" | "outlined" | "text";
+	}
+}
+
+declare module "@mui/material/ButtonGroup" {
+	interface ButtonGroupPropsColorOverrides {
+		error: false;
+		info: false;
+		inherit: false;
+		primary: false;
+		secondary: false;
+		success: false;
+		warning: false;
+	}
+
+	interface ButtonGroupOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		color?: ButtonGroupProps["color"];
 	}
 }
 

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -290,7 +290,7 @@ function createTheme(args: CreateThemeArgs) {
 			MuiButtonGroup: {
 				defaultProps: {
 					component: Role.div,
-					color: "secondary",
+					color: "secondary" as never,
 					disableRipple: true, // ButtonGroup overrides Button's disableRipple so we need to set it here as well
 				},
 			},


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17623839.

- `ButtonGroup` component
  - `color` prop (none of the color string literals are supported)

### Testing

<img width="859" height="341" alt="Screenshot 2026-08-07 at 11 19 35" src="https://github.com/user-attachments/assets/061f817a-f69a-4a26-acdd-594a25d90ca7" />
