### PR TITLE
Deprecate `Tooltip` props

### DIFF
--- a/.changeset/smooth-webs-matter.md
+++ b/.changeset/smooth-webs-matter.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `arrow`, `disableFocusListener`, `disableHoverListener`, `disableInteractive`, `disableTouchListener`, `enterDelay`, `enterNextDelay`, and `enterTouchDelay` props of `Tooltip`
+Deprecated `arrow`, `disableFocusListener`, `disableHoverListener`, `disableInteractive`, `disableTouchListener`, `enterDelay`, `enterNextDelay`, `enterTouchDelay` and `followCursor` props of `Tooltip`.

--- a/.changeset/smooth-webs-matter.md
+++ b/.changeset/smooth-webs-matter.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `arrow`, `disableFocusListener`, `disableHoverListener`, `disableInteractive`, `disableTouchListener`, `enterDelay`, `enterNextDelay`, and `enterTouchDelay` props of `Tooltip`

--- a/apps/website/src/content/docs/components/mui/Tooltip.md
+++ b/apps/website/src/content/docs/components/mui/Tooltip.md
@@ -30,7 +30,7 @@ Make sure the **Tooltip** is suitable for your use case. In some cases, a static
 - Change default placement from `"bottom"` to `"top"`.
 - Includes full `forced-colors` support.
 - The default portal container is now the [root portal container](/components/root/#portal-container).
-- The `arrow`, `disableFocusListener`, `disableHoverListener`, `disableInteractive`, `disableTouchListener`, `enterDelay`, `enterNextDelay`, and `enterTouchDelay` props are not supported.
+- The `arrow`, `disableFocusListener`, `disableHoverListener`, `disableInteractive`, `disableTouchListener`, `enterDelay`, `enterNextDelay`, `enterTouchDelay` and `followCursor` props are not supported.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Tooltip.md
+++ b/apps/website/src/content/docs/components/mui/Tooltip.md
@@ -30,6 +30,7 @@ Make sure the **Tooltip** is suitable for your use case. In some cases, a static
 - Change default placement from `"bottom"` to `"top"`.
 - Includes full `forced-colors` support.
 - The default portal container is now the [root portal container](/components/root/#portal-container).
+- The `arrow`, `disableFocusListener`, `disableHoverListener`, `disableInteractive`, `disableTouchListener`, `enterDelay`, `enterNextDelay`, and `enterTouchDelay` props are not supported.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1114,7 +1114,7 @@ declare module "@mui/material/Tooltip" {
 		 *
 		 * @default true
 		 */
-		describeChild?: boolean;
+		describeChild?: TooltipProps["describeChild"];
 		/** @deprecated StrataKit does not support this prop. */
 		disableFocusListener?: TooltipProps["disableFocusListener"];
 		/** @deprecated StrataKit does not support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1106,6 +1106,8 @@ declare module "@mui/material/ToggleButtonGroup" {
 
 declare module "@mui/material/Tooltip" {
 	interface TooltipProps {
+		/** @deprecated StrataKit does not support this prop. */
+		arrow?: TooltipProps["arrow"];
 		/**
 		 * The default value with `@stratakit/mui` is `true`.
 		 * Use `describeChild={false}` if you want to label the child element.
@@ -1113,6 +1115,22 @@ declare module "@mui/material/Tooltip" {
 		 * @default true
 		 */
 		describeChild?: boolean;
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusListener?: TooltipProps["disableFocusListener"];
+		/** @deprecated StrataKit does not support this prop. */
+		disableHoverListener?: TooltipProps["disableHoverListener"];
+		/** @deprecated StrataKit does not support this prop. */
+		disableInteractive?: TooltipProps["disableInteractive"];
+		/** @deprecated StrataKit does not support this prop.  */
+		disableTouchListener?: TooltipProps["disableTouchListener"];
+		/** @deprecated StrataKit does not support this prop. */
+		enterDelay?: TooltipProps["enterDelay"];
+		/** @deprecated StrataKit does not support this prop. */
+		enterNextDelay?: TooltipProps["enterNextDelay"];
+		/** @deprecated StrataKit does not support this prop. */
+		enterTouchDelay?: TooltipProps["enterTouchDelay"];
+		/** @deprecated StrataKit does not support this prop. */
+		followCursor?: TooltipProps["followCursor"];
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `arrow`, `disableFocusListener`, `disableHoverListener`, `disableInteractive`, `disableTouchListener`, `enterDelay`, `enterNextDelay`,  `enterTouchDelay`, and `followCursor` props of `Tooltip`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17636334

<img width="634" height="268" alt="image" src="https://github.com/user-attachments/assets/7c665128-4e84-4d07-b1bf-a9263b80292a" />


### Testing

```tsx
		<Tooltip
			arrow={undefined}
			disableFocusListener
			disableHoverListener
			disableInteractive
			disableTouchListener
			enterDelay={0}
			enterNextDelay={0}
			enterTouchDelay={0}
			title="Save is disabled until you finish reading the documentation"
		>
			<Button disabled>Save</Button>
		</Tooltip>
```
