### PR TITLE
`Tab` prop deprecation

### DIFF
--- a/.changeset/few-camels-rescue.md
+++ b/.changeset/few-camels-rescue.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `disableRipple`, `disableFocusRipple`, and `disableTouchRipple` props of `Tab`.

--- a/.changeset/few-camels-rescue.md
+++ b/.changeset/few-camels-rescue.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `disableRipple`, `disableFocusRipple`, and `disableTouchRipple` props of `Tab`.
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `Tab`.

--- a/apps/website/src/content/docs/components/mui/Tabs.md
+++ b/apps/website/src/content/docs/components/mui/Tabs.md
@@ -15,7 +15,8 @@ links:
 - `<Tabs>` does not support `textColor="inherit"`.
 - `<Tabs>` does not support `allowScrollButtonsMobile` or `scrollButtons`. Scroll buttons are automatically shown for mouse users and hidden for touch users.
 - `<Tab>` default value for `iconPosition` is now `"start"`.
-- `<Tab>` does not support the `disableRipple` prop.
+- The `action` prop of `Tab` is not supported.
+- Ripple effect removed from `Tab`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
 

--- a/apps/website/src/content/docs/components/mui/Tabs.md
+++ b/apps/website/src/content/docs/components/mui/Tabs.md
@@ -15,6 +15,7 @@ links:
 - `<Tabs>` does not support `textColor="inherit"`.
 - `<Tabs>` does not support `allowScrollButtonsMobile` or `scrollButtons`. Scroll buttons are automatically shown for mouse users and hidden for touch users.
 - `<Tab>` default value for `iconPosition` is now `"start"`.
+- `<Tab>` does not support the `disableRipple` prop.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -891,13 +891,7 @@ declare module "@mui/material/Tab" {
 		LinkComponent?: never;
 
 		/** @deprecated StrataKit does not support this prop. */
-		disableRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
-		disableFocusRipple?: boolean;
-
-		/** @deprecated StrataKit does not support this prop. */
-		disableTouchRipple?: boolean;
+		disableFocusRipple?: TabProps["disableFocusRipple"];
 
 		/**
 		 * The default icon position with `@stratakit/mui` is `"start"`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -890,6 +890,15 @@ declare module "@mui/material/Tab" {
 	interface TabOwnProps {
 		LinkComponent?: never;
 
+		/** @deprecated StrataKit does not support this prop. */
+		disableRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableTouchRipple?: boolean;
+
 		/**
 		 * The default icon position with `@stratakit/mui` is `"start"`.
 		 *

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -887,7 +887,7 @@ declare module "@mui/material/StepButton" {
 }
 
 declare module "@mui/material/Tab" {
-	interface TabOwnProps {
+	interface TabOwnProps extends ButtonBaseDeprecatedProps {
 		LinkComponent?: never;
 
 		/** @deprecated StrataKit does not support this prop. */


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17910900.

- `disableRipple`
- `disableFocusRipple`
- `disableTouchRipple`

### Testing
<img width="255" height="156" alt="Screenshot 2026-08-07 at 11 31 48 AM" src="https://github.com/user-attachments/assets/0a428f35-0426-4575-8019-a335aa52bb16" />

