### PR TITLE
Deprecate CssBaseline

### DIFF
--- a/.changeset/gentle-emus-guess.md
+++ b/.changeset/gentle-emus-guess.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `CssBaseline` and `ScopedCssBaseline` components.

--- a/examples/mui/Tooltip.default.tsx
+++ b/examples/mui/Tooltip.default.tsx
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import Button from "@mui/material/Button";
+import CssBaseline from "@mui/material/CssBaseline";
+import ScopedCssBaseline from "@mui/material/ScopedCssBaseline";
 import Tooltip from "@mui/material/Tooltip";
 
 export default () => {
 	return (
-		<Tooltip title="Save is disabled until you finish reading the documentation">
-			<Button disabled>Save</Button>
-		</Tooltip>
+		<CssBaseline>
+			<ScopedCssBaseline />
+		</CssBaseline>
 	);
 };

--- a/examples/mui/Tooltip.default.tsx
+++ b/examples/mui/Tooltip.default.tsx
@@ -4,14 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import Button from "@mui/material/Button";
-import CssBaseline from "@mui/material/CssBaseline";
-import ScopedCssBaseline from "@mui/material/ScopedCssBaseline";
 import Tooltip from "@mui/material/Tooltip";
 
 export default () => {
 	return (
-		<CssBaseline>
-			<ScopedCssBaseline />
-		</CssBaseline>
+		<Tooltip title="Save is disabled until you finish reading the documentation">
+			<Button disabled>Save</Button>
+		</Tooltip>
 	);
 };

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -808,9 +808,7 @@ interface RadioDeprecatedProps extends ButtonBaseDeprecatedProps {
 declare module "@mui/material/ScopedCssBaseline" {
 	/** @deprecated StrataKit does not support this component.  Use `Root` from `@stratakit/mui` instead */
 	// @ts-expect-error -- Default exports cannot be augmented, but the `@deprecated` above still takes effect.
-	export default function ScopedCssBaseline(
-		props: CssBaselineProps,
-	): React.JSX.Element;
+	export default function ScopedCssBaseline(): React.JSX.Element;
 }
 
 declare module "@mui/material/Select" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -15,6 +15,7 @@ import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { ButtonGroupProps } from "@mui/material/ButtonGroup";
 import type { CardProps } from "@mui/material/Card";
 import type { CheckboxProps } from "@mui/material/Checkbox";
+import type { CssBaselineProps } from "@mui/material/CssBaseline";
 import type { FilledInputProps } from "@mui/material/FilledInput";
 import type { FormControlProps } from "@mui/material/FormControl";
 import type { IconProps } from "@mui/material/Icon";
@@ -493,6 +494,13 @@ declare module "@mui/material/CircularProgress" {
 	}
 }
 
+declare module "@mui/material/CssBaseline" {
+	/** @deprecated StrataKit does not support this component.  Use `Root` from `@stratakit/mui` instead */
+	export default function CssBaseline(
+		props: CssBaselineProps,
+	): React.JSX.Element;
+}
+
 declare module "@mui/material/Dialog" {
 	interface DialogProps extends Pick<CommonProps, "render"> {
 		/** @deprecated Use `render` prop instead. */
@@ -795,6 +803,14 @@ interface RadioDeprecatedProps extends ButtonBaseDeprecatedProps {
 
 	/** @deprecated StrataKit does not support this prop. */
 	size?: RadioProps["size"];
+}
+
+declare module "@mui/material/ScopedCssBaseline" {
+	/** @deprecated StrataKit does not support this component.  Use `Root` from `@stratakit/mui` instead */
+	// @ts-expect-error -- Default exports cannot be augmented, but the `@deprecated` above still takes effect.
+	export default function ScopedCssBaseline(
+		props: CssBaselineProps,
+	): React.JSX.Element;
 }
 
 declare module "@mui/material/Select" {


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `CssBaseline` and `ScopedCssBaseline` components.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17705010

<img width="233" height="99" alt="image" src="https://github.com/user-attachments/assets/628d48aa-bf28-48f7-8b36-5c4387277355" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
