### PR TITLE
Deprecate `Pagination` props

### DIFF
--- a/.changeset/major-meals-juggle.md
+++ b/.changeset/major-meals-juggle.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color`, `shape` and `variant` props of `Pagination`

--- a/apps/website/src/content/docs/components/mui/Pagination.md
+++ b/apps/website/src/content/docs/components/mui/Pagination.md
@@ -12,3 +12,4 @@ links:
 
 - The `shape` prop now defaults to `"rounded"` instead of `"circular"`.
 - Lightly styled using StrataKit's visual language.
+- The `color`, `shape` and `variant` props of `Pagination` are not supported.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -794,6 +794,7 @@ declare module "@mui/material/Pagination" {
 
 	interface PaginationPropsVariantOverrides {
 		text: false;
+		outlined: false;
 	}
 
 	interface PaginationProps {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -30,6 +30,7 @@ import type {
 	DefaultComponentProps,
 	OverridableTypeMap,
 } from "@mui/material/OverridableComponent";
+import type { PaginationProps as MuiPaginationProps } from "@mui/material/Pagination";
 import type { PaperOwnProps } from "@mui/material/Paper";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SelectProps } from "@mui/material/Select";
@@ -782,6 +783,27 @@ declare module "@mui/material/OutlinedInput" {
 interface OutlinedInputDeprecatedProps extends InputBaseDeprecatedProps {
 	/** @deprecated StrataKit does not support this prop. */
 	notched?: OutlinedInputProps["notched"];
+}
+
+declare module "@mui/material/Pagination" {
+	interface PaginationPropsColorOverrides {
+		primary: false;
+		secondary: false;
+		standard: false;
+	}
+
+	interface PaginationPropsVariantOverrides {
+		text: false;
+	}
+
+	interface PaginationProps {
+		/** @deprecated StrataKit does not support this prop. */
+		color?: MuiPaginationProps["color"];
+		/** @deprecated StrataKit does not support this prop. */
+		shape?: MuiPaginationProps["shape"];
+		/** @deprecated StrataKit does not support this prop. */
+		variant?: MuiPaginationProps["variant"];
+	}
 }
 
 declare module "@mui/material/PaginationItem" {


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes
Deprecated `color`, `shape` and `variant` props of `Pagination`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17674184

<img width="662" height="62" alt="image" src="https://github.com/user-attachments/assets/c1f7701e-1c2f-47d4-bd0a-cf02e4ef5de6" />

### Testing

```tsx
		<Pagination count={10} color="primary" variant="outlined" shape="rounded" />
```