### PR TITLE
Deprecate Menu props

### DIFF
--- a/.changeset/fancy-maps-hide.md
+++ b/.changeset/fancy-maps-hide.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `autoFocus` and `disableAutoFocusItem` props of `Menu`.

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -16,6 +16,7 @@ links:
 - Includes full `forced-colors` support.
 - `disableScrollLock` is used to prevent scroll locking when the menu is open.
 - The default portal container is now the [root portal container](/components/root/#portal-container).
+- The `autoFocus` and `disableAutoFocusItem` props are not supported.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -24,6 +24,7 @@ import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type { InputProps } from "@mui/material/Input";
 import type { InputBaseProps } from "@mui/material/InputBase";
+import type { MenuProps as MuiMenuProps } from "@mui/material/Menu";
 import type { OutlinedInputProps } from "@mui/material/OutlinedInput";
 import type {
 	CommonProps,
@@ -756,6 +757,15 @@ declare module "@mui/material/Link" {
 declare module "@mui/material/ListItemButton" {
 	interface ListItemButtonOwnProps {
 		LinkComponent?: never;
+	}
+}
+
+declare module "@mui/material/Menu" {
+	interface MenuProps {
+		/** @deprecated StrataKit does not support this prop. */
+		autoFocus?: MuiMenuProps["autoFocus"];
+		/** @deprecated StrataKit does not support this prop. */
+		disableAutoFocusItem?: MuiMenuProps["disableAutoFocusItem"];
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `autoFocus` and `disableAutoFocusItem` props of `Menu`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17664670

<img width="229" height="94" alt="image" src="https://github.com/user-attachments/assets/1739c83b-cc53-4324-bc5a-e2a8dc627125" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
