### PR TITLE
`TextField` prop deprecation

### DIFF
--- a/.changeset/major-papayas-burn.md
+++ b/.changeset/major-papayas-burn.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+`TextField` component props `color` and `select` have been deprecated.

--- a/.changeset/major-papayas-burn.md
+++ b/.changeset/major-papayas-burn.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-`TextField` component props `color` and `select` have been deprecated.
+Deprecated `color` and `select` props of `TextField`.

--- a/apps/website/src/content/docs/components/mui/TextField.md
+++ b/apps/website/src/content/docs/components/mui/TextField.md
@@ -29,7 +29,7 @@ Modifications specific to `TextField`:
 
 - The `select` prop is not supported.
 - The `color` prop is not supported. Color is applied automatically based on state (e.g., disabled, error).
-- Only the `"outlined"` variant is supported. The `variant` prop is not supported.
+- The `variant` prop is not supported. Only the `"outlined"` variant is supported. 
 - Removed the [floating label](https://mui.com/material-ui/react-text-field/#floating-label) behavior. The label is always displayed above the input.
 
 ## Examples

--- a/apps/website/src/content/docs/components/mui/TextField.md
+++ b/apps/website/src/content/docs/components/mui/TextField.md
@@ -27,6 +27,9 @@ Modifications to `FormControl` (applies to all MUI components that extend `FormC
 
 Modifications specific to `TextField`:
 
+- The `select` prop is not supported.
+- The `color` prop is not supported. Color is applied automatically based on state (e.g., disabled, error).
+- Only the `"outlined"` variant is supported. The `variant` prop is not supported.
 - Removed the [floating label](https://mui.com/material-ui/react-text-field/#floating-label) behavior. The label is always displayed above the input.
 
 ## Examples

--- a/apps/website/src/content/docs/components/mui/TextField.md
+++ b/apps/website/src/content/docs/components/mui/TextField.md
@@ -29,7 +29,7 @@ Modifications specific to `TextField`:
 
 - The `select` prop is not supported.
 - The `color` prop is not supported. Color is applied automatically based on state (e.g., disabled, error).
-- The `variant` prop is not supported. Only the `"outlined"` variant is supported. 
+- The `variant` prop is not supported. Only the `"outlined"` variant is supported.
 - Removed the [floating label](https://mui.com/material-ui/react-text-field/#floating-label) behavior. The label is always displayed above the input.
 
 ## Examples

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -3,10 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-// This file is used to define custom types for MUI components to work with the StrataKit customizations.
-// See: https://mui.com/material-ui/customization/theming/#typescript
-// See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
-
 import type { RoleProps } from "@ariakit/react/role";
 import type { AppBarOwnProps as MuiAppBarOwnProps } from "@mui/material/AppBar";
 import type { BadgeProps } from "@mui/material/Badge";
@@ -36,16 +32,16 @@ import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";
-import type {
-	TextFieldProps,
-	TextFieldVariants,
-} from "@mui/material/TextField";
+import type { TextFieldProps } from "@mui/material/TextField";
 import type { ToggleButtonProps } from "@mui/material/ToggleButton";
 import type { TooltipProps } from "@mui/material/Tooltip";
 import type {
 	TypographyProps,
 	TypographyTypeMap,
 } from "@mui/material/Typography";
+// This file is used to define custom types for MUI components to work with the StrataKit customizations.
+// See: https://mui.com/material-ui/customization/theming/#typescript
+// See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
 import type * as React from "react";
 
 declare module "@mui/material/OverridableComponent" {
@@ -577,6 +573,14 @@ declare module "@mui/material/FormControl" {
 	}
 }
 
+interface FormControlDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	color?: FormControlProps["color"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	variant?: FormControlProps["variant"];
+}
+
 declare module "@mui/material/FormLabel" {
 	interface FormLabelPropsColorOverrides {
 		secondary: false;
@@ -985,13 +989,7 @@ declare module "@mui/material/TextField" {
 	}
 
 	export default function TextField(
-		props: {
-			/** @deprecated StrataKit does not support this prop. */
-			variant?: TextFieldVariants;
-
-			/** @deprecated StrataKit does not support this prop. */
-			color?: TextFieldProps["color"];
-
+		props: FormControlDeprecatedProps & {
 			/** @deprecated StrataKit does not support this prop. */
 			select?: TextFieldProps["select"];
 		} & Omit<TextFieldProps, "variant" | "color" | "select">,

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -986,8 +986,15 @@ declare module "@mui/material/TextField" {
 
 	export default function TextField(
 		props: {
-			/** @deprecated StrataKit does not support this prop. */ variant?: TextFieldVariants;
-		} & Omit<TextFieldProps, "variant">,
+			/** @deprecated StrataKit does not support this prop. */
+			variant?: TextFieldVariants;
+
+			/** @deprecated StrataKit does not support this prop. */
+			color?: TextFieldProps["color"];
+
+			/** @deprecated StrataKit does not support this prop. */
+			select?: TextFieldProps["select"];
+		} & Omit<TextFieldProps, "variant" | "color" | "select">,
 	): React.JSX.Element;
 }
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -3,6 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+// This file is used to define custom types for MUI components to work with the StrataKit customizations.
+// See: https://mui.com/material-ui/customization/theming/#typescript
+// See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+
 import type { RoleProps } from "@ariakit/react/role";
 import type { AppBarOwnProps as MuiAppBarOwnProps } from "@mui/material/AppBar";
 import type { BadgeProps } from "@mui/material/Badge";
@@ -39,9 +43,6 @@ import type {
 	TypographyProps,
 	TypographyTypeMap,
 } from "@mui/material/Typography";
-// This file is used to define custom types for MUI components to work with the StrataKit customizations.
-// See: https://mui.com/material-ui/customization/theming/#typescript
-// See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
 import type * as React from "react";
 
 declare module "@mui/material/OverridableComponent" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -576,7 +576,10 @@ declare module "@mui/material/FormControl" {
 interface FormControlDeprecatedProps {
 	/** @deprecated StrataKit does not support this prop. */
 	color?: FormControlProps["color"];
-
+	/** @deprecated StrataKit does not support this prop. */
+	focused?: FormControlProps["focused"];
+	/** @deprecated StrataKit does not support this prop. */
+	hiddenLabel?: FormControlProps["hiddenLabel"];
 	/** @deprecated StrataKit does not support this prop. */
 	variant?: FormControlProps["variant"];
 }
@@ -992,7 +995,7 @@ declare module "@mui/material/TextField" {
 		props: FormControlDeprecatedProps & {
 			/** @deprecated StrataKit does not support this prop. */
 			select?: TextFieldProps["select"];
-		} & Omit<TextFieldProps, "variant" | "color" | "select">,
+		} & Omit<TextFieldProps, "select" | keyof FormControlDeprecatedProps>,
 	): React.JSX.Element;
 }
 


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17633884.

- `color`
- `select`

### Testing

```tsx
<TextField
	label="Name"
	color="primary"
	focused={true}
	hiddenLabel={true}
	variant="outlined"
	select={false}
/>
```

<img width="190" height="178" alt="image" src="https://github.com/user-attachments/assets/76773725-1336-43ec-a7f4-ccecceca26f7" />

