### PR TITLE
Deprecate props from MenuItem

### DIFF
--- a/.changeset/goofy-meteors-drive.md
+++ b/.changeset/goofy-meteors-drive.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `dense`, `focusRipple`, `focusVisibleClassName`, `TouchRippleProps` and `touchRippleRef` props of `MenuItem`.

--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -1,5 +1,5 @@
 ---
-"@stratakit/mui": patch
+"@stratakit/mui": minor
 ---
 
 Deprecated `action`, `centerRipple`, `checkedIcon`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `LinkComponent`, `TouchRippleProps`, and `touchRippleRef` props of `Switch`.

--- a/.changeset/odd-hats-nail.md
+++ b/.changeset/odd-hats-nail.md
@@ -1,5 +1,5 @@
 ---
-"@stratakit/mui": minor
+"@stratakit/mui": patch
 ---
 
 Deprecated `action`, `centerRipple`, `checkedIcon`, `color`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `LinkComponent`, `TouchRippleProps`, and `touchRippleRef` props of `Switch`.

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -18,7 +18,7 @@ links:
 - The default portal container is now the [root portal container](/components/root/#portal-container).
 - The `autoFocus` and `disableAutoFocusItem` props are not supported.
 - The `action`, `dense`, and `focusVisibleClassname` props of `MenuItem` are not supported.
-- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `MenutItem` are not supported.
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps`, and `touchRippleRef` props of `MenutItem` are not supported.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -17,6 +17,8 @@ links:
 - `disableScrollLock` is used to prevent scroll locking when the menu is open.
 - The default portal container is now the [root portal container](/components/root/#portal-container).
 - The `autoFocus` and `disableAutoFocusItem` props are not supported.
+- The `action`, `dense` and `focusVisibleClassname` props of `MenuItem` are not supported.
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `MenutItem` are not supported.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Menu.md
+++ b/apps/website/src/content/docs/components/mui/Menu.md
@@ -17,7 +17,7 @@ links:
 - `disableScrollLock` is used to prevent scroll locking when the menu is open.
 - The default portal container is now the [root portal container](/components/root/#portal-container).
 - The `autoFocus` and `disableAutoFocusItem` props are not supported.
-- The `action`, `dense` and `focusVisibleClassname` props of `MenuItem` are not supported.
+- The `action`, `dense`, and `focusVisibleClassname` props of `MenuItem` are not supported.
 - Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `MenutItem` are not supported.
 
 ## Examples

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -875,6 +875,9 @@ declare module "@mui/material/Radio" {
 		disableRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: boolean;
+
+		/** @deprecated StrataKit does not support this prop. */
 		disableTouchRipple?: boolean;
 
 		/** @deprecated StrataKit does not support this prop. */
@@ -882,15 +885,6 @@ declare module "@mui/material/Radio" {
 
 		/** @deprecated StrataKit does not support this prop. */
 		size?: RadioProps["size"];
-	}
-
-	interface RadioPropsColorOverrides {
-		secondary: false;
-		default: false;
-		info: false;
-		success: false;
-		warning: false;
-		error: false;
 	}
 
 	interface RadioPropsColorOverrides {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -38,6 +38,7 @@ import type { SelectProps } from "@mui/material/Select";
 import type {} from "@mui/material/Slide";
 import type {} from "@mui/material/Stepper";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
+import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -889,6 +889,15 @@ declare module "@mui/material/Radio" {
 		error: false;
 	}
 
+	interface RadioPropsColorOverrides {
+		secondary: false;
+		default: false;
+		info: false;
+		success: false;
+		warning: false;
+		error: false;
+	}
+
 	interface RadioPropsSizeOverrides {
 		small: false;
 	}

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -38,7 +38,6 @@ import type { SelectProps } from "@mui/material/Select";
 import type {} from "@mui/material/Slide";
 import type {} from "@mui/material/Stepper";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
-import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
 import type { TabsProps } from "@mui/material/Tabs";

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -770,7 +770,11 @@ declare module "@mui/material/Menu" {
 }
 
 declare module "@mui/material/MenuItem" {
-	interface MenuItemOwnProps {
+	interface MenuItemOwnProps extends ButtonBaseDeprecatedProps {
+		/** @deprecated StrataKit does not support this prop. */
+		dense?: MenuItemOwnProps["dense"];
+		/** @deprecated StrataKit does not support this prop. */
+		focusVisibleClassName?: string;
 		LinkComponent?: never;
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `dense`, `focusRipple`, `focusVisibleClassName`, `TouchRippleProps` and `touchRippleRef` props of `MenuItem`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17664670 for discussion

<img width="773" height="568" alt="image" src="https://github.com/user-attachments/assets/fc563dee-a577-4952-bc71-da507a41f6ce" />


### Testing

```tsx
				<MenuItem
					onClick={handleClose}
					action={undefined}
					centerRipple
					dense
					disableRipple
					focusRipple
					focusVisibleClassName=""
					TouchRippleProps={{}}
					touchRippleRef={undefined}
				>

```