### PR TITLE
Deprecate props from ListItemButton

### DIFF
--- a/.changeset/bold-streets-enter.md
+++ b/.changeset/bold-streets-enter.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `ListItemButton`

--- a/apps/website/src/content/docs/components/mui/List.md
+++ b/apps/website/src/content/docs/components/mui/List.md
@@ -14,6 +14,8 @@ links:
 - The `ListSubheader` component renders as a `<div>` element by default.
 - The `subheader` props of `List` is not supported. Use the `ListSubheader` component instead.
 - The `color` prop of `ListSubheader` is not supported.
+- The `action` prop of `ListButtonItem` is not supported by StrataKit.
+- Ripple effect removed from `ListItemButton`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -765,7 +765,7 @@ declare module "@mui/material/List" {
 }
 
 declare module "@mui/material/ListItemButton" {
-	interface ListItemButtonOwnProps {
+	interface ListItemButtonOwnProps extends ButtonBaseDeprecatedProps {
 		LinkComponent?: never;
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `ListItemButton`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17599232

<img width="705" height="496" alt="image" src="https://github.com/user-attachments/assets/2fd8d977-c62f-46ef-8613-fc25fa9619ed" />


### Testing

```tsx
				<ListItemButton
					action={undefined}
					centerRipple
					disableRipple
					disableTouchRipple
					focusRipple
					TouchRippleProps={{}}
					touchRippleRef={undefined}
				>
```