### PR TITLE
Deprecate `FormControl` props

### DIFF
--- a/.changeset/eager-parts-work.md
+++ b/.changeset/eager-parts-work.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color`, `focused`, `hiddenLabel` and `variant` props of `FormControl`.

--- a/apps/website/src/content/docs/components/mui/TextField.md
+++ b/apps/website/src/content/docs/components/mui/TextField.md
@@ -21,8 +21,12 @@ Make sure the **TextField** is suitable for your use case. There may be other, m
 
 ## StrataKit MUI modifications
 
-- Only the `"outlined"` variant is supported. The `variant` prop is marked as deprecated.
-- The `color` prop is not supported.
+Modifications to `FormControl` (applies to all MUI components that extend `FormControl`):
+
+- The `color`, `focused`, `hiddenLabel` and `variant` props are not supported.
+
+Modifications specific to `TextField`:
+
 - Removed the [floating label](https://mui.com/material-ui/react-text-field/#floating-label) behavior. The label is always displayed above the input.
 
 ## Examples

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -13,6 +13,7 @@ import type { ButtonProps } from "@mui/material/Button";
 import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { ButtonGroupProps } from "@mui/material/ButtonGroup";
 import type { CheckboxProps } from "@mui/material/Checkbox";
+import type { FormControlProps } from "@mui/material/FormControl";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type {
@@ -473,6 +474,28 @@ declare module "@mui/material/Fab" {
 		 * @default 'primary'
 		 */
 		color?: "primary" | "secondary";
+	}
+}
+
+declare module "@mui/material/FormControl" {
+	interface FormControlPropsColorOverrides {
+		error: false;
+		info: false;
+		primary: false;
+		secondary: false;
+		success: false;
+		warning: false;
+	}
+
+	interface FormControlOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		color?: FormControlProps["color"];
+		/** @deprecated StrataKit does not support this prop. */
+		focused?: FormControlProps["focused"];
+		/** @deprecated StrataKit does not support this prop. */
+		hiddenLabel?: FormControlProps["hiddenLabel"];
+		/** @deprecated StrataKit does not support this prop. */
+		variant?: FormControlProps["variant"];
 	}
 }
 


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17633884

- `FormControl` component
  - `color`
  - `focused`
  - `hiddenLabel`
  - `variant`

### Testing

<img width="565" height="259" alt="Screenshot 2026-08-10 at 16 16 09" src="https://github.com/user-attachments/assets/7def9b36-3a39-4b04-bc42-8014bc82e417" />
