### PR TITLE
BottomNavigation.showLabels defaults to true

### DIFF
--- a/.changeset/quick-dragons-slide.md
+++ b/.changeset/quick-dragons-slide.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+The `showLabels` prop of `BottomNavigation` now defaults to `true`.

--- a/apps/website/src/content/docs/components/mui/BottomNavigation.md
+++ b/apps/website/src/content/docs/components/mui/BottomNavigation.md
@@ -13,4 +13,5 @@ links:
 - The _selected_ state of `BottomNavigationAction` has been visually reinforced, and semantically conveyed using the [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current) attribute.
 - The markup of `BottomNavigationAction` now includes a wrapper element around the icon and label.
 - Includes `forced-colors` support.
+- `showLabels` prop of `ButtonNavigation` now defaults to `true`.
 - `showLabel` prop of `BottomNavigationAction` is not supported. Set `showLabels` on `BottomNavigation` to have it applied consistently to all `BottomNavigationAction`

--- a/examples/mui/BottomNavigation.default.tsx
+++ b/examples/mui/BottomNavigation.default.tsx
@@ -16,7 +16,6 @@ export default () => {
 	const [value, setValue] = React.useState(0);
 	return (
 		<BottomNavigation
-			showLabels
 			value={value}
 			onChange={(_, newValue) => {
 				setValue(newValue);

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -262,7 +262,12 @@ function createTheme(args: CreateThemeArgs) {
 					slotProps: { badge: { component: MuiBadgeBadge } },
 				},
 			},
-			MuiBottomNavigation: { defaultProps: { component: Role.div } },
+			MuiBottomNavigation: {
+				defaultProps: {
+					component: Role.div,
+					showLabels: true,
+				},
+			},
 			MuiBottomNavigationAction: {
 				defaultProps: {
 					component: MuiBottomNavigationAction,


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

`showLabels` prop of `ButtonNavigation` now defaults to `true`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17923920

### Testing

Make sure example still shows labels on all entries.
