### PR TITLE
Use flex gap

### DIFF
--- a/.changeset/hot-poets-speak.md
+++ b/.changeset/hot-poets-speak.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Changed default value of `useFlexGap` prop of `Stack` to be true.

--- a/apps/test-app/app/mui/Avatar.showcase.tsx
+++ b/apps/test-app/app/mui/Avatar.showcase.tsx
@@ -10,7 +10,7 @@ import AvatarInitials from "examples/mui/Avatar.initials.tsx";
 
 export default function AvatarExamples() {
 	return (
-		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 			<AvatarDefault />
 			<AvatarInitials />
 			<AvatarIcon />

--- a/apps/test-app/app/mui/Chip.showcase.tsx
+++ b/apps/test-app/app/mui/Chip.showcase.tsx
@@ -13,7 +13,7 @@ import { createKnob, isProduction } from "~/~utils.tsx";
 
 export default function ChipExamples() {
 	return (
-		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 			<ChipDefault />
 			<ChipOutlined />
 			<ChipClickable />

--- a/apps/test-app/app/mui/IconButton.showcase.tsx
+++ b/apps/test-app/app/mui/IconButton.showcase.tsx
@@ -15,12 +15,12 @@ export default function IconButtonExamples() {
 			<IconButtonDefault />
 			<IconButtonSizes />
 			{!isProduction && (
-				<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+				<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 					<IconButtonColors_ />
 				</Stack>
 			)}
 			{!isProduction && (
-				<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+				<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 					<IconButtonPlacements_ />
 				</Stack>
 			)}

--- a/apps/test-app/app/mui/ToggleButton.showcase.tsx
+++ b/apps/test-app/app/mui/ToggleButton.showcase.tsx
@@ -18,7 +18,7 @@ export default function ToggleButtonExamples() {
 			<ToggleButtonSizes />
 			<ToggleButtonText />
 			{!isProduction && (
-				<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+				<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 					<ToggleButtonPlacements_ />
 				</Stack>
 			)}

--- a/examples/mui/Badge.colors.tsx
+++ b/examples/mui/Badge.colors.tsx
@@ -14,7 +14,7 @@ import svgWarning from "@stratakit/icons/status-warning.svg";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 			<Badge
 				badgeContent={
 					<>

--- a/examples/mui/Badge.sizes.tsx
+++ b/examples/mui/Badge.sizes.tsx
@@ -14,7 +14,6 @@ export default () => {
 		<Stack
 			spacing={1}
 			direction="row"
-			useFlexGap
 			sx={{ alignItems: "center", flexWrap: "wrap" }}
 		>
 			<Badge

--- a/examples/mui/Badge.type.tsx
+++ b/examples/mui/Badge.type.tsx
@@ -8,7 +8,7 @@ import Stack from "@mui/material/Stack";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 			<Badge badgeContent="Strong" type="strong" inline />
 			<Badge badgeContent="Muted" type="muted" inline />
 			<Badge badgeContent="Outlined" type="outlined" inline />

--- a/examples/mui/Button._icons.tsx
+++ b/examples/mui/Button._icons.tsx
@@ -11,7 +11,7 @@ import svgPlaceholder from "@stratakit/icons/placeholder.svg";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 			<Button startIcon={<Icon href={svgPlaceholder} />}>Start icon</Button>
 			<Button endIcon={<Icon href={svgPlaceholder} />}>End icon</Button>
 			<Button

--- a/examples/mui/Button._permutations.tsx
+++ b/examples/mui/Button._permutations.tsx
@@ -38,7 +38,6 @@ export default () => {
 									key={variant}
 									spacing={1}
 									direction="row"
-									useFlexGap
 									sx={{ flexWrap: "wrap" }}
 								>
 									{colors.map((color) => {

--- a/examples/mui/Button.colors.tsx
+++ b/examples/mui/Button.colors.tsx
@@ -8,7 +8,7 @@ import Stack from "@mui/material/Stack";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 			<Button color="primary">Primary</Button>
 			<Button color="secondary">Secondary</Button>
 			<Button color="error">Error</Button>

--- a/examples/mui/Button.sizes.tsx
+++ b/examples/mui/Button.sizes.tsx
@@ -11,7 +11,6 @@ export default () => {
 		<Stack
 			spacing={1}
 			direction="row"
-			useFlexGap
 			sx={{ alignItems: "center", flexWrap: "wrap" }}
 		>
 			<Button size="small">Small</Button>

--- a/examples/mui/Button.variants.tsx
+++ b/examples/mui/Button.variants.tsx
@@ -8,7 +8,7 @@ import Stack from "@mui/material/Stack";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 			<Button variant="contained">Contained</Button>
 			<Button variant="outlined">Outlined</Button>
 			<Button variant="text">Text</Button>

--- a/examples/mui/Chip.sizes.tsx
+++ b/examples/mui/Chip.sizes.tsx
@@ -11,7 +11,6 @@ export default () => {
 		<Stack
 			spacing={1}
 			direction="row"
-			useFlexGap
 			sx={{ alignItems: "center", flexWrap: "wrap" }}
 		>
 			<Chip size="small" label="Small" />

--- a/examples/mui/IconButton.sizes.tsx
+++ b/examples/mui/IconButton.sizes.tsx
@@ -14,7 +14,6 @@ export default () => {
 		<Stack
 			spacing={1}
 			direction="row"
-			useFlexGap
 			sx={{ alignItems: "center", flexWrap: "wrap" }}
 		>
 			<IconButton size="small" label="Small">

--- a/examples/mui/Link._colors.tsx
+++ b/examples/mui/Link._colors.tsx
@@ -17,7 +17,7 @@ const colors = [
 
 export default () => {
 	return (
-		<Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
 			{colors.map((color) => (
 				<Link key={color} color={color} href={`#${color}`}>
 					{color.charAt(0).toUpperCase()}

--- a/examples/mui/Select.sizes.tsx
+++ b/examples/mui/Select.sizes.tsx
@@ -15,7 +15,6 @@ export default () => {
 		<Stack
 			spacing={1}
 			direction="row"
-			useFlexGap
 			sx={{ alignItems: "center", flexWrap: "wrap" }}
 		>
 			<SmallSelect />

--- a/examples/mui/Switch.sizes.tsx
+++ b/examples/mui/Switch.sizes.tsx
@@ -9,7 +9,7 @@ import Switch from "@mui/material/Switch";
 
 export default () => {
 	return (
-		<Stack spacing={1} direction="row" useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack spacing={1} direction="row" sx={{ flexWrap: "wrap" }}>
 			<FormControlLabel control={<Switch size="small" />} label="Small" />
 			<FormControlLabel control={<Switch size="medium" />} label="Medium" />
 		</Stack>

--- a/examples/mui/TextField.sizes.tsx
+++ b/examples/mui/TextField.sizes.tsx
@@ -11,7 +11,6 @@ export default () => {
 		<Stack
 			spacing={1}
 			direction="row"
-			useFlexGap
 			sx={{ alignItems: "center", flexWrap: "wrap" }}
 		>
 			<TextField size="small" label="Small" />

--- a/examples/mui/ToggleButton.sizes.tsx
+++ b/examples/mui/ToggleButton.sizes.tsx
@@ -14,7 +14,6 @@ export default () => {
 		<Stack
 			spacing={1}
 			direction="row"
-			useFlexGap
 			sx={{ alignItems: "center", flexWrap: "wrap" }}
 		>
 			<ToggleButton value="small" size="small" label="Small">

--- a/examples/mui/Typography.colors.tsx
+++ b/examples/mui/Typography.colors.tsx
@@ -8,7 +8,7 @@ import Typography from "@mui/material/Typography";
 
 export default () => {
 	return (
-		<Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: "wrap" }}>
+		<Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
 			<Typography color="textPrimary">Text Primary</Typography>
 			<Typography color="textSecondary">Text Secondary</Typography>
 			<Typography color="textTertiary">Text Tertiary</Typography>

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1047,7 +1047,7 @@ declare module "@mui/material/Stack" {
 	interface StackOwnProps {
 		/**
 		 *
-		 * The default value with `@mui/stratakit` is `true`.
+		 * The default value with `@stratakit/mui` is `true`.
 		 *
 		 * @default true
 		 */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1043,6 +1043,18 @@ declare module "@mui/material/Slider" {
 	}
 }
 
+declare module "@mui/material/Stack" {
+	interface StackOwnProps {
+		/**
+		 *
+		 * The default value with `@mui/stratakit` is `true`.
+		 *
+		 * @default true
+		 */
+		useFlexGap?: StackOwnProps["useFlexGap"];
+	}
+}
+
 declare module "@mui/material/SvgIcon" {
 	/** @deprecated Use `Icon` from `@stratakit/mui` instead. */
 	// @ts-expect-error -- Default exports cannot be augmented, but the `@deprecated` above still takes effect.

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -569,7 +569,12 @@ function createTheme(args: CreateThemeArgs) {
 				},
 			},
 			MuiSnackbarContent: { defaultProps: { component: Role.div } },
-			MuiStack: { defaultProps: { component: Role.div } },
+			MuiStack: {
+				defaultProps: {
+					component: Role.div,
+					useFlexGap: true,
+				},
+			},
 			MuiStep: { defaultProps: { component: Role.li } },
 			MuiSwitch: { defaultProps: { component: Role.span } },
 			MuiStepper: {


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Default Stack.useFlexGap to true.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17675989

Note that Stack is not documented in StrataKit

### Testing
View the examples page and make sure that the flex containers now have a `gap` CSS property set.
