### PR TITLE
Deprecate props on ListSubheader

### DIFF
--- a/.changeset/full-bikes-brake.md
+++ b/.changeset/full-bikes-brake.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color` prop of `ListSubheader`.

--- a/apps/website/src/content/docs/components/mui/List.md
+++ b/apps/website/src/content/docs/components/mui/List.md
@@ -13,6 +13,7 @@ links:
 - Spacing and sizing has been adjusted to better align with StrataKit's more compact visual design language.
 - The `ListSubheader` component renders as a `<div>` element by default.
 - The `subheader` props of `List` is not supported. Use the `ListSubheader` component instead.
+- The `color` prop of `ListSubheader` is not supported.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -24,6 +24,7 @@ import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type { InputProps } from "@mui/material/Input";
 import type { InputBaseProps } from "@mui/material/InputBase";
+import type { ListSubheaderOwnProps as MuiListSubheaderOwnProps } from "@mui/material/ListSubheader";
 import type { MenuProps as MuiMenuProps } from "@mui/material/Menu";
 import type { OutlinedInputProps } from "@mui/material/OutlinedInput";
 import type {
@@ -766,6 +767,13 @@ declare module "@mui/material/List" {
 declare module "@mui/material/ListItemButton" {
 	interface ListItemButtonOwnProps {
 		LinkComponent?: never;
+	}
+}
+
+declare module "@mui/material/ListSubheader" {
+	interface ListSubheaderOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		color?: MuiListSubheaderOwnProps["color"];
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `color` prop of `ListSubheader`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17599232

### Testing

<img width="1293" height="137" alt="image" src="https://github.com/user-attachments/assets/a51ddeef-fac3-4da4-a1da-907da3953fbc" />
