### PR TITLE
Deprecate Dialog props

### DIFF
--- a/.changeset/deep-moles-ring.md
+++ b/.changeset/deep-moles-ring.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `fullScreen` and `PaperComponent` props of `Dialog`

--- a/.changeset/deep-moles-ring.md
+++ b/.changeset/deep-moles-ring.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `fullScreen` and `PaperComponent` props of `Dialog`
+Deprecated `PaperComponent` prop of `Dialog`

--- a/apps/website/src/content/docs/components/mui/Dialog.md
+++ b/apps/website/src/content/docs/components/mui/Dialog.md
@@ -12,3 +12,4 @@ links:
 
 - Restyled using StrataKit's visual language.
 - The default [`container`](https://mui.com/material-ui/api/modal/#modal-prop-container) is now the [root portal container](/components/root/#portal-container).
+- The `PaperComponent` and `fullScreen` props are not supported.

--- a/apps/website/src/content/docs/components/mui/Dialog.md
+++ b/apps/website/src/content/docs/components/mui/Dialog.md
@@ -12,4 +12,4 @@ links:
 
 - Restyled using StrataKit's visual language.
 - The default [`container`](https://mui.com/material-ui/api/modal/#modal-prop-container) is now the [root portal container](/components/root/#portal-container).
-- The `PaperComponent` and `fullScreen` props are not supported.
+- The `PaperComponent` prop is not supported.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -503,8 +503,6 @@ declare module "@mui/material/Dialog" {
 		/** @deprecated Use `render` prop instead. */
 		component?: React.ElementType;
 		/** @deprecated StrataKit does not support this prop. */
-		fullScreen?: DialogProps["fullScreen"];
-		/** @deprecated StrataKit does not support this prop. */
 		PaperComponent?: DialogProps["PaperComponent"];
 	}
 }

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -502,6 +502,10 @@ declare module "@mui/material/Dialog" {
 	interface DialogProps extends Pick<CommonProps, "render"> {
 		/** @deprecated Use `render` prop instead. */
 		component?: React.ElementType;
+		/** @deprecated StrataKit does not support this prop. */
+		fullScreen?: DialogProps["fullScreen"];
+		/** @deprecated StrataKit does not support this prop. */
+		PaperComponent?: DialogProps["PaperComponent"];
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated ~~`fullScreen`~~ and `PaperComponent` props of `Dialog` .  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17652860.

<img width="729" height="285" alt="image" src="https://github.com/user-attachments/assets/0eb26428-68a9-447c-891e-5e73f620c59e" />



### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
