### PR TITLE
Deprecate DialogContent prop

### DIFF
--- a/.changeset/neat-hands-sink.md
+++ b/.changeset/neat-hands-sink.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `dividers` prop of `DialogContent`.

--- a/apps/website/src/content/docs/components/mui/Dialog.md
+++ b/apps/website/src/content/docs/components/mui/Dialog.md
@@ -13,3 +13,4 @@ links:
 - Restyled using StrataKit's visual language.
 - The default [`container`](https://mui.com/material-ui/api/modal/#modal-prop-container) is now the [root portal container](/components/root/#portal-container).
 - The `PaperComponent` prop is not supported.
+- The `dividers` prop of `DialogContent` is not supported.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -507,6 +507,13 @@ declare module "@mui/material/Dialog" {
 	}
 }
 
+declare module "@mui/material/DialogContent" {
+	interface DialogContentProps {
+		/** @deprecated StrataKit does not support this prop. */
+		dividers?: DialogContentProps["dividers"];
+	}
+}
+
 declare module "@mui/material/Divider" {
 	interface DividerOwnProps {
 		/** Add a 1x margin before and after the divider */


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `dividers` prop of `DialogContent`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17652860

<img width="593" height="146" alt="image" src="https://github.com/user-attachments/assets/0d6da045-4983-463c-8b7a-fd6bc4c052bd" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
