### PR TITLE
Deprecate `IconButton` props

### DIFF
--- a/.changeset/spicy-balloons-attend.md
+++ b/.changeset/spicy-balloons-attend.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `disableFocusRipple` prop of `IconButton`.
+Deprecated `action`, `centerRipple`, `disableFocusRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `IconButton`.

--- a/.changeset/spicy-balloons-attend.md
+++ b/.changeset/spicy-balloons-attend.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `disableFocusRipple` prop of `IconButton`.

--- a/apps/website/src/content/docs/components/mui/IconButton.md
+++ b/apps/website/src/content/docs/components/mui/IconButton.md
@@ -22,7 +22,9 @@ Make sure the **IconButton** is suitable for your use case. There may be other, 
 
 ## StrataKit MUI modifications
 
-- The `disableFocusRipple` prop is not supported.
+- The `action` prop is not supported.
+- The `LinkComponent` prop is not supported. Use the more flexible `render` prop instead.
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableFocusRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - The `"default"`, `"info"`, `"success"`, `"warning"`, `"inherit"` colors have been removed. The default color is now `"secondary"`.
 - The `size` options (`"small"`, `"medium"`, `"large"`) have all been decreased in height.
 - A `label` prop has been added. When specified, it is used as the **IconButton's** accessible name and is also shown in a tooltip on hover and focus. This is the recommended way to set the accessible name and tooltip.

--- a/apps/website/src/content/docs/components/mui/IconButton.md
+++ b/apps/website/src/content/docs/components/mui/IconButton.md
@@ -22,6 +22,7 @@ Make sure the **IconButton** is suitable for your use case. There may be other, 
 
 ## StrataKit MUI modifications
 
+- The `disableFocusRipple` prop is not supported.
 - The `"default"`, `"info"`, `"success"`, `"warning"`, `"inherit"` colors have been removed. The default color is now `"secondary"`.
 - The `size` options (`"small"`, `"medium"`, `"large"`) have all been decreased in height.
 - A `label` prop has been added. When specified, it is used as the **IconButton's** accessible name and is also shown in a tooltip on hover and focus. This is the recommended way to set the accessible name and tooltip.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -534,7 +534,7 @@ declare module "@mui/material/IconButton" {
 		inherit: false;
 	}
 
-	interface IconButtonOwnProps {
+	interface IconButtonOwnProps extends ButtonBaseDeprecatedProps {
 		LinkComponent?: never;
 
 		/**
@@ -543,6 +543,9 @@ declare module "@mui/material/IconButton" {
 		 * @default 'secondary'
 		 */
 		color?: IconButtonProps["color"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableFocusRipple?: IconButtonProps["disableFocusRipple"];
 
 		/**
 		 * The accessible name of the button, which is also shown as a tooltip on hover/focus.


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17636668

- `IconButton` component
  - `disableFocusRipple `
  - props from `ButtonBaseDeprecatedProps` interface

### Testing

<img width="613" height="206" alt="Screenshot 2026-08-11 at 14 41 02" src="https://github.com/user-attachments/assets/7e4210e9-d202-4d5a-95da-f761a7d3d799" />
