### PR TITLE
Deprecate List props

### DIFF
--- a/.changeset/fresh-balloons-flash.md
+++ b/.changeset/fresh-balloons-flash.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `subheader` prop of `List`.

--- a/apps/website/src/content/docs/components/mui/List.md
+++ b/apps/website/src/content/docs/components/mui/List.md
@@ -12,6 +12,7 @@ links:
 
 - Spacing and sizing has been adjusted to better align with StrataKit's more compact visual design language.
 - The `ListSubheader` component renders as a `<div>` element by default.
+- The `subheader` props of `List` is not supported. Use the `ListSubheader` component instead.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -756,6 +756,13 @@ declare module "@mui/material/Link" {
 	}
 }
 
+declare module "@mui/material/List" {
+	interface ListOwnProps {
+		/** @deprecated StrataKit does not support this prop.  Use `ListSubheader` component instead. */
+		subheader?: ListOwnProps["subheader"];
+	}
+}
+
 declare module "@mui/material/ListItemButton" {
 	interface ListItemButtonOwnProps {
 		LinkComponent?: never;


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `subheader` prop of `List`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17599232

<img width="251" height="44" alt="image" src="https://github.com/user-attachments/assets/188e56fa-203d-4150-a5ac-5d4b00e4a4c0" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
