### PR TITLE
Deprecate `NativeSelect` props

### DIFF
--- a/.changeset/eighty-dingos-roll.md
+++ b/.changeset/eighty-dingos-roll.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `variant` prop of `NativeSelect`.
+Deprecated `color`, `disableUnderline`, `disableInjectingGlobalStyles` and `variant` props of `NativeSelect`.

--- a/.changeset/eighty-dingos-roll.md
+++ b/.changeset/eighty-dingos-roll.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `variant` prop of `NativeSelect`.

--- a/.changeset/gentle-houses-matter.md
+++ b/.changeset/gentle-houses-matter.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Changed the default `disableUnderline` prop value of `Input` to `true`.

--- a/.changeset/six-papers-jump.md
+++ b/.changeset/six-papers-jump.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `disableUnderline` prop of `Input` and changed the default value to `true`.

--- a/.changeset/six-papers-jump.md
+++ b/.changeset/six-papers-jump.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `disableUnderline` prop of `Input` and changed the default value to `true`.
+Deprecated `color`, `disableUnderline` and `disableInjectingGlobalStyles` props of `Input`.

--- a/.changeset/tall-crews-write.md
+++ b/.changeset/tall-crews-write.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color` and `disableInjectingGlobalStyles` props of `InputBase`.

--- a/apps/website/src/content/docs/components/mui/Select.md
+++ b/apps/website/src/content/docs/components/mui/Select.md
@@ -21,6 +21,15 @@ Make sure the **Select** is suitable for your use case. There may be other, more
 
 ## StrataKit MUI modifications
 
+Modifications to `NativeSelect`:
+
+- The `color` and `disableInjectingGlobalStyles` props are not supported via `InputBase`.
+- The `disableUnderline` prop is not supported via `Input`. Changed the default value to `true`.
+- The `variant` prop is not supported.
+- Restyled using StrataKit's visual language.
+
+Modifications to `Select`:
+
 - Restyled using StrataKit's visual language.
 - The active option implementation and styling differ from the default approach. A checkmark icon has been added using a pseudo-element.
 - Includes full `forced-colors` support.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -18,7 +18,6 @@ import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type { InputProps } from "@mui/material/Input";
 import type { InputBaseProps } from "@mui/material/InputBase";
-import type { NativeSelectProps } from "@mui/material/NativeSelect";
 import type {
 	CommonProps,
 	DefaultComponentProps,
@@ -567,15 +566,14 @@ declare module "@mui/material/IconButton" {
 }
 
 declare module "@mui/material/Input" {
-	interface InputProps extends InputBaseDeprecatedProps {}
+	interface InputProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disableUnderline?: InputProps["disableUnderline"];
+	}
 
 	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
 	export default function Input(
-		props: {
-			/** @deprecated StrataKit does not support this prop. */
-			disableUnderline?: InputProps["disableUnderline"];
-		} & Omit<InputProps, "disableUnderline" | keyof InputBaseDeprecatedProps> &
-			InputBaseDeprecatedProps,
+		props: Omit<InputProps, keyof InputDeprecatedProps> & InputDeprecatedProps,
 	): React.JSX.Element;
 }
 
@@ -629,8 +627,12 @@ declare module "@mui/material/MenuItem" {
 		LinkComponent?: never;
 	}
 }
-
 declare module "@mui/material/NativeSelect" {
+	interface NativeSelectProps {
+		/** @deprecated StrataKit does not support this prop. */
+		variant?: NativeSelectProps["variant"];
+	}
+
 	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
 	export default function NativeSelect(
 		props: {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -16,6 +16,9 @@ import type { CheckboxProps } from "@mui/material/Checkbox";
 import type { FormControlProps } from "@mui/material/FormControl";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
+import type { InputProps } from "@mui/material/Input";
+import type { InputBaseProps } from "@mui/material/InputBase";
+import type { NativeSelectProps } from "@mui/material/NativeSelect";
 import type {
 	CommonProps,
 	DefaultComponentProps,
@@ -563,14 +566,49 @@ declare module "@mui/material/IconButton" {
 	}
 }
 
+declare module "@mui/material/Input" {
+	interface InputProps extends InputBaseDeprecatedProps {}
+
+	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
+	export default function Input(
+		props: {
+			/** @deprecated StrataKit does not support this prop. */
+			disableUnderline?: InputProps["disableUnderline"];
+		} & Omit<InputProps, "disableUnderline" | keyof InputBaseDeprecatedProps> &
+			InputBaseDeprecatedProps,
+	): React.JSX.Element;
+}
+
+interface InputDeprecatedProps extends InputBaseDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	disableUnderline?: InputProps["disableUnderline"];
+}
+
 declare module "@mui/material/InputBase" {
 	interface InputBasePropsColorOverrides {
+		primary: false;
 		secondary: false;
 		info: false;
 		success: false;
 		warning: false;
 		error: false;
 	}
+
+	interface InputBaseProps {
+		/** @deprecated StrataKit does not support this prop. */
+		color?: InputBaseProps["color"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		disableInjectingGlobalStyles?: InputBaseProps["disableInjectingGlobalStyles"];
+	}
+}
+
+interface InputBaseDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	color?: InputBaseProps["color"];
+
+	/** @deprecated StrataKit does not support this prop. */
+	disableInjectingGlobalStyles?: InputBaseProps["disableInjectingGlobalStyles"];
 }
 
 declare module "@mui/material/Link" {
@@ -590,6 +628,17 @@ declare module "@mui/material/MenuItem" {
 	interface MenuItemOwnProps {
 		LinkComponent?: never;
 	}
+}
+
+declare module "@mui/material/NativeSelect" {
+	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
+	export default function NativeSelect(
+		props: {
+			/** @deprecated StrataKit does not support this prop. */
+			variant?: NativeSelectProps["variant"];
+		} & Omit<NativeSelectProps, "variant" | keyof InputDeprecatedProps> &
+			InputDeprecatedProps,
+	): React.JSX.Element;
 }
 
 declare module "@mui/material/PaginationItem" {

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -429,6 +429,11 @@ function createTheme(args: CreateThemeArgs) {
 					classes: { root: "🥝MuiInput" },
 				},
 			},
+			MuiInput: {
+				defaultProps: {
+					disableUnderline: true,
+				},
+			},
 			MuiInputAdornment: { defaultProps: { component: Role.div } },
 			MuiInputLabel: {
 				defaultProps: {


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17700798

- `InputBase` component
  - `color` prop
  - `disableInjectingGlobalStyles` prop
- `Input` component
  - `disableUnderline` prop (and changed the default value to `true`)
- `NativeSelect`
  - `variant` prop

### Testing

<img width="539" height="176" alt="Screenshot 2026-08-11 at 16 35 51" src="https://github.com/user-attachments/assets/1c741318-38a6-4c40-b178-809533f4f3dc" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>