### PR TITLE
Deprecate `Card` props

### DIFF
--- a/.changeset/moody-flowers-draw.md
+++ b/.changeset/moody-flowers-draw.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `elevation`, `raised`, `square` and `variant` prop of `Card`.

--- a/.changeset/moody-flowers-draw.md
+++ b/.changeset/moody-flowers-draw.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `elevation`, `raised`, `square` and `variant` prop of `Card`.
+Deprecated `elevation`, `raised`, `square` and `variant` props of `Card`.

--- a/.changeset/neat-ways-build.md
+++ b/.changeset/neat-ways-build.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props of `CardActionArea` component.

--- a/.changeset/polite-deer-mate.md
+++ b/.changeset/polite-deer-mate.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `disableTypography` prop of `CardHeader`.

--- a/apps/website/src/content/docs/components/mui/Card.md
+++ b/apps/website/src/content/docs/components/mui/Card.md
@@ -24,12 +24,23 @@ Make sure the **Card** is suitable for your use case. There may be other, more a
 
 ## StrataKit MUI modifications
 
+Modifications to `Card`:
+
 - The `elevation`, `raised` and `square` props are not supported.
-- `Card` is rendered as an [`<article>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article) element by default. This programmatically indicates the bounds of the **Card’s** contents.
-- `CardHeader`'s `disableTypography` prop is not supported.
-- `CardHeader`'s `title` is rendered as an `<h2>` by default.
-- `CardActionArea` has been redesigned to no longer wrap the entire card content. Instead, it should be used in the **Card's** title.
-- `Card` defaults to `variant="outlined"`. The `variant` prop is not supported.
+- Rendered as an [`<article>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article) element by default. This programmatically indicates the bounds of the **Card’s** contents.
+- The `variant` prop defaults to `"outlined"`. The `variant` prop is not supported.
+
+Modifications to `CardHeader`:
+
+- The `disableTypography` prop is not supported.
+- The `title` is rendered as an `<h2>` by default.
+
+Modifications to `CardActionArea`:
+
+- The `action` prop is not supported.
+- The `LinkComponent` prop is not supported. Use the more flexible `render` prop instead.
+- Ripple effect removed. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
+- Redesigned to no longer wrap the entire card content. Instead, it should be used in the **Card's** title.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Card.md
+++ b/apps/website/src/content/docs/components/mui/Card.md
@@ -24,10 +24,12 @@ Make sure the **Card** is suitable for your use case. There may be other, more a
 
 ## StrataKit MUI modifications
 
+- The `elevation`, `raised` and `square` props are not supported.
 - `Card` is rendered as an [`<article>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article) element by default. This programmatically indicates the bounds of the **Card’s** contents.
+- `CardHeader`'s `disableTypography` prop is not supported.
 - `CardHeader`'s `title` is rendered as an `<h2>` by default.
 - `CardActionArea` has been redesigned to no longer wrap the entire card content. Instead, it should be used in the **Card's** title.
-- `Card` defaults to `variant="outlined"`.
+- `Card` defaults to `variant="outlined"`. The `variant` prop is not supported.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -12,6 +12,7 @@ import type { BadgeProps } from "@mui/material/Badge";
 import type { ButtonProps } from "@mui/material/Button";
 import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { ButtonGroupProps } from "@mui/material/ButtonGroup";
+import type { CardProps } from "@mui/material/Card";
 import type { CheckboxProps } from "@mui/material/Checkbox";
 import type { FormControlProps } from "@mui/material/FormControl";
 import type { IconProps } from "@mui/material/Icon";
@@ -23,6 +24,7 @@ import type {
 	DefaultComponentProps,
 	OverridableTypeMap,
 } from "@mui/material/OverridableComponent";
+import type { PaperOwnProps } from "@mui/material/Paper";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { SwitchProps } from "@mui/material/Switch";
@@ -315,18 +317,35 @@ declare module "@mui/material/BottomNavigationAction" {
 
 declare module "@mui/material/Card" {
 	interface CardOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		elevation?: PaperOwnProps["elevation"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		raised?: CardProps["raised"];
+
+		/** @deprecated StrataKit does not support this prop. */
+		square?: PaperOwnProps["square"];
+
 		/**
 		 * The default variant with `@stratakit/mui` is `"outlined"`.
 		 *
 		 * @default 'outlined'
+		 * @deprecated StrataKit does not support this prop.
 		 */
-		variant?: "outlined" | "elevation";
+		variant?: PaperOwnProps["variant"];
 	}
 }
 
 declare module "@mui/material/CardActionArea" {
-	interface CardActionAreaOwnProps {
+	interface CardActionAreaOwnProps extends ButtonBaseDeprecatedProps {
 		LinkComponent?: never;
+	}
+}
+
+declare module "@mui/material/CardHeader" {
+	interface CardHeaderOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		disableTypography?: CardHeaderOwnProps["disableTypography"];
 	}
 }
 


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17638515

- `Card` component
  - `elevation` prop
  - `raised` prop
  - `square` prop
  - `variant` prop
- `CardActionArea` component
  - props from `ButtonBaseDeprecatedProps` interface
- `CardHeader` component
  - `disableTypography` prop

### Testing

<img width="241" height="271" alt="Screenshot 2026-08-12 at 13 00 14" src="https://github.com/user-attachments/assets/fbfb40ba-cc2b-40e6-b019-3ed260174179" />
<img width="491" height="151" alt="Screenshot 2026-08-12 at 13 15 21" src="https://github.com/user-attachments/assets/514c06f3-960b-414b-8fbd-758861b7b573" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>