### PR TITLE
Deprecate StepButton props

### DIFF
--- a/.changeset/cozy-eggs-cry.md
+++ b/.changeset/cozy-eggs-cry.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `TouchRippleProps` and `touchRippleRef` props of `ButtonBase` component.

--- a/.changeset/cozy-eggs-cry.md
+++ b/.changeset/cozy-eggs-cry.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `TouchRippleProps` and `touchRippleRef` props of `ButtonBase` component.
+Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `TouchRippleProps` and `touchRippleRef` props of `StepButton` component.

--- a/apps/website/src/content/docs/components/mui/Stepper.md
+++ b/apps/website/src/content/docs/components/mui/Stepper.md
@@ -14,6 +14,8 @@ links:
 - The `connector` prop of `Stepper` is not supported.
 - The `StepIcon` has been fully replaced with new icons and a custom CSS implementation.
 - Reduced the hit target size of `StepButton`.
+- Ripple effect removed from `StepButton`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
+- The `action` prop of `StepButton` is not supported.
 - The `connector` prop is used to add `aria-hidden="true"` to the `StepConnector`.
 - Includes `forced-colors` support.
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1019,7 +1019,9 @@ interface SwitchDeprecatedProps extends IconButtonDeprecatedProps {
 }
 
 declare module "@mui/material/StepButton" {
-	interface StepButtonOwnProps {
+	interface StepButtonOwnProps extends ButtonBaseDeprecatedProps {
+		/** @deprecated StrataKit does not support this prop. */
+		icon?: StepButtonOwnProps["icon"];
 		LinkComponent?: never;
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `action`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `icon`, `TouchRippleProps` and `touchRippleRef` props of `StepButton` component.   Only `icon` is unique, others came from `ButtonBase`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17674513

<img width="508" height="29" alt="image" src="https://github.com/user-attachments/assets/222d7198-320b-4439-b9a4-33c1349912df" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
