### PR TITLE
Deprecate StepIcon

### DIFF
--- a/.changeset/gold-trees-flash.md
+++ b/.changeset/gold-trees-flash.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `StepIcon`. Use `icon` prop of `StepLabel` instead.

--- a/.changeset/gold-trees-flash.md
+++ b/.changeset/gold-trees-flash.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `StepIcon`. Use `icon` prop of `StepLabel` instead.
+Deprecated `StepIcon`. StrataKit does not support custom icons in `Stepper`.

--- a/.changeset/petite-radios-trade.md
+++ b/.changeset/petite-radios-trade.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `icon` prop of `StepLabel`.

--- a/apps/website/src/content/docs/components/mui/Stepper.md
+++ b/apps/website/src/content/docs/components/mui/Stepper.md
@@ -12,7 +12,7 @@ links:
 
 - Lightly styled using StrataKit's visual language.
 - The `connector` prop of `Stepper` is not supported.
-- The `StepIcon` has been fully replaced with new icons and a custom CSS implementation. Do not use `StepIcon` directly, instead use the `icon` prop of `StepLabel`.
+- The `StepIcon` has been fully replaced with new icons and a custom CSS implementation and is not supported. StrataKit does not support custom icons in `Stepper`.
 - Reduced the hit target size of `StepButton`.
 - Ripple effect removed from `StepButton`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - The `action` prop of `StepButton` is not supported.

--- a/apps/website/src/content/docs/components/mui/Stepper.md
+++ b/apps/website/src/content/docs/components/mui/Stepper.md
@@ -12,7 +12,7 @@ links:
 
 - Lightly styled using StrataKit's visual language.
 - The `connector` prop of `Stepper` is not supported.
-- The `StepIcon` has been fully replaced with new icons and a custom CSS implementation.
+- The `StepIcon` has been fully replaced with new icons and a custom CSS implementation. Do not use `StepIcon` directly, instead use the `icon` prop of `StepLabel`.
 - Reduced the hit target size of `StepButton`.
 - Ripple effect removed from `StepButton`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - The `action` prop of `StepButton` is not supported.

--- a/apps/website/src/content/docs/components/mui/Stepper.md
+++ b/apps/website/src/content/docs/components/mui/Stepper.md
@@ -12,7 +12,7 @@ links:
 
 - Lightly styled using StrataKit's visual language.
 - The `connector` prop of `Stepper` is not supported.
-- The `StepIcon` has been fully replaced with new icons and a custom CSS implementation and is not supported. Both `StepIcon` and the `icon` prop of `StepLabel`. are not supported.
+- The `StepIcon` has been fully replaced with new icons and a custom CSS implementation and is not supported. Both `StepIcon` and the `icon` prop of `StepLabel` are not supported.
 - Reduced the hit target size of `StepButton`.
 - Ripple effect removed from `StepButton`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - The `action` prop of `StepButton` is not supported.

--- a/apps/website/src/content/docs/components/mui/Stepper.md
+++ b/apps/website/src/content/docs/components/mui/Stepper.md
@@ -12,7 +12,7 @@ links:
 
 - Lightly styled using StrataKit's visual language.
 - The `connector` prop of `Stepper` is not supported.
-- The `StepIcon` has been fully replaced with new icons and a custom CSS implementation and is not supported. StrataKit does not support custom icons in `Stepper`.
+- The `StepIcon` has been fully replaced with new icons and a custom CSS implementation and is not supported. Both `StepIcon` and the `icon` prop of `StepLabel`. are not supported.
 - Reduced the hit target size of `StepButton`.
 - Ripple effect removed from `StepButton`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - The `action` prop of `StepButton` is not supported.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -37,6 +37,7 @@ import type { RadioProps } from "@mui/material/Radio";
 import type { SelectProps } from "@mui/material/Select";
 import type {} from "@mui/material/Slide";
 import type { StepIconProps } from "@mui/material/StepIcon";
+import type {} from "@mui/material/StepLabel";
 import type {} from "@mui/material/Stepper";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { SwitchProps } from "@mui/material/Switch";
@@ -1030,6 +1031,13 @@ declare module "@mui/material/StepButton" {
 declare module "@mui/material/StepIcon" {
 	/** @deprecated StrataKit does not support this component. */
 	export default function StepIcon(props: StepIconProps): React.JSX.Element;
+}
+
+declare module "@mui/material/StepLabel" {
+	interface StepLabelProps {
+		/** @deprecated StrataKit does not support this prop. */
+		icon?: StepLabelProps["icon"];
+	}
 }
 
 declare module "@mui/material/Stepper" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -36,6 +36,7 @@ import type { PaperOwnProps } from "@mui/material/Paper";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SelectProps } from "@mui/material/Select";
 import type {} from "@mui/material/Slide";
+import type { StepIconProps } from "@mui/material/StepIcon";
 import type {} from "@mui/material/Stepper";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { SwitchProps } from "@mui/material/Switch";
@@ -1024,6 +1025,11 @@ declare module "@mui/material/StepButton" {
 		icon?: StepButtonOwnProps["icon"];
 		LinkComponent?: never;
 	}
+}
+
+declare module "@mui/material/StepIcon" {
+	/** @deprecated StrataKit does not support this component. Use the `icon` prop of `StepLabel`. */
+	export default function StepIcon(props: StepIconProps): React.JSX.Element;
 }
 
 declare module "@mui/material/Stepper" {

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -1028,7 +1028,7 @@ declare module "@mui/material/StepButton" {
 }
 
 declare module "@mui/material/StepIcon" {
-	/** @deprecated StrataKit does not support this component. Use the `icon` prop of `StepLabel`. */
+	/** @deprecated StrataKit does not support this component. */
 	export default function StepIcon(props: StepIconProps): React.JSX.Element;
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

- Deprecated `StepIcon`.
- Deprecated `icon` prop of  `StepLabel`

See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17674513 and https://github.com/iTwin/stratakit/pull/1363

<img width="398" height="113" alt="image" src="https://github.com/user-attachments/assets/3704e0d1-1165-40c0-9325-865be28a5fbe" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
