### PR TITLE
Deprecate Stepper.connector

### DIFF
--- a/.changeset/shaky-lamps-joke.md
+++ b/.changeset/shaky-lamps-joke.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `connector` prop of `Stepper`.

--- a/apps/website/src/content/docs/components/mui/Stepper.md
+++ b/apps/website/src/content/docs/components/mui/Stepper.md
@@ -11,6 +11,7 @@ links:
 ## StrataKit MUI modifications
 
 - Lightly styled using StrataKit's visual language.
+- The `connector` prop of `Stepper` is not supported.
 - The `StepIcon` has been fully replaced with new icons and a custom CSS implementation.
 - Reduced the hit target size of `StepButton`.
 - The `connector` prop is used to add `aria-hidden="true"` to the `StepConnector`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -35,6 +35,7 @@ import type { PaperOwnProps } from "@mui/material/Paper";
 import type { RadioProps } from "@mui/material/Radio";
 import type { SelectProps } from "@mui/material/Select";
 import type {} from "@mui/material/Slide";
+import type {} from "@mui/material/Stepper";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
@@ -994,6 +995,13 @@ interface SwitchDeprecatedProps extends IconButtonDeprecatedProps {
 declare module "@mui/material/StepButton" {
 	interface StepButtonOwnProps {
 		LinkComponent?: never;
+	}
+}
+
+declare module "@mui/material/Stepper" {
+	interface StepperOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		connector?: StepperOwnProps["connector"];
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `connector` prop of `Stepper`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17674513

<img width="381" height="41" alt="image" src="https://github.com/user-attachments/assets/6a797a06-fe91-4f75-b31d-5b100aac26db" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
