### PR TITLE
bump `typescript` to 7.0

### DIFF
--- a/internal/minimal-template/package.json
+++ b/internal/minimal-template/package.json
@@ -23,7 +23,7 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^5.1.1",
 		"babel-plugin-react-compiler": "^1.0.0",
-		"typescript": "~6.0.3",
+		"typescript": "~7.0.2",
 		"vite": "^7.3.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: ^19.2.8
       version: 19.2.8
     typescript:
-      specifier: ~6.0.3
-      version: 6.0.3
+      specifier: ~7.0.2
+      version: 7.0.2
 
 overrides:
   lightningcss: 1.30.1
@@ -81,7 +81,7 @@ importers:
         version: 4.23.1
       typescript:
         specifier: "catalog:"
-        version: 6.0.3
+        version: 7.0.2
       wireit:
         specifier: ^0.14.13
         version: 0.14.13
@@ -108,7 +108,7 @@ importers:
         version: 9.6.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@mui/system@9.0.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       "@react-router/node":
         specifier: ^7.18.1
-        version: 7.18.1(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@6.0.3)
+        version: 7.18.1(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
       "@stratakit/bricks":
         specifier: workspace:*
         version: link:../../packages/bricks
@@ -166,7 +166,7 @@ importers:
         version: 1.62.1
       "@react-router/dev":
         specifier: ^7.18.1
-        version: 7.18.1(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.1)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1))
+        version: 7.18.1(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.1)(typescript@7.0.2)(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1))
       "@types/node":
         specifier: "catalog:"
         version: 22.19.19
@@ -184,7 +184,7 @@ importers:
         version: 1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce)
       typescript:
         specifier: "catalog:"
-        version: 6.0.3
+        version: 7.0.2
       vite:
         specifier: ^7.3.5
         version: 7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1)
@@ -196,13 +196,13 @@ importers:
         version: 1.1.0(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1))
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1))
+        version: 6.1.1(typescript@7.0.2)(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1))
 
   apps/website:
     dependencies:
       "@astrojs/starlight":
         specifier: ^0.40.0
-        version: 0.40.0(astro@6.4.8(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.23.1))(typescript@6.0.3)
+        version: 0.40.0(astro@6.4.8(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.23.1))(typescript@7.0.2)
       "@mui/material":
         specifier: "catalog:"
         version: 9.0.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -269,7 +269,7 @@ importers:
         version: 27.0.2
       typescript:
         specifier: "catalog:"
-        version: 6.0.3
+        version: 7.0.2
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -373,7 +373,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       typescript:
         specifier: "catalog:"
-        version: 6.0.3
+        version: 7.0.2
 
   packages/foundations:
     dependencies:
@@ -413,7 +413,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       typescript:
         specifier: "catalog:"
-        version: 6.0.3
+        version: 7.0.2
 
   packages/icons: {}
 
@@ -440,7 +440,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       typescript:
         specifier: "catalog:"
-        version: 6.0.3
+        version: 7.0.2
 
   packages/mui:
     dependencies:
@@ -495,7 +495,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       typescript:
         specifier: "catalog:"
-        version: 6.0.3
+        version: 7.0.2
 
   packages/structures:
     dependencies:
@@ -541,7 +541,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       typescript:
         specifier: "catalog:"
-        version: 6.0.3
+        version: 7.0.2
 
 packages:
   "@actions/github@9.1.1":
@@ -2710,6 +2710,186 @@ packages:
       {
         integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==,
       }
+
+  "@typescript/typescript-aix-ppc64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [ppc64]
+    os: [aix]
+
+  "@typescript/typescript-darwin-arm64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@typescript/typescript-darwin-x64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@typescript/typescript-freebsd-arm64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [arm64]
+    os: [freebsd]
+
+  "@typescript/typescript-freebsd-x64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@typescript/typescript-linux-arm64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@typescript/typescript-linux-arm@7.0.2":
+    resolution:
+      {
+        integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [arm]
+    os: [linux]
+
+  "@typescript/typescript-linux-loong64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@typescript/typescript-linux-mips64el@7.0.2":
+    resolution:
+      {
+        integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [mips64el]
+    os: [linux]
+
+  "@typescript/typescript-linux-ppc64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@typescript/typescript-linux-riscv64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@typescript/typescript-linux-s390x@7.0.2":
+    resolution:
+      {
+        integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@typescript/typescript-linux-x64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [x64]
+    os: [linux]
+
+  "@typescript/typescript-netbsd-arm64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [arm64]
+    os: [netbsd]
+
+  "@typescript/typescript-netbsd-x64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [x64]
+    os: [netbsd]
+
+  "@typescript/typescript-openbsd-arm64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [arm64]
+    os: [openbsd]
+
+  "@typescript/typescript-openbsd-x64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@typescript/typescript-sunos-x64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [x64]
+    os: [sunos]
+
+  "@typescript/typescript-win32-arm64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@typescript/typescript-win32-x64@7.0.2":
+    resolution:
+      {
+        integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==,
+      }
+    engines: { node: ">=16.20.0" }
+    cpu: [x64]
+    os: [win32]
 
   "@ungap/structured-clone@1.3.1":
     resolution:
@@ -5402,12 +5582,12 @@ packages:
       }
     engines: { node: ">=0.6.11 <=0.7.0 || >=0.7.3" }
 
-  typescript@6.0.3:
+  typescript@7.0.2:
     resolution:
       {
-        integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==,
+        integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==,
       }
-    engines: { node: ">=14.17" }
+    engines: { node: ">=16.20.0" }
     hasBin: true
 
   ufo@1.6.4:
@@ -5993,7 +6173,7 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  "@astrojs/starlight@0.40.0(astro@6.4.8(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.23.1))(typescript@6.0.3)":
+  "@astrojs/starlight@0.40.0(astro@6.4.8(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.23.1))(typescript@7.0.2)":
     dependencies:
       "@astrojs/markdown-remark": 7.2.2
       "@astrojs/mdx": 6.0.3(astro@6.4.8(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(rollup@4.61.0)(tsx@4.23.1))
@@ -6009,7 +6189,7 @@ snapshots:
       hast-util-select: 6.0.4
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
-      i18next: 26.3.6(typescript@6.0.3)
+      i18next: 26.3.6(typescript@7.0.2)
       js-yaml: 4.3.1
       klona: 2.0.6
       magic-string: 0.30.21
@@ -6927,7 +7107,7 @@ snapshots:
 
   "@popperjs/core@2.11.8": {}
 
-  "@react-router/dev@7.18.1(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.1)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1))":
+  "@react-router/dev@7.18.1(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.1)(typescript@7.0.2)(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1))":
     dependencies:
       "@babel/core": 7.29.7
       "@babel/generator": 7.29.7
@@ -6936,7 +7116,7 @@ snapshots:
       "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7)
       "@babel/traverse": 7.29.7
       "@babel/types": 7.29.7
-      "@react-router/node": 7.18.1(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@6.0.3)
+      "@react-router/node": 7.18.1(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
       "@remix-run/node-fetch-server": 0.13.3
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.12
@@ -6956,11 +7136,11 @@ snapshots:
       react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       semver: 7.8.5
       tinyglobby: 0.2.17
-      valibot: 1.4.2(typescript@6.0.3)
+      valibot: 1.4.2(typescript@7.0.2)
       vite: 7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1)
       vite-node: 3.2.4(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - "@types/node"
       - babel-plugin-macros
@@ -6976,12 +7156,12 @@ snapshots:
       - tsx
       - yaml
 
-  "@react-router/node@7.18.1(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@6.0.3)":
+  "@react-router/node@7.18.1(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)":
     dependencies:
       "@mjackson/node-fetch-server": 0.2.0
       react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   "@remix-run/node-fetch-server@0.13.3": {}
 
@@ -7184,6 +7364,66 @@ snapshots:
   "@types/xml2js@0.4.14":
     dependencies:
       "@types/node": 24.13.3
+
+  "@typescript/typescript-aix-ppc64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-darwin-arm64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-darwin-x64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-freebsd-arm64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-freebsd-x64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-linux-arm64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-linux-arm@7.0.2":
+    optional: true
+
+  "@typescript/typescript-linux-loong64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-linux-mips64el@7.0.2":
+    optional: true
+
+  "@typescript/typescript-linux-ppc64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-linux-riscv64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-linux-s390x@7.0.2":
+    optional: true
+
+  "@typescript/typescript-linux-x64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-netbsd-arm64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-netbsd-x64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-openbsd-arm64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-openbsd-x64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-sunos-x64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-win32-arm64@7.0.2":
+    optional: true
+
+  "@typescript/typescript-win32-x64@7.0.2":
+    optional: true
 
   "@ungap/structured-clone@1.3.1": {}
 
@@ -7957,9 +8197,9 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  i18next@26.3.6(typescript@6.0.3):
+  i18next@26.3.6(typescript@7.0.2):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   immer@11.1.15: {}
 
@@ -9187,9 +9427,9 @@ snapshots:
       "@ts-morph/common": 0.28.1
       code-block-writer: 13.0.3
 
-  tsconfck@3.1.6(typescript@6.0.3):
+  tsconfck@3.1.6(typescript@7.0.2):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   tslib@2.8.1:
     optional: true
@@ -9202,7 +9442,28 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  typescript@6.0.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      "@typescript/typescript-aix-ppc64": 7.0.2
+      "@typescript/typescript-darwin-arm64": 7.0.2
+      "@typescript/typescript-darwin-x64": 7.0.2
+      "@typescript/typescript-freebsd-arm64": 7.0.2
+      "@typescript/typescript-freebsd-x64": 7.0.2
+      "@typescript/typescript-linux-arm": 7.0.2
+      "@typescript/typescript-linux-arm64": 7.0.2
+      "@typescript/typescript-linux-loong64": 7.0.2
+      "@typescript/typescript-linux-mips64el": 7.0.2
+      "@typescript/typescript-linux-ppc64": 7.0.2
+      "@typescript/typescript-linux-riscv64": 7.0.2
+      "@typescript/typescript-linux-s390x": 7.0.2
+      "@typescript/typescript-linux-x64": 7.0.2
+      "@typescript/typescript-netbsd-arm64": 7.0.2
+      "@typescript/typescript-netbsd-x64": 7.0.2
+      "@typescript/typescript-openbsd-arm64": 7.0.2
+      "@typescript/typescript-openbsd-x64": 7.0.2
+      "@typescript/typescript-sunos-x64": 7.0.2
+      "@typescript/typescript-win32-arm64": 7.0.2
+      "@typescript/typescript-win32-x64": 7.0.2
 
   ufo@1.6.4: {}
 
@@ -9305,9 +9566,9 @@ snapshots:
 
   uuid@14.0.1: {}
 
-  valibot@1.4.2(typescript@6.0.3):
+  valibot@1.4.2(typescript@7.0.2):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   vfile-location@5.0.3:
     dependencies:
@@ -9355,11 +9616,11 @@ snapshots:
       uuid: 14.0.1
       vite: 7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1)
 
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1)):
+  vite-tsconfig-paths@6.1.1(typescript@7.0.2)(vite@7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
+      tsconfck: 3.1.6(typescript@7.0.2)
       vite: 7.3.5(@types/node@22.19.19)(lightningcss@1.30.1(patch_hash=08799541637750cfcbce57a74df05d308e21746a013ef47cad57bdaea23282ce))(tsx@4.23.1)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ catalog:
   lightningcss: ^1.33.0
   react: ^19.2.8
   react-dom: ^19.2.8
-  typescript: ~6.0.3
+  typescript: ~7.0.2
 
 minimumReleaseAgeStrict: true
 


### PR DESCRIPTION
### Changes

[TypeScript 7.0](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) was released recently, bringing with it the Go rewrite. This turned out to be a very straightforward upgrade from 6.0 (which did require a few migration changes in https://github.com/iTwin/stratakit/pull/1458).

### Testing

Everything seems to be working correctly.

Noticed that typechecking is now 15-20s faster (from ~50s → ~30s, including build step).
