### PR TITLE
remove Emotion from peer deps

### DIFF
--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -16,8 +16,6 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.35",
-		"@emotion/react": "^11.14.0",
-		"@emotion/styled": "^11.14.1",
 		"@mui/material": "catalog:",
 		"@mui/utils": "catalog:",
 		"@mui/x-date-pickers": "catalog:",

--- a/apps/website/src/content/docs/getting-started/develop.mdx
+++ b/apps/website/src/content/docs/getting-started/develop.mdx
@@ -21,7 +21,7 @@ Open the [minimal starter template on StackBlitz](https://stackblitz.com/github/
    npm add @stratakit/mui @stratakit/icons
    ```
 
-   You will also need to install `@mui/material` and its peer dependencies (`@emotion/styled` and `@emotion/react`).
+   You will also need to install `@mui/material`.
 
 2. **Configure your bundler**
 

--- a/internal/minimal-template/package.json
+++ b/internal/minimal-template/package.json
@@ -9,8 +9,6 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"@emotion/react": "^11.14.0",
-		"@emotion/styled": "^11.14.1",
 		"@mui/material": "^9.0.0",
 		"@stratakit/icons": "latest",
 		"@stratakit/mui": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,12 +91,6 @@ importers:
       "@ariakit/react":
         specifier: ^0.4.35
         version: 0.4.35(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      "@emotion/react":
-        specifier: ^11.14.0
-        version: 11.14.0(@types/react@19.2.18)(react@19.2.8)
-      "@emotion/styled":
-        specifier: ^11.14.1
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
       "@mui/material":
         specifier: "catalog:"
         version: 9.0.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)


### PR DESCRIPTION
### Changes

This PR updates the docs, the minimal-template, and the test-app to remove Emotion from "peer dependencies".

After https://github.com/iTwin/stratakit/pull/1312, `@emotion` packages are direct dependencies of `@stratakit/mui` and therefore don't need to be installed _manually_ by consumers.

### Testing

In #1312, I said this about `@emotion` packages:

> This could mean that these packages don't need to be installed manually, at least for some package managers. (Unverified hypothesis)

This hypothesis has now been _actually_ verified. The minimal template created from this branch (without `@emotion` packages in `package.json`) works fine: https://stackblitz.com/github/iTwin/stratakit/tree/mayank/emotion-peer-dep/internal/minimal-template?file=package.json