### PR TITLE
Deprecate `Select` props

### DIFF
--- a/.changeset/better-toes-send.md
+++ b/.changeset/better-toes-send.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `disableUnderline` and `notched` props of `FilledInput`.
+Deprecated `FilledInput` component.

--- a/.changeset/better-toes-send.md
+++ b/.changeset/better-toes-send.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `disableUnderline` and `notched` props of `FilledInput`.

--- a/.changeset/silent-windows-tickle.md
+++ b/.changeset/silent-windows-tickle.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `IconComponent`, `variant` and `disableUnderline` props of `Select`.

--- a/.changeset/silent-windows-tickle.md
+++ b/.changeset/silent-windows-tickle.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `IconComponent`, `variant` and `disableUnderline` props of `Select`.
+Deprecated `color`, `disableInjectingGlobalStyles`, `disableUnderline`, `IconComponent`, `notched` and `variant` props of `Select`.

--- a/.changeset/tall-walls-fry.md
+++ b/.changeset/tall-walls-fry.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `notched` prop of `OutlinedInput`.

--- a/.changeset/tall-walls-fry.md
+++ b/.changeset/tall-walls-fry.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `notched` prop of `OutlinedInput`.
+Deprecated `color`, `disableInjectingGlobalStyles` and `notched` props of `OutlinedInput`.

--- a/apps/website/src/content/docs/components/mui/Select.md
+++ b/apps/website/src/content/docs/components/mui/Select.md
@@ -30,6 +30,7 @@ Modifications to `NativeSelect`:
 
 Modifications to `Select`:
 
+- The `disableUnderline`, `IconComponent`, `notched` and `variant` props are not supported.
 - Restyled using StrataKit's visual language.
 - The active option implementation and styling differ from the default approach. A checkmark icon has been added using a pseudo-element.
 - Includes full `forced-colors` support.

--- a/apps/website/src/content/docs/components/mui/Select.md
+++ b/apps/website/src/content/docs/components/mui/Select.md
@@ -30,7 +30,7 @@ Modifications to `NativeSelect`:
 
 Modifications to `Select`:
 
-- The `disableUnderline`, `IconComponent`, `notched` and `variant` props are not supported.
+- The `color`, `disableInjectingGlobalStyles`, `disableUnderline`, `IconComponent`, `notched` and `variant` props are not supported.
 - Restyled using StrataKit's visual language.
 - The active option implementation and styling differ from the default approach. A checkmark icon has been added using a pseudo-element.
 - Includes full `forced-colors` support.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -504,6 +504,7 @@ declare module "@mui/material/Fab" {
 declare module "@mui/material/FilledInput" {
 	interface FilledInputProps extends FilledInputDeprecatedProps {}
 
+	/** @deprecated StrataKit does not support this component. */
 	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
 	export default function FilledInput(
 		props: Omit<FilledInputProps, keyof FilledInputDeprecatedProps> &

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -14,11 +14,13 @@ import type { ButtonBaseProps } from "@mui/material/ButtonBase";
 import type { ButtonGroupProps } from "@mui/material/ButtonGroup";
 import type { CardProps } from "@mui/material/Card";
 import type { CheckboxProps } from "@mui/material/Checkbox";
+import type { FilledInputProps } from "@mui/material/FilledInput";
 import type { FormControlProps } from "@mui/material/FormControl";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
 import type { InputProps } from "@mui/material/Input";
 import type { InputBaseProps } from "@mui/material/InputBase";
+import type { OutlinedInputProps } from "@mui/material/OutlinedInput";
 import type {
 	CommonProps,
 	DefaultComponentProps,
@@ -26,6 +28,7 @@ import type {
 } from "@mui/material/OverridableComponent";
 import type { PaperOwnProps } from "@mui/material/Paper";
 import type { RadioProps } from "@mui/material/Radio";
+import type { SelectProps } from "@mui/material/Select";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
@@ -498,6 +501,23 @@ declare module "@mui/material/Fab" {
 	}
 }
 
+declare module "@mui/material/FilledInput" {
+	interface FilledInputProps extends FilledInputDeprecatedProps {}
+
+	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
+	export default function FilledInput(
+		props: Omit<FilledInputProps, keyof FilledInputDeprecatedProps> &
+			FilledInputDeprecatedProps,
+	): React.JSX.Element;
+}
+
+interface FilledInputDeprecatedProps extends InputBaseDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	disableUnderline?: FilledInputProps["disableUnderline"];
+	/** @deprecated StrataKit does not support this prop. */
+	notched?: FilledInputProps["notched"];
+}
+
 declare module "@mui/material/FormControl" {
 	interface FormControlPropsColorOverrides {
 		error: false;
@@ -662,6 +682,21 @@ declare module "@mui/material/NativeSelect" {
 	): React.JSX.Element;
 }
 
+declare module "@mui/material/OutlinedInput" {
+	interface OutlinedInputProps extends OutlinedInputDeprecatedProps {}
+
+	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
+	export default function OutlinedInput(
+		props: Omit<OutlinedInputProps, keyof OutlinedInputDeprecatedProps> &
+			OutlinedInputDeprecatedProps,
+	): React.JSX.Element;
+}
+
+interface OutlinedInputDeprecatedProps extends InputBaseDeprecatedProps {
+	/** @deprecated StrataKit does not support this prop. */
+	notched?: OutlinedInputProps["notched"];
+}
+
 declare module "@mui/material/PaginationItem" {
 	interface PaginationItemOwnProps {
 		LinkComponent?: never;
@@ -731,6 +766,27 @@ interface RadioDeprecatedProps extends ButtonBaseDeprecatedProps {
 
 	/** @deprecated StrataKit does not support this prop. */
 	size?: RadioProps["size"];
+}
+
+declare module "@mui/material/Select" {
+	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
+	export default function Select(
+		props: {
+			/** @deprecated StrataKit does not support this prop. */
+			IconComponent?: SelectProps["IconComponent"];
+			/** @deprecated StrataKit does not support this prop. */
+			variant?: SelectProps["variant"];
+			/** @deprecated StrataKit does not support this prop. */
+			disableUnderline?: SelectProps["disableUnderline"];
+		} & Omit<
+			SelectProps,
+			| "IconComponent"
+			| "variant"
+			| "disableUnderline"
+			| keyof OutlinedInputDeprecatedProps
+		> &
+			OutlinedInputDeprecatedProps,
+	): React.JSX.Element;
 }
 
 declare module "@mui/material/Slider" {


### PR DESCRIPTION
### Changes

Deprecating remaining unwanted props from https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17626251

- `FilledInput` component **itself is deprecated**
  - `disableUnderline` prop
  - `notched` prop
  -  props from `InputBaseDeprecatedProps` interface
- `OutlinedInput` component
  - `notched` prop
  - props from `InputBaseDeprecatedProps` interface
- `Select` component
  - `IconComponent` prop
  - `variant` prop
  - `disableUnderline` prop
  - props from `OutlinedInputDeprecatedProps` interface

### Testing

<img width="644" height="328" alt="Screenshot 2026-08-13 at 11 33 46" src="https://github.com/user-attachments/assets/e7361c48-f34e-4bd2-b6bc-f053f7323249" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>