### PR TITLE
Deprecate props on PaginationItem

### DIFF
--- a/.changeset/slick-coins-lie.md
+++ b/.changeset/slick-coins-lie.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `shape`, `TouchRippleProps`, `touchRippleRef`, and `variant` props of `PaginationItem`

--- a/.changeset/slick-coins-lie.md
+++ b/.changeset/slick-coins-lie.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecated `color`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `shape`, `TouchRippleProps`, `touchRippleRef`, and `variant` props of `PaginationItem`
+Deprecated `color`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `shape`, `TouchRippleProps`, `touchRippleRef`, and `variant` props of `PaginationItem`.

--- a/apps/website/src/content/docs/components/mui/Pagination.md
+++ b/apps/website/src/content/docs/components/mui/Pagination.md
@@ -12,4 +12,6 @@ links:
 
 - The `shape` prop now defaults to `"rounded"` instead of `"circular"`.
 - Lightly styled using StrataKit's visual language.
-- The `color`, `shape` and `variant` props of `Pagination` are not supported.
+- The `color`, `shape` and `variant` props of `Pagination` and `PaginationItem` are not supported.
+- Ripple effect removed from `PaginationItem`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
+- The `action` prop of `PaginationItem` is not supported.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -808,8 +808,24 @@ declare module "@mui/material/Pagination" {
 }
 
 declare module "@mui/material/PaginationItem" {
-	interface PaginationItemOwnProps {
+	interface PaginationItemPropsColorOverrides {
+		primary: false;
+		secondary: false;
+		standard: false;
+	}
+
+	interface PaginationItemPropsVariantOverrides {
+		text: false;
+	}
+
+	interface PaginationItemOwnProps extends ButtonBaseDeprecatedProps {
+		/** @deprecated StrataKit does not support this prop. */
+		color?: PaginationItemOwnProps["color"];
 		LinkComponent?: never;
+		/** @deprecated StrataKit does not support this prop. */
+		shape?: PaginationItemOwnProps["shape"];
+		/** @deprecated StrataKit does not support this prop. */
+		variant?: PaginationItemOwnProps["variant"];
 	}
 }
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -816,6 +816,7 @@ declare module "@mui/material/PaginationItem" {
 
 	interface PaginationItemPropsVariantOverrides {
 		text: false;
+		outlined: false;
 	}
 
 	interface PaginationItemOwnProps extends ButtonBaseDeprecatedProps {


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `color`, `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `shape`, `TouchRippleProps`, `touchRippleRef`, and `variant` props of `PaginationItem`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17674184


<img width="823" height="621" alt="image" src="https://github.com/user-attachments/assets/3fdec455-8c2f-4881-83a4-3b624ce6e4e4" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
