### PR TITLE
color token removals

### DIFF
--- a/.changeset/rare-cars-glow.md
+++ b/.changeset/rare-cars-glow.md
@@ -1,0 +1,62 @@
+---
+"@stratakit/foundations": minor
+"@stratakit/mui": minor
+---
+
+Removed tokens:
+
+- `--stratakit-color-bg-neutral-muted`
+- `--stratakit-color-bg-neutral-faded`
+
+- `--stratakit-color-bg-accent-faded`
+- `--stratakit-color-bg-accent-transparent`
+- `--stratakit-color-bg-positive-faded`
+- `--stratakit-color-bg-info-faded`
+- `--stratakit-color-bg-attention-faded`
+- `--stratakit-color-bg-critical-faded`
+
+- `--stratakit-color-bg-control-slider-track`
+- `--stratakit-color-bg-control-select`
+- `--stratakit-color-bg-control-scrollbar-canvas`
+
+- `--stratakit-color-text-neutral-faded`
+- `--stratakit-color-text-accent-faded`
+- `--stratakit-color-text-positive-faded`
+- `--stratakit-color-text-info-faded`
+- `--stratakit-color-text-attention-faded`
+- `--stratakit-color-text-critical-faded`
+
+- `--stratakit-color-text-glow-base-hover-%`
+- `--stratakit-color-text-glow-base-pressed-%`
+- `--stratakit-color-text-glow-strong-hover-%`
+- `--stratakit-color-text-glow-strong-pressed-%`
+
+- `--stratakit-color-icon-neutral-tertiary`
+- `--stratakit-color-icon-neutral-muted`
+- `--stratakit-color-icon-neutral-faded`
+- `--stratakit-color-icon-accent-faded`
+- `--stratakit-color-icon-positive-faded`
+- `--stratakit-color-icon-info-faded`
+- `--stratakit-color-icon-attention-faded`
+- `--stratakit-color-icon-critical-faded`
+
+- `--stratakit-color-icon-glow-base-hover-%`
+- `--stratakit-color-icon-glow-base-pressed-%`
+- `--stratakit-color-icon-glow-strong-hover-%`
+- `--stratakit-color-icon-glow-strong-pressed-%`
+
+- `--stratakit-color-border-page-depth`
+- `--stratakit-color-border-neutral-faded`
+- `--stratakit-color-border-accent-faded`
+- `--stratakit-color-border-positive-faded`
+- `--stratakit-color-border-info-faded`
+- `--stratakit-color-border-attention-faded`
+- `--stratakit-color-border-critical-faded`
+
+- `--stratakit-color-border-control-scrollbar-canvas`
+- `--stratakit-color-border-control-switch`
+- `--stratakit-color-border-control-checkbox`
+- `--stratakit-color-border-control-radio`
+- `--stratakit-color-border-control-textbox`
+- `--stratakit-color-border-control-select`
+- `--stratakit-color-border-control-navrail-item`

--- a/internal/theme-dark.json
+++ b/internal/theme-dark.json
@@ -10,10 +10,6 @@
 					"$type": "color",
 					"$value": "{p-color.gray.800}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.300}"
-				},
 				"transparent": {
 					"$type": "color",
 					"$value": "{p-color.gray.16}"
@@ -27,14 +23,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.aurora.800}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.aurora.300}"
-				},
-				"transparent": {
-					"$type": "color",
-					"$value": "{p-color.aurora.16}"
 				}
 			},
 			"info": {
@@ -45,10 +33,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.blue.800}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.blue.300}"
 				},
 				"transparent": {
 					"$type": "color",
@@ -64,10 +48,6 @@
 					"$type": "color",
 					"$value": "{p-color.green.800}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.green.300}"
-				},
 				"transparent": {
 					"$type": "color",
 					"$value": "{p-color.green.16}"
@@ -81,10 +61,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.yellow.800}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.yellow.300}"
 				},
 				"transparent": {
 					"$type": "color",
@@ -100,10 +76,6 @@
 					"$type": "color",
 					"$value": "{p-color.orange.800}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.orange.300}"
-				},
 				"transparent": {
 					"$type": "color",
 					"$value": "{p-color.orange.16}"
@@ -117,10 +89,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.red.800}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.red.300}"
 				},
 				"transparent": {
 					"$type": "color",
@@ -136,10 +104,6 @@
 					"$type": "color",
 					"$value": "{p-color.pink.800}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.pink.300}"
-				},
 				"transparent": {
 					"$type": "color",
 					"$value": "{p-color.pink.16}"
@@ -153,10 +117,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.purple.800}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.purple.300}"
 				},
 				"transparent": {
 					"$type": "color",
@@ -199,14 +159,6 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.gray.800}"
-				},
-				"muted": {
-					"$type": "color",
-					"$value": "{p-color.gray.825}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.600}"
 				},
 				"inverse": {
 					"$type": "color",
@@ -302,21 +254,9 @@
 					"$type": "color",
 					"$value": "{p-color.white.40}"
 				},
-				"scrollbar-canvas": {
-					"$type": "color",
-					"$value": "{p-color.black.48}"
-				},
 				"switch": {
 					"$type": "color",
 					"$value": "{p-color.gray.950}"
-				},
-				"slider-track": {
-					"$type": "color",
-					"$value": "{p-color.gray.800}"
-				},
-				"select": {
-					"$type": "color",
-					"$value": "{p-color.gray.925}"
 				}
 			}
 		},
@@ -334,10 +274,6 @@
 					"$type": "color",
 					"$value": "{p-color.gray.400}"
 				},
-				"tertiary": {
-					"$type": "color",
-					"$value": "{p-color.gray.500}"
-				},
 				"disabled": {
 					"$type": "color",
 					"$value": "{p-color.gray.600}"
@@ -345,10 +281,6 @@
 				"emphasis": {
 					"$type": "color",
 					"$value": "{p-color.white.100}"
-				},
-				"muted": {
-					"$type": "color",
-					"$value": "{p-color.gray.600}"
 				}
 			},
 			"accent": {
@@ -359,128 +291,54 @@
 				"strong": {
 					"$type": "color",
 					"$value": "{p-color.aurora.0}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.aurora.200}"
 				}
 			},
 			"info": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.blue.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.blue.200}"
 				}
 			},
 			"positive": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.green.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.green.200}"
 				}
 			},
 			"attention": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.yellow.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.yellow.200}"
 				}
 			},
 			"🫥severe": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.orange.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.orange.200}"
 				}
 			},
 			"critical": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.red.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.red.200}"
 				}
 			},
 			"🫥highlight": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.pink.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.pink.200}"
 				}
 			},
 			"🫥special": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.purple.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.purple.200}"
 				}
 			},
 			"mono": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.gray.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.200}"
-				}
-			},
-			"glow": {
-				"base": {
-					"🫥hover": {
-						"$type": "color",
-						"$value": "{p-color.white.8}"
-					},
-					"🫥pressed": {
-						"$type": "color",
-						"$value": "{p-color.white.12}"
-					},
-					"hover-%": {
-						"$type": "number",
-						"$value": 8
-					},
-					"pressed-%": {
-						"$type": "number",
-						"$value": 12
-					}
-				},
-				"strong": {
-					"🫥hover": {
-						"$type": "color",
-						"$value": "{p-color.white.16}"
-					},
-					"🫥pressed": {
-						"$type": "color",
-						"$value": "{p-color.white.24}"
-					},
-					"hover-%": {
-						"$type": "number",
-						"$value": 16
-					},
-					"pressed-%": {
-						"$type": "number",
-						"$value": 24
-					}
 				}
 			}
 		},
@@ -489,10 +347,6 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.gray.400}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.100}"
 				},
 				"muted": {
 					"$type": "color",
@@ -503,10 +357,6 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.aurora.400}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.aurora.100}"
 				},
 				"muted": {
 					"$type": "color",
@@ -522,10 +372,6 @@
 					"$type": "color",
 					"$value": "{p-color.blue.400}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.blue.100}"
-				},
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.blue.700}"
@@ -539,10 +385,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.green.700}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.green.100}"
 				}
 			},
 			"attention": {
@@ -553,10 +395,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.yellow.700}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.yellow.100}"
 				}
 			},
 			"🫥severe": {
@@ -567,10 +405,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.orange.700}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.orange.100}"
 				}
 			},
 			"critical": {
@@ -581,10 +415,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.red.700}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.red.100}"
 				}
 			},
 			"🫥highlight": {
@@ -595,10 +425,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.pink.700}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.pink.100}"
 				}
 			},
 			"🫥special": {
@@ -609,10 +435,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.purple.700}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.purple.100}"
 				}
 			},
 			"glow": {
@@ -680,10 +502,6 @@
 					"$type": "color",
 					"$value": "{p-color.gray.700}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.400}"
-				},
 				"inverse": {
 					"$type": "color",
 					"$value": "{p-color.gray.5}"
@@ -703,40 +521,6 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.white.36}"
-				},
-				"depth": {
-					"$type": "color",
-					"$value": "{p-color.white.24}"
-				}
-			},
-			"control": {
-				"scrollbar-canvas": {
-					"$type": "color",
-					"$value": "{p-color.white.24}"
-				},
-				"switch": {
-					"$type": "color",
-					"$value": "{p-color.gray.700}"
-				},
-				"checkbox": {
-					"$type": "color",
-					"$value": "{p-color.gray.600}"
-				},
-				"radio": {
-					"$type": "color",
-					"$value": "{p-color.gray.600}"
-				},
-				"textbox": {
-					"$type": "color",
-					"$value": "{p-color.gray.600}"
-				},
-				"select": {
-					"$type": "color",
-					"$value": "{p-color.gray.600}"
-				},
-				"navrail-item": {
-					"$type": "color",
-					"$value": "{p-color.gray.600}"
 				}
 			}
 		},
@@ -745,20 +529,12 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.gray.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.200}"
 				}
 			},
 			"accent": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.aurora.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.aurora.200}"
 				},
 				"strong": {
 					"$type": "color",
@@ -769,70 +545,42 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.blue.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.blue.200}"
 				}
 			},
 			"positive": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.green.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.green.200}"
 				}
 			},
 			"attention": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.yellow.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.yellow.200}"
 				}
 			},
 			"🫥severe": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.orange.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.orange.200}"
 				}
 			},
 			"critical": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.red.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.red.200}"
 				}
 			},
 			"🫥highlight": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.pink.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.pink.200}"
 				}
 			},
 			"🫥special": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.purple.300}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.purple.200}"
 				}
 			},
 			"neutral": {
@@ -855,44 +603,6 @@
 				"disabled": {
 					"$type": "color",
 					"$value": "{p-color.gray.600}"
-				}
-			},
-			"glow": {
-				"base": {
-					"🫥hover": {
-						"$type": "color",
-						"$value": "{p-color.white.8}"
-					},
-					"🫥pressed": {
-						"$type": "color",
-						"$value": "{p-color.white.12}"
-					},
-					"hover-%": {
-						"$type": "number",
-						"$value": 8
-					},
-					"pressed-%": {
-						"$type": "number",
-						"$value": 12
-					}
-				},
-				"strong": {
-					"🫥hover": {
-						"$type": "color",
-						"$value": "{p-color.white.16}"
-					},
-					"🫥pressed": {
-						"$type": "color",
-						"$value": "{p-color.white.24}"
-					},
-					"hover-%": {
-						"$type": "number",
-						"$value": 16
-					},
-					"pressed-%": {
-						"$type": "number",
-						"$value": 24
-					}
 				}
 			},
 			"control": {

--- a/internal/theme-light.json
+++ b/internal/theme-light.json
@@ -10,10 +10,6 @@
 					"$type": "color",
 					"$value": "{p-color.gray.25}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.800}"
-				},
 				"transparent": {
 					"$type": "color",
 					"$value": "{p-color.gray.16}"
@@ -27,14 +23,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.aurora.50}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.aurora.800}"
-				},
-				"transparent": {
-					"$type": "color",
-					"$value": "{p-color.aurora.16}"
 				}
 			},
 			"info": {
@@ -45,10 +33,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.blue.50}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.blue.800}"
 				},
 				"transparent": {
 					"$type": "color",
@@ -64,10 +48,6 @@
 					"$type": "color",
 					"$value": "{p-color.green.50}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.green.800}"
-				},
 				"transparent": {
 					"$type": "color",
 					"$value": "{p-color.green.16}"
@@ -81,10 +61,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.yellow.50}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.yellow.800}"
 				},
 				"transparent": {
 					"$type": "color",
@@ -100,10 +76,6 @@
 					"$type": "color",
 					"$value": "{p-color.orange.50}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.orange.800}"
-				},
 				"transparent": {
 					"$type": "color",
 					"$value": "{p-color.orange.16}"
@@ -117,10 +89,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.red.50}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.red.800}"
 				},
 				"transparent": {
 					"$type": "color",
@@ -136,10 +104,6 @@
 					"$type": "color",
 					"$value": "{p-color.pink.50}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.pink.800}"
-				},
 				"transparent": {
 					"$type": "color",
 					"$value": "{p-color.pink.16}"
@@ -153,10 +117,6 @@
 				"muted": {
 					"$type": "color",
 					"$value": "{p-color.purple.50}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.purple.800}"
 				},
 				"transparent": {
 					"$type": "color",
@@ -199,14 +159,6 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.white.100}"
-				},
-				"muted": {
-					"$type": "color",
-					"$value": "{p-color.gray.10}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.15}"
 				},
 				"inverse": {
 					"$type": "color",
@@ -302,21 +254,9 @@
 					"$type": "color",
 					"$value": "{p-color.black.48}"
 				},
-				"scrollbar-canvas": {
-					"$type": "color",
-					"$value": "{p-color.black.48}"
-				},
 				"switch": {
 					"$type": "color",
 					"$value": "{p-color.gray.15}"
-				},
-				"slider-track": {
-					"$type": "color",
-					"$value": "{p-color.gray.25}"
-				},
-				"select": {
-					"$type": "color",
-					"$value": "{p-color.white.100}"
 				}
 			}
 		},
@@ -334,10 +274,6 @@
 					"$type": "color",
 					"$value": "{p-color.gray.400}"
 				},
-				"tertiary": {
-					"$type": "color",
-					"$value": "{p-color.gray.300}"
-				},
 				"disabled": {
 					"$type": "color",
 					"$value": "{p-color.gray.200}"
@@ -345,10 +281,6 @@
 				"emphasis": {
 					"$type": "color",
 					"$value": "{p-color.white.100}"
-				},
-				"muted": {
-					"$type": "color",
-					"$value": "{p-color.gray.100}"
 				}
 			},
 			"accent": {
@@ -359,128 +291,54 @@
 				"strong": {
 					"$type": "color",
 					"$value": "{p-color.aurora.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.aurora.700}"
 				}
 			},
 			"info": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.blue.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.blue.700}"
 				}
 			},
 			"positive": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.green.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.green.700}"
 				}
 			},
 			"attention": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.yellow.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.yellow.700}"
 				}
 			},
 			"🫥severe": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.orange.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.orange.700}"
 				}
 			},
 			"critical": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.red.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.red.700}"
 				}
 			},
 			"🫥highlight": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.pink.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.pink.700}"
 				}
 			},
 			"🫥special": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.purple.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.purple.700}"
 				}
 			},
 			"mono": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.gray.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.700}"
-				}
-			},
-			"glow": {
-				"base": {
-					"🫥hover": {
-						"$type": "color",
-						"$value": "{p-color.black.8}"
-					},
-					"🫥pressed": {
-						"$type": "color",
-						"$value": "{p-color.black.12}"
-					},
-					"hover-%": {
-						"$type": "number",
-						"$value": 8
-					},
-					"pressed-%": {
-						"$type": "number",
-						"$value": 12
-					}
-				},
-				"strong": {
-					"🫥hover": {
-						"$type": "color",
-						"$value": "{p-color.black.8}"
-					},
-					"🫥pressed": {
-						"$type": "color",
-						"$value": "{p-color.black.16}"
-					},
-					"hover-%": {
-						"$type": "number",
-						"$value": 8
-					},
-					"pressed-%": {
-						"$type": "number",
-						"$value": 16
-					}
 				}
 			}
 		},
@@ -680,10 +538,6 @@
 					"$type": "color",
 					"$value": "{p-color.gray.200}"
 				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.500}"
-				},
 				"inverse": {
 					"$type": "color",
 					"$value": "{p-color.gray.1000}"
@@ -703,40 +557,6 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.black.48}"
-				},
-				"depth": {
-					"$type": "color",
-					"$value": "{p-color.black.40}"
-				}
-			},
-			"control": {
-				"scrollbar-canvas": {
-					"$type": "color",
-					"$value": "{p-color.white.24}"
-				},
-				"switch": {
-					"$type": "color",
-					"$value": "{p-color.gray.50}"
-				},
-				"checkbox": {
-					"$type": "color",
-					"$value": "{p-color.gray.100}"
-				},
-				"radio": {
-					"$type": "color",
-					"$value": "{p-color.gray.100}"
-				},
-				"textbox": {
-					"$type": "color",
-					"$value": "{p-color.gray.100}"
-				},
-				"select": {
-					"$type": "color",
-					"$value": "{p-color.gray.100}"
-				},
-				"navrail-item": {
-					"$type": "color",
-					"$value": "{p-color.gray.100}"
 				}
 			}
 		},
@@ -745,20 +565,12 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.gray.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.gray.700}"
 				}
 			},
 			"accent": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.aurora.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.aurora.700}"
 				},
 				"strong": {
 					"$type": "color",
@@ -769,70 +581,42 @@
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.blue.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.blue.700}"
 				}
 			},
 			"positive": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.green.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.green.700}"
 				}
 			},
 			"attention": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.yellow.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.yellow.700}"
 				}
 			},
 			"🫥severe": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.orange.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.orange.700}"
 				}
 			},
 			"critical": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.red.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.red.700}"
 				}
 			},
 			"🫥highlight": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.pink.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.pink.700}"
 				}
 			},
 			"🫥special": {
 				"base": {
 					"$type": "color",
 					"$value": "{p-color.purple.600}"
-				},
-				"faded": {
-					"$type": "color",
-					"$value": "{p-color.purple.700}"
 				}
 			},
 			"neutral": {
@@ -855,44 +639,6 @@
 				"disabled": {
 					"$type": "color",
 					"$value": "{p-color.gray.200}"
-				}
-			},
-			"glow": {
-				"base": {
-					"🫥hover": {
-						"$type": "color",
-						"$value": "{p-color.black.8}"
-					},
-					"🫥pressed": {
-						"$type": "color",
-						"$value": "{p-color.black.12}"
-					},
-					"hover-%": {
-						"$type": "number",
-						"$value": 8
-					},
-					"pressed-%": {
-						"$type": "number",
-						"$value": 12
-					}
-				},
-				"strong": {
-					"🫥hover": {
-						"$type": "color",
-						"$value": "{p-color.black.8}"
-					},
-					"🫥pressed": {
-						"$type": "color",
-						"$value": "{p-color.black.16}"
-					},
-					"hover-%": {
-						"$type": "number",
-						"$value": 8
-					},
-					"pressed-%": {
-						"$type": "number",
-						"$value": 16
-					}
 				}
 			},
 			"control": {


### PR DESCRIPTION
### Changes

Removes a bunch of tokens by directly editing `theme-light.json` and `theme-dark.json`.

<details>
<summary>List of removed tokens</summary>

- `--stratakit-color-bg-neutral-muted`
- `--stratakit-color-bg-neutral-faded`

- `--stratakit-color-bg-accent-faded`
- `--stratakit-color-bg-accent-transparent`
- `--stratakit-color-bg-positive-faded`
- `--stratakit-color-bg-info-faded`
- `--stratakit-color-bg-attention-faded`
- `--stratakit-color-bg-critical-faded`

- `--stratakit-color-bg-control-slider-track`
- `--stratakit-color-bg-control-select`
- `--stratakit-color-bg-control-scrollbar-canvas`

- `--stratakit-color-text-neutral-faded`
- `--stratakit-color-text-accent-faded`
- `--stratakit-color-text-positive-faded`
- `--stratakit-color-text-info-faded`
- `--stratakit-color-text-attention-faded`
- `--stratakit-color-text-critical-faded`

- `--stratakit-color-text-glow-base-hover-%`
- `--stratakit-color-text-glow-base-pressed-%`
- `--stratakit-color-text-glow-strong-hover-%`
- `--stratakit-color-text-glow-strong-pressed-%`

- `--stratakit-color-icon-neutral-tertiary`
- `--stratakit-color-icon-neutral-muted`
- `--stratakit-color-icon-neutral-faded`
- `--stratakit-color-icon-accent-faded`
- `--stratakit-color-icon-positive-faded`
- `--stratakit-color-icon-info-faded`
- `--stratakit-color-icon-attention-faded`
- `--stratakit-color-icon-critical-faded`

- `--stratakit-color-icon-glow-base-hover-%`
- `--stratakit-color-icon-glow-base-pressed-%`
- `--stratakit-color-icon-glow-strong-hover-%`
- `--stratakit-color-icon-glow-strong-pressed-%`

- `--stratakit-color-border-page-depth`
- `--stratakit-color-border-neutral-faded`
- `--stratakit-color-border-accent-faded`
- `--stratakit-color-border-positive-faded`
- `--stratakit-color-border-info-faded`
- `--stratakit-color-border-attention-faded`
- `--stratakit-color-border-critical-faded`

- `--stratakit-color-border-control-scrollbar-canvas`
- `--stratakit-color-border-control-switch`
- `--stratakit-color-border-control-checkbox`
- `--stratakit-color-border-control-radio`
- `--stratakit-color-border-control-textbox`
- `--stratakit-color-border-control-select`
- `--stratakit-color-border-control-navrail-item`

</details>

### Usage

All existing usage of removed tokens in this repo was replaced in past PRs:
- #1759 
- #1760 
- #1761 
- #1773 
- #1794
- #1795 

Usage of these tokens in [iTwinUI theme bridge](https://github.com/iTwin/iTwinUI/blob/main/packages/itwinui-css/src/bridge.scss) will need to be updated separately.

### Not included in this PR

- `--stratakit-color-text-control-placeholder` (will be renamed in [#1797](https://github.com/iTwin/stratakit/pull/1797))
- `--stratakit-color-border-shadow-base` (blocked by [one remaining usage](https://github.com/iTwin/stratakit/pull/1795#discussion_r3847732959))
- `--stratakit-color-border-shadow-strong` (needs replacement in Button and Checkbox)
- shadows, space, typography, and other non-color token changes (out of scope for this PR)

### Testing

Did a search for every removed token to ensure there is no remaining usage.