### PR TITLE
replace `bg-control-slider-track`

### DIFF
--- a/packages/mui/src/~components/MuiSlider.css
+++ b/packages/mui/src/~components/MuiSlider.css
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 .MuiSlider-root {
-	--✨color-rail-bg--default: var(--stratakit-color-bg-control-slider-track);
+	--✨color-rail-bg--default: var(--stratakit-color-bg-mono-muted);
 	--✨color-rail-bg--disabled: var(--stratakit-color-bg-control-switch);
-	--✨color-rail-border--default: var(--stratakit-color-bg-control-slider-track);
+	--✨color-rail-border--default: var(--stratakit-color-bg-mono-muted);
 	--✨color-rail-border--disabled: var(--stratakit-color-border-neutral-disabled);
 	--✨color-track-bg--default: var(--stratakit-color-bg-accent-base);
 	--✨color-track-bg--disabled: var(--stratakit-color-border-neutral-disabled);


### PR DESCRIPTION
### Changes

Updates the `Slider` component to use `bg-mono-muted`, instead of `bg-control-slider-track` which is being removed in #1758. The values of these tokens are the exact same.

### Testing

No visual change. (Didn't add a changeset for this reason)