### PR TITLE
Deprecated variant on FormHelperText

### DIFF
--- a/.changeset/pretty-items-poke.md
+++ b/.changeset/pretty-items-poke.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `variant` prop of `FormHelperText`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -635,6 +635,17 @@ interface FormControlDeprecatedProps {
 	variant?: FormControlProps["variant"];
 }
 
+declare module "@mui/material/FormHelperText" {
+	interface FormHelperTextPropsVariantOverrides {
+		standard: false;
+		filled: false;
+	}
+	interface FormHelperTextOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		variant?: FormHelperTextOwnProps["variant"];
+	}
+}
+
 declare module "@mui/material/FormLabel" {
 	interface FormLabelPropsColorOverrides {
 		secondary: false;


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `variant` prop of `FormHelperText`.   Removed `filled` and `standard` as options. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17910338  .  This component isn't documented in StrataKit so there wasn't a good place to note the deprecation. Also a component consumers are not likely to use unless they are building their own input.

<img width="495" height="52" alt="image" src="https://github.com/user-attachments/assets/0d6f5eca-d4d4-43e5-a3cd-2a65741439a8" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
