### PR TITLE
Deprecate variant of InputAdornment

### DIFF
--- a/.changeset/red-lizards-fly.md
+++ b/.changeset/red-lizards-fly.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `variant` prop of `InputAdornment`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -729,6 +729,13 @@ declare module "@mui/material/Input" {
 	): React.JSX.Element;
 }
 
+declare module "@mui/material/InputAdornment" {
+	interface InputAdornmentOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		variant?: InputAdornmentOwnProps["variant"];
+	}
+}
+
 interface InputDeprecatedProps extends InputBaseDeprecatedProps {
 	/** @deprecated StrataKit does not support this prop. */
 	disableUnderline?: InputProps["disableUnderline"];


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `variant` prop of `InputAdornment`. This doesn't appear in StrataKit documentation so this is just a types only update.  `variant` is also a hard coded set of strings not an `OverridableStringUnion` so no good way to remove `"filled"|"standard"`

See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-18002096


<img width="500" height="114" alt="image" src="https://github.com/user-attachments/assets/bdbeb16c-a3ae-42a3-8fee-909eee2790a9" />

### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
