### PR TITLE
Deprecate color prop of FormLabel

### DIFF
--- a/.changeset/great-ads-go.md
+++ b/.changeset/great-ads-go.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color` prop of `FormLabel`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -19,6 +19,7 @@ import type { CheckboxProps } from "@mui/material/Checkbox";
 import type { CssBaselineProps } from "@mui/material/CssBaseline";
 import type { FilledInputProps } from "@mui/material/FilledInput";
 import type { FormControlProps } from "@mui/material/FormControl";
+import type { FormLabelProps } from "@mui/material/FormLabel";
 import type {} from "@mui/material/Grow";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
@@ -656,9 +657,20 @@ declare module "@mui/material/FormLabel" {
 	}
 
 	interface FormLabelOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		color?: FormLabelOwnProps["color"];
 		/** @deprecated */
 		component?: never; // `@deprecated` marker is not showing up, so using `never` to prevent usage of this prop.
 	}
+
+	// Need to also declare the deprecation for color here to get the strike through in VS Code
+	// @ts-expect-error -- Default exports cannot be augmented, but the prop deprecations still take effect.
+	export default function FormLabel(
+		props: {
+			/** @deprecated StrataKit does not support this prop. */
+			color?: FormLabelOwnProps["color"];
+		} & Omit<FormLabelProps, "color">,
+	): React.JSX.Element;
 }
 
 declare module "@mui/material/Grow" {


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes
Deprecate `color` prop of `FormLabel`.  This component isn't documented in the StrataKit docs.
See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17910338

<img width="365" height="41" alt="image" src="https://github.com/user-attachments/assets/366a0c4d-2266-4ecf-9555-8ecfd10d51f6" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
