### PR TITLE
Deprecate props on InputLabel

### DIFF
--- a/.changeset/ten-bananas-laugh.md
+++ b/.changeset/ten-bananas-laugh.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `color`, `shrink`, and `variant` prop of `InputLabel`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -780,6 +780,15 @@ interface InputBaseDeprecatedProps {
 	disableInjectingGlobalStyles?: InputBaseProps["disableInjectingGlobalStyles"];
 }
 
+declare module "@mui/material/InputLabel" {
+	interface InputLabelOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		shrink?: InputLabelOwnProps["shrink"];
+		/** @deprecated StrataKit does not support this prop. */
+		variant?: InputLabelOwnProps["variant"];
+	}
+}
+
 declare module "@mui/material/Link" {
 	interface LinkOwnProps {
 		/** @deprecated StrataKit does not support this prop. */


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `color`, `shrink`, and `variant` prop of `InputLabel`. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-18002011

The `color` prop was already deprecated through inheritance of `FormLabel` in https://github.com/iTwin/stratakit/pull/1766

This component is not documented in StrataKit

<img width="614" height="44" alt="image" src="https://github.com/user-attachments/assets/83b6e241-37db-4ebd-b4eb-2ab0c4d31b05" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
