### PR TITLE
Deprecate TabScrollButton

### DIFF
--- a/.changeset/dull-rules-joke.md
+++ b/.changeset/dull-rules-joke.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `TabScrollButton` component.

--- a/apps/website/src/content/docs/components/mui/Tabs.md
+++ b/apps/website/src/content/docs/components/mui/Tabs.md
@@ -19,7 +19,7 @@ links:
 - Ripple effect removed from `Tab`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
-- StrataKit does not support use of `TabScrollButton`.
+- StrataKit does not support use of `TabScrollButton`. The scroll buttons are handled automatically when `variant="scrollable"`
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Tabs.md
+++ b/apps/website/src/content/docs/components/mui/Tabs.md
@@ -19,6 +19,7 @@ links:
 - Ripple effect removed from `Tab`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
+- StrataKit does not support use of `TabScrollButton`.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/Tabs.md
+++ b/apps/website/src/content/docs/components/mui/Tabs.md
@@ -19,7 +19,7 @@ links:
 - Ripple effect removed from `Tab`. The `centerRipple`, `disableRipple`, `disableTouchRipple`, `focusRipple`, `TouchRippleProps` and `touchRippleRef` props are not supported.
 - Restyled using StrataKit's visual language.
 - Includes full `forced-colors` support.
-- StrataKit does not support use of `TabScrollButton`. The scroll buttons are handled automatically when `variant="scrollable"`
+- StrataKit does not support use of `TabScrollButton`. The scroll buttons are handled automatically when `variant="scrollable"`.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -45,6 +45,7 @@ import type { SvgIconProps } from "@mui/material/SvgIcon";
 import type { SwitchProps } from "@mui/material/Switch";
 import type { TabProps } from "@mui/material/Tab";
 import type { TableCellProps as MuiTableCellProps } from "@mui/material/TableCell";
+import type { TabScrollButtonProps } from "@mui/material/TabScrollButton";
 import type { TabsProps } from "@mui/material/Tabs";
 import type { TextFieldProps } from "@mui/material/TextField";
 import type { ToggleButtonProps } from "@mui/material/ToggleButton";
@@ -1115,6 +1116,13 @@ declare module "@mui/material/Tab" {
 		 */
 		iconPosition?: TabProps["iconPosition"];
 	}
+}
+
+declare module "@mui/material/TabScrollButton" {
+	/** @deprecated StrataKit does not support this component. */
+	export default function TabScrollButton(
+		props: TabScrollButtonProps,
+	): React.JSX.Element;
 }
 
 declare module "@mui/material/TableCell" {


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `TabScrollButton` component. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17993706

<img width="552" height="49" alt="image" src="https://github.com/user-attachments/assets/682b263c-fd1c-47f9-bf81-c649a5983ca9" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
