### PR TITLE
Fix font size of small inputs & pagination select styling

### DIFF
--- a/.changeset/fiery-papayas-add.md
+++ b/.changeset/fiery-papayas-add.md
@@ -1,5 +1,0 @@
----
-"@stratakit/mui": patch
----
-
-Fixed font size of small inputs.

--- a/.changeset/fiery-papayas-add.md
+++ b/.changeset/fiery-papayas-add.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed font size of small inputs.

--- a/packages/mui/src/~components/MuiInput.css
+++ b/packages/mui/src/~components/MuiInput.css
@@ -3,17 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-.MuiInputBase-root {
-	--_MuiInput-block-size: var(--stratakit-size-control-field-height-medium);
-	--_MuiInput-padding-inline: var(--stratakit-space-x3);
-
-	&:where(.MuiInputBase-sizeSmall) {
-		@apply --typography("body-sm");
-		--_MuiInput-block-size: var(--stratakit-size-control-field-height-small);
-		--_MuiInput-padding-inline: var(--stratakit-space-x2);
-	}
-}
-
 .🥝MuiInput {
 	--✨border--default: var(--stratakit-color-border-neutral-base);
 	--✨border--focus: var(--stratakit-color-border-accent-strong);
@@ -58,6 +47,17 @@
 
 	:where(fieldset) {
 		display: none;
+	}
+}
+
+.MuiInputBase-root {
+	--_MuiInput-block-size: var(--stratakit-size-control-field-height-medium);
+	--_MuiInput-padding-inline: var(--stratakit-space-x3);
+
+	&:where(.MuiInputBase-sizeSmall) {
+		@apply --typography("body-sm");
+		--_MuiInput-block-size: var(--stratakit-size-control-field-height-small);
+		--_MuiInput-padding-inline: var(--stratakit-space-x2);
 	}
 }
 

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -596,7 +596,10 @@ function createTheme(args: CreateThemeArgs) {
 			MuiTablePagination: {
 				defaultProps: {
 					component: withRenderProp(Role, "td"),
-					slotProps: { root: { colSpan: 999 } },
+					slotProps: {
+						root: { colSpan: 999 },
+						select: { classes: { root: "🥝MuiInput" } },
+					},
 				},
 			},
 			MuiTableRow: { defaultProps: { component: withRenderProp(Role, "tr") } },

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -406,7 +406,7 @@ function createTheme(args: CreateThemeArgs) {
 			MuiImageListItem: { defaultProps: { component: Role.li } },
 			MuiInputBase: {
 				defaultProps: {
-					className: "🥝MuiInput",
+					classes: { root: "🥝MuiInput" },
 				},
 			},
 			MuiInputAdornment: { defaultProps: { component: Role.div } },
@@ -596,10 +596,7 @@ function createTheme(args: CreateThemeArgs) {
 			MuiTablePagination: {
 				defaultProps: {
 					component: withRenderProp(Role, "td"),
-					slotProps: {
-						root: { colSpan: 999 },
-						select: { classes: { root: "🥝MuiInput" } },
-					},
+					slotProps: { root: { colSpan: 999 } },
 				},
 			},
 			MuiTableRow: { defaultProps: { component: withRenderProp(Role, "tr") } },


### PR DESCRIPTION
### Changes

#### Font size

Discovered font size wasn't being applied properly to small inputs https://github.com/iTwin/stratakit/pull/1608#discussion_r3779070874.  Fixed by moving `.🥝MuiInput` above `.MuiInputBase-root`.

Considered defining the typography size for both small and medium in `.MuiInputBase-root`, however that would mean `.🥝MuiInput` would have no typography size set and as a custom class it might not be paired with `.MuiInputBase-root`.
```diff
.MuiInputBase-root {
+	@apply --typography("body-md");
	--_MuiInput-block-size: var(--stratakit-size-control-field-height-medium);
	--_MuiInput-padding-inline: var(--stratakit-space-x3);

	&:where(.MuiInputBase-sizeSmall) {
		@apply --typography("body-sm");
		--_MuiInput-block-size: var(--stratakit-size-control-field-height-small);
		--_MuiInput-padding-inline: var(--stratakit-space-x2);
	}
}
```

#### Pagination select

The `TablePagination`'s native select was no longer inheriting the correct visual styling, noticed in https://github.com/iTwin/stratakit/pull/1608#discussion_r3779128136. This was fixed by applying `"🥝MuiInput"` to `MuiInputBase.classes.root` instead of `MuiInputBase.className`.

### Testing

| Before | After |
| -- | -- |
| <img width="344" height="253" alt="Screenshot 2026-08-17 at 3 13 36 PM" src="https://github.com/user-attachments/assets/7a62f4a8-2a4b-424b-a896-0659c1dd90b7" /> | <img width="344" height="253" alt="Screenshot 2026-08-17 at 3 13 52 PM" src="https://github.com/user-attachments/assets/bbbf41e2-7212-4270-b18f-a88d16a3920c" /> | 
| <img width="475" height="134" alt="Screenshot 2026-08-17 at 4 33 05 PM" src="https://github.com/user-attachments/assets/d47d41ae-7c9d-40ae-8325-47d83c042799" /> | <img width="475" height="134" alt="Screenshot 2026-08-17 at 4 32 45 PM" src="https://github.com/user-attachments/assets/ea69b465-63be-41f4-9233-1e1131fc69a8" /> |
