### PR TITLE
fix `ownerState` being applied as a DOM attribute

### DIFF
--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -347,7 +347,7 @@ function createTheme(args: CreateThemeArgs) {
 			MuiDatePicker: {
 				defaultProps: {
 					slots: {
-						openPickerIcon: CalendarIcon,
+						openPickerIcon: withExcludedProps(CalendarIcon, ["ownerState"]),
 					},
 					slotProps: {
 						openPickerButton: {
@@ -622,7 +622,7 @@ function createTheme(args: CreateThemeArgs) {
 			MuiTimePicker: {
 				defaultProps: {
 					slots: {
-						openPickerIcon: ClockIcon,
+						openPickerIcon: withExcludedProps(ClockIcon, ["ownerState"]),
 					},
 					slotProps: {
 						openPickerButton: {
@@ -717,6 +717,22 @@ function withRenderProp(
 ) {
 	return React.forwardRef<HTMLDivElement, RoleProps>((props, forwardedRef) => {
 		return <Role render={<DefaultTagName />} {...props} ref={forwardedRef} />;
+	});
+}
+
+// ----------------------------------------------------------------------------
+
+/** HOC that "excludes" certain props from being passed to the specified Component. */
+function withExcludedProps<Element, Props extends object>(
+	Component: React.ComponentType<Props & React.RefAttributes<Element>>,
+	excludedProps: readonly string[],
+) {
+	return React.forwardRef<Element, Props>((props, forwardedRef) => {
+		const filteredProps = Object.fromEntries(
+			Object.entries(props).filter(([key]) => !excludedProps.includes(key)),
+		) as Props;
+
+		return <Component {...filteredProps} ref={forwardedRef} />;
 	});
 }
 


### PR DESCRIPTION
### Changes

Fixes https://github.com/iTwin/stratakit/pull/1608#discussion_r3778029847 where `ownerState=[object Object]` was seen in the DOM because the icon components used as slots were not built to consume the `ownerState` prop.

Instead of creating wrapper components just for the sake of destructuring certain props, I decided to create a generic HOC utility that filters out any specified props, allowing `CalendarIcon` and `ClockIcon` to retain their original form.

### Testing

Confirmed that `ownerState` is _not_ being applied as a DOM attribute.

| Before | After |
| --- | --- |
| <img width="470" height="50" alt="screenshot" src="https://github.com/user-attachments/assets/5eb258d7-03b0-45e0-ac99-c5eef4421f5f" /> | <img width="445" height="49" alt="screenshot" src="https://github.com/user-attachments/assets/3e52ced5-d9af-4777-ad7e-e9a0d91999d3" /> |

Confirmed that the following console warning is _not_ showing up during local development.

> React does not recognize the `ownerState` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `ownerstate` instead. If you accidentally passed it from a parent component, remove it from the DOM element.