### PR TITLE
replace `border-shadow-base`

### DIFF
--- a/.changeset/frank-apples-eat.md
+++ b/.changeset/frank-apples-eat.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Updated borders for `Checkbox`, `Kbd`, `Radio`, `Select`, and `Switch`.

--- a/.changeset/spotty-dragons-hammer.md
+++ b/.changeset/spotty-dragons-hammer.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated borders for `Checkbox`, `Radio`, `Slider`, and `Switch`.

--- a/packages/bricks/src/Checkbox.css
+++ b/packages/bricks/src/Checkbox.css
@@ -21,7 +21,7 @@
 	--✨bg--invalid-hover: color-mix(in oklch, var(--✨bg--invalid) 100%, var(--✨glow--bg-hover));
 	--✨bg--disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
 
-	--✨border--default: var(--stratakit-color-border-shadow-base);
+	--✨border--default: var(--stratakit-color-border-neutral-base);
 	--✨border--hover: color-mix(
 		in oklch,
 		var(--✨border--default) 100%,

--- a/packages/bricks/src/Kbd.css
+++ b/packages/bricks/src/Kbd.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .🥝Kbd {
-	--✨shadow-border: 0px 0px 0px 1px var(--stratakit-color-border-shadow-base) inset;
+	--✨shadow-border: 0px 0px 0px 1px var(--stratakit-color-border-neutral-base) inset;
 
 	@layer base {
 		@apply --typography("body-sm");

--- a/packages/bricks/src/Select.css
+++ b/packages/bricks/src/Select.css
@@ -50,7 +50,7 @@
 		var(--stratakit-shadow-control-button-base-inset), var(--✨shadow-border),
 		var(--stratakit-shadow-control-button-base-drop);
 
-	--✨border--solid-default: var(--stratakit-color-border-shadow-base);
+	--✨border--solid-default: var(--stratakit-color-border-neutral-base);
 	--✨border--solid-hover: color-mix(
 		in oklch,
 		var(--✨border--solid-default) 100%,

--- a/packages/bricks/src/Switch.css
+++ b/packages/bricks/src/Switch.css
@@ -10,10 +10,14 @@
 	--✨checked-translateX: 75%;
 	--✨pressed-scaleX: 1.75;
 
-	--✨shadow-border: 0px 0px 0px 1px var(--stratakit-color-border-neutral-base) inset;
+	--✨thumb-border-color: light-dark(
+		var(--stratakit-color-border-neutral-base),
+		--primitive("color.white.8")
+	);
 
 	--✨thumb-shadow--default:
-		var(--stratakit-shadow-control-button-base-inset), var(--✨shadow-border),
+		var(--stratakit-shadow-control-button-base-inset),
+		0px 0px 0px 1px var(--✨thumb-border-color) inset,
 		var(--stratakit-shadow-control-button-base-drop);
 	--✨thumb-shadow--checked:
 		var(--stratakit-shadow-control-button-base-inset),

--- a/packages/bricks/src/Switch.css
+++ b/packages/bricks/src/Switch.css
@@ -10,7 +10,7 @@
 	--✨checked-translateX: 75%;
 	--✨pressed-scaleX: 1.75;
 
-	--✨shadow-border: 0px 0px 0px 1px var(--stratakit-color-border-shadow-base) inset;
+	--✨shadow-border: 0px 0px 0px 1px var(--stratakit-color-border-neutral-base) inset;
 
 	--✨thumb-shadow--default:
 		var(--stratakit-shadow-control-button-base-inset), var(--✨shadow-border),

--- a/packages/mui/src/~components/MuiCheckbox.css
+++ b/packages/mui/src/~components/MuiCheckbox.css
@@ -13,7 +13,7 @@
 	--✨bg--error: var(--stratakit-color-bg-neutral-base);
 	--✨bg--disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
 
-	--✨border--default: var(--stratakit-color-border-shadow-base);
+	--✨border--default: var(--stratakit-color-border-neutral-base);
 	--✨border--checked: var(--stratakit-color-border-shadow-strong);
 	--✨border--error: var(--stratakit-color-border-critical-base);
 	--✨border--disabled: var(--stratakit-color-border-glow-on-surface-disabled);

--- a/packages/mui/src/~components/MuiSlider.css
+++ b/packages/mui/src/~components/MuiSlider.css
@@ -120,7 +120,7 @@
 	block-size: var(--_MuiSlider-thumb-size);
 	inline-size: var(--_MuiSlider-thumb-size);
 	background-color: var(--stratakit-color-bg-neutral-inverse);
-	border: 1px solid var(--stratakit-color-border-shadow-base);
+	border: 1px solid var(--stratakit-color-border-neutral-base);
 	box-shadow: none;
 	cursor: grab;
 

--- a/packages/mui/src/~components/MuiSwitch.css
+++ b/packages/mui/src/~components/MuiSwitch.css
@@ -41,14 +41,20 @@
 	--✨bg--disabled: var(--stratakit-color-icon-neutral-disabled);
 	--✨pressed-scaleX: 2;
 	--✨radius: 50%;
+
+	--✨thumb-border-color: light-dark(
+		var(--stratakit-color-border-neutral-base),
+		--primitive("color.white.8")
+	);
 	--✨shadow--default:
 		var(--stratakit-shadow-control-button-base-inset),
-		0px 0px 0px 1px var(--stratakit-color-border-neutral-base) inset,
+		0px 0px 0px 1px var(--✨thumb-border-color) inset,
 		var(--stratakit-shadow-control-button-base-drop);
 	--✨shadow--checked:
 		var(--stratakit-shadow-control-button-base-inset),
 		var(--stratakit-shadow-control-button-base-drop);
 	--✨shadow--disabled: none;
+
 	--✨translate-distance--full: calc(var(--_MuiSwitch-height) - var(--_MuiSwitch-padding) * 2);
 	--✨translate-distance--half: calc(var(--✨translate-distance--full) * 0.5);
 

--- a/packages/mui/src/~components/MuiSwitch.css
+++ b/packages/mui/src/~components/MuiSwitch.css
@@ -43,7 +43,7 @@
 	--✨radius: 50%;
 	--✨shadow--default:
 		var(--stratakit-shadow-control-button-base-inset),
-		0px 0px 0px 1px var(--stratakit-color-border-shadow-base) inset,
+		0px 0px 0px 1px var(--stratakit-color-border-neutral-base) inset,
 		var(--stratakit-shadow-control-button-base-drop);
 	--✨shadow--checked:
 		var(--stratakit-shadow-control-button-base-inset),


### PR DESCRIPTION
### Changes

Replaces _most_(*) uses of `--stratakit-color-border-shadow-base` with `--stratakit-color-border-neutral-base`, which is being updated in #1497. First mentioned in https://github.com/iTwin/stratakit/pull/1707#discussion_r3732162243.

(*)The only complication was the `Switch` component. In dark mode, _thumb_ has a white background, which makes `border-neutral-base` both unnecessary and ugly. Ultimately decided to use [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/light-dark) to conditionally set a different value in dark mode (`white` @ `8%`).

This PR is also a first step towards getting rid of these "faux" borders that are created using `box-shadow`. In the future, these should be replaced with real `border`, similar to #1719.

### Testing

Very hard to notice. In dark mode, there is a tiny difference. In light mode, these tokens are identical. (Both will become much more contrasty after #1497)

[Deploy preview](https://stratakit.bentley.com/1774/mui/)