### PR TITLE
Fix broken link on Badge page

### DIFF
--- a/apps/website/src/content/docs/components/mui/Badge.md
+++ b/apps/website/src/content/docs/components/mui/Badge.md
@@ -75,7 +75,7 @@ Use the `type` prop to adjust the visual prominence of an [`inline`](#inline) **
 
 - Use **Badge** for indicating state or status.
 - Include a concise and descriptive label.
-- Use an `icon` to communicate a status [`color`](#color) in a color-independent fashion.
+- Use an `icon` to communicate a status [`color`](#colors) in a color-independent fashion.
 
 ## 🚫 Don't
 

--- a/apps/website/src/content/docs/components/mui/Badge.md
+++ b/apps/website/src/content/docs/components/mui/Badge.md
@@ -75,7 +75,7 @@ Use the `type` prop to adjust the visual prominence of an [`inline`](#inline) **
 
 - Use **Badge** for indicating state or status.
 - Include a concise and descriptive label.
-- Use an [`icon`](#icons) to communicate a status `color` in a color-independent fashion.
+- Use an `icon` to communicate a status [`color`](#color) in a color-independent fashion.
 
 ## 🚫 Don't
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Icon heading does not exist.   From https://github.com/iTwin/stratakit/pull/1650#discussion_r3798117447

### Testing

Go to https://stratakit.bentley.com/1775/docs/components/badge/#-do and click on the color link.  Make sure it takes you to the color section


