### PR TITLE
Deprecate margin prop

### DIFF
--- a/.changeset/tender-sides-itch.md
+++ b/.changeset/tender-sides-itch.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": minor
 ---
 
-Deprecate `margin` prop from `FilledInput`, `FormControl`, `FormHelperText`, `InputBase`, `InputLabel`, `OutlinedInput` and `TextField`. Use CSS grid, CSS flexbox, `Grid` , or `Stack` to handle spacing between form controls.
+Deprecated `margin` prop from `FilledInput`, `FormControl`, `FormHelperText`, `InputBase`, `InputLabel`, `OutlinedInput` and `TextField`. Use CSS grid, CSS flexbox, `Grid` , or `Stack` to handle spacing between form controls.

--- a/.changeset/tender-sides-itch.md
+++ b/.changeset/tender-sides-itch.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecate `margin` prop from `FilledInput`, `FormControl`, `FormHelperText`, `InputBase`, `InputLabel`, `OutlinedInput` and `TextField`. Use CSS grid, CSS flexbox, `Grid` , or `Stack` to handle spacing between form controls.

--- a/apps/website/src/content/docs/components/mui/TextField.md
+++ b/apps/website/src/content/docs/components/mui/TextField.md
@@ -31,6 +31,7 @@ Modifications specific to `TextField`:
 - The `color` prop is not supported. Color is applied automatically based on state (e.g., disabled, error).
 - The `variant` prop is not supported. Only the `"outlined"` variant is supported.
 - Removed the [floating label](https://mui.com/material-ui/react-text-field/#floating-label) behavior. The label is always displayed above the input.
+- The `margin` prop is not supported. Use CSS grid, CSS flexbox, `Grid` , or `Stack` to handle spacing between form controls.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/TextField.md
+++ b/apps/website/src/content/docs/components/mui/TextField.md
@@ -31,7 +31,7 @@ Modifications specific to `TextField`:
 - The `color` prop is not supported. Color is applied automatically based on state (e.g., disabled, error).
 - The `variant` prop is not supported. Only the `"outlined"` variant is supported.
 - Removed the [floating label](https://mui.com/material-ui/react-text-field/#floating-label) behavior. The label is always displayed above the input.
-- The `margin` prop is not supported. Use CSS grid, CSS flexbox, `Grid` , or `Stack` to handle spacing between form controls.
+- The `margin` prop is not supported. Use CSS grid, CSS flexbox, [`Grid`](https://mui.com/material-ui/react-grid/) , or [`Stack`](https://mui.com/material-ui/react-stack/) to handle spacing between form controls.
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/mui/TextField.md
+++ b/apps/website/src/content/docs/components/mui/TextField.md
@@ -24,6 +24,7 @@ Make sure the **TextField** is suitable for your use case. There may be other, m
 Modifications to `FormControl` (applies to all MUI components that extend `FormControl`):
 
 - The `color`, `focused`, `hiddenLabel` and `variant` props are not supported.
+- The `margin` prop is not supported. Use CSS grid, CSS flexbox, [`Grid`](https://mui.com/material-ui/react-grid/) , or [`Stack`](https://mui.com/material-ui/react-stack/) to handle spacing between form controls.
 
 Modifications specific to `TextField`:
 
@@ -31,7 +32,6 @@ Modifications specific to `TextField`:
 - The `color` prop is not supported. Color is applied automatically based on state (e.g., disabled, error).
 - The `variant` prop is not supported. Only the `"outlined"` variant is supported.
 - Removed the [floating label](https://mui.com/material-ui/react-text-field/#floating-label) behavior. The label is always displayed above the input.
-- The `margin` prop is not supported. Use CSS grid, CSS flexbox, [`Grid`](https://mui.com/material-ui/react-grid/) , or [`Stack`](https://mui.com/material-ui/react-stack/) to handle spacing between form controls.
 
 ## Examples
 

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -777,7 +777,7 @@ declare module "@mui/material/InputBase" {
 		/** @deprecated StrataKit does not support this prop. */
 		color?: InputBaseProps["color"];
 		/** @deprecated StrataKit does not support this prop. */
-		margin?: InputProps["margin"];
+		margin?: InputBaseProps["margin"];
 		/** @deprecated StrataKit does not support this prop. */
 		disableInjectingGlobalStyles?: InputBaseProps["disableInjectingGlobalStyles"];
 	}

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -623,6 +623,8 @@ declare module "@mui/material/FormControl" {
 		/** @deprecated StrataKit does not support this prop. */
 		hiddenLabel?: FormControlProps["hiddenLabel"];
 		/** @deprecated StrataKit does not support this prop. */
+		margin?: FormControlProps["margin"];
+		/** @deprecated StrataKit does not support this prop. */
 		variant?: FormControlProps["variant"];
 	}
 }
@@ -634,6 +636,10 @@ interface FormControlDeprecatedProps {
 	focused?: FormControlProps["focused"];
 	/** @deprecated StrataKit does not support this prop. */
 	hiddenLabel?: FormControlProps["hiddenLabel"];
+	/**
+	 * FormControlDeprecatedProos
+	 *  @deprecated StrataKit does not support this prop. */
+	margin?: FormControlProps["margin"];
 	/** @deprecated StrataKit does not support this prop. */
 	variant?: FormControlProps["variant"];
 }
@@ -644,6 +650,8 @@ declare module "@mui/material/FormHelperText" {
 		filled: false;
 	}
 	interface FormHelperTextOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		margin?: FormHelperTextOwnProps["margin"];
 		/** @deprecated StrataKit does not support this prop. */
 		variant?: FormHelperTextOwnProps["variant"];
 	}
@@ -768,7 +776,8 @@ declare module "@mui/material/InputBase" {
 	interface InputBaseProps {
 		/** @deprecated StrataKit does not support this prop. */
 		color?: InputBaseProps["color"];
-
+		/** @deprecated StrataKit does not support this prop. */
+		margin?: InputProps["margin"];
 		/** @deprecated StrataKit does not support this prop. */
 		disableInjectingGlobalStyles?: InputBaseProps["disableInjectingGlobalStyles"];
 	}
@@ -777,13 +786,16 @@ declare module "@mui/material/InputBase" {
 interface InputBaseDeprecatedProps {
 	/** @deprecated StrataKit does not support this prop. */
 	color?: InputBaseProps["color"];
-
+	/** @deprecated StrataKit does not support this prop. */
+	margin?: InputBaseProps["margin"];
 	/** @deprecated StrataKit does not support this prop. */
 	disableInjectingGlobalStyles?: InputBaseProps["disableInjectingGlobalStyles"];
 }
 
 declare module "@mui/material/InputLabel" {
 	interface InputLabelOwnProps {
+		/** @deprecated StrataKit does not support this prop. */
+		margin?: InputLabelOwnProps["margin"];
 		/** @deprecated StrataKit does not support this prop. */
 		shrink?: InputLabelOwnProps["shrink"];
 		/** @deprecated StrataKit does not support this prop. */

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -636,9 +636,7 @@ interface FormControlDeprecatedProps {
 	focused?: FormControlProps["focused"];
 	/** @deprecated StrataKit does not support this prop. */
 	hiddenLabel?: FormControlProps["hiddenLabel"];
-	/**
-	 * FormControlDeprecatedProos
-	 *  @deprecated StrataKit does not support this prop. */
+	/** @deprecated StrataKit does not support this prop. */
 	margin?: FormControlProps["margin"];
 	/** @deprecated StrataKit does not support this prop. */
 	variant?: FormControlProps["variant"];


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecate `margin` prop from `FilledInput`, `FormControl`, `FormHelperText`, `InputBase`, `InputLabel`, `OutlinedInput` and `TextField`.  See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-17910338

<img width="779" height="410" alt="image" src="https://github.com/user-attachments/assets/18140027-c115-48f2-bc9f-3557d1fe0542" />


### Testing
```tsx
		<>
			<FilledInput margin="dense" />
			<FormControl margin="dense" />
			<FormHelperText margin="dense" />
			<InputBase margin="dense" />
			<InputLabel margin="dense" />
			<OutlinedInput margin="dense" />
			<TextField margin="dense" />
		</>
```