### PR TITLE
`IconButton`'s `title` mapped to `label`

### DIFF
--- a/.changeset/blue-shrimps-mix.md
+++ b/.changeset/blue-shrimps-mix.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-`IconButton`'s `title` prop is now internally mapped to `label` for use within `Tooltip`.
+`IconButton` now treats `title` and `label` as equivalent props. Both set the accessible name and tooltip. Use either prop as they're interchangeable.

--- a/.changeset/blue-shrimps-mix.md
+++ b/.changeset/blue-shrimps-mix.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+`IconButton`'s `title` prop is now internally mapped to `label` for use within `Tooltip`.

--- a/.changeset/blue-shrimps-mix.md
+++ b/.changeset/blue-shrimps-mix.md
@@ -2,4 +2,4 @@
 "@stratakit/mui": patch
 ---
 
-`IconButton` now treats `title` and `label` as equivalent props. Both set the accessible name and tooltip. Use either prop as they're interchangeable.
+`IconButton` now automatically maps the `title` prop to `label` for better compatibility with external components that use the native `title` attribute. The recommended approach is still to use the `label` prop.

--- a/apps/website/src/content/docs/components/mui/IconButton.md
+++ b/apps/website/src/content/docs/components/mui/IconButton.md
@@ -24,6 +24,7 @@ Make sure the **IconButton** is suitable for your use case. There may be other, 
 
 - The `"default"`, `"info"`, `"success"`, `"warning"`, `"inherit"` colors have been removed. The default color is now `"secondary"`.
 - The `size` options (`"small"`, `"medium"`, `"large"`) have all been decreased in height.
+- The `title` is redirected to `label` for use within `Tooltip`.
 - A `label` prop has been added. When specified, it is used as the **IconButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 

--- a/apps/website/src/content/docs/components/mui/IconButton.md
+++ b/apps/website/src/content/docs/components/mui/IconButton.md
@@ -24,8 +24,8 @@ Make sure the **IconButton** is suitable for your use case. There may be other, 
 
 - The `"default"`, `"info"`, `"success"`, `"warning"`, `"inherit"` colors have been removed. The default color is now `"secondary"`.
 - The `size` options (`"small"`, `"medium"`, `"large"`) have all been decreased in height.
-- Both `title` and `label` props set the accessible name and tooltip as they're interchangeable aliases. Use whichever fits your use case.
-- A `label` prop has been added. When specified, it is used as the **IconButton's** accessible name and is also shown in a tooltip on hover and focus.
+- A `label` prop has been added. When specified, it is used as the **IconButton's** accessible name and is also shown in a tooltip on hover and focus. This is the recommended way to set the accessible name and tooltip.
+- The `title` prop is automatically mapped to `label` as a fallback, providing better compatibility with external components that use the native `title` attribute.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 
 ## Examples
@@ -56,3 +56,4 @@ Make sure to provide an accessible description in the form of a visually hidden 
 
 - Don't use to replace buttons.
 - Don't use if an icon doesn't clearly convey the action. Use a [**Button**](/components/button) with a text label or a more suitable icon.
+- Don't set both `title` and `label` at the same time. Use only `label` instead.

--- a/apps/website/src/content/docs/components/mui/IconButton.md
+++ b/apps/website/src/content/docs/components/mui/IconButton.md
@@ -24,7 +24,7 @@ Make sure the **IconButton** is suitable for your use case. There may be other, 
 
 - The `"default"`, `"info"`, `"success"`, `"warning"`, `"inherit"` colors have been removed. The default color is now `"secondary"`.
 - The `size` options (`"small"`, `"medium"`, `"large"`) have all been decreased in height.
-- The `title` is redirected to `label` for use within `Tooltip`.
+- Both `title` and `label` props set the accessible name and tooltip as they're interchangeable aliases. Use whichever fits your use case.
 - A `label` prop has been added. When specified, it is used as the **IconButton's** accessible name and is also shown in a tooltip on hover and focus.
 - A `labelPlacement` prop has been added to control the placement of a tooltip that is shown when the `label` prop is specified.
 

--- a/packages/mui/src/~components/MuiIconButton.tsx
+++ b/packages/mui/src/~components/MuiIconButton.tsx
@@ -18,7 +18,7 @@ interface MuiIconButtonProps
 
 const MuiIconButton = forwardRef<"button", MuiIconButtonProps>(
 	(props, forwardedRef) => {
-		const { label, labelPlacement, ...rest } = props;
+		const { title, label = title, labelPlacement, ...rest } = props;
 
 		if (label) {
 			return (


### PR DESCRIPTION
### Changes

In #1770 I removed `title` from 2 buttons, @mayank99 suggested in https://github.com/iTwin/stratakit/pull/1770#discussion_r3799219312 forwarding it to `label` for use within `Tooltip`.

This appears to effect:
- `Alert`'s close button.
- `DatePicker`'s previous / next month buttons.
- `Autocomplete`'s open button **but not the clear button**.  

### Testing

| Before | After |
| - | - |
| <img width="194" height="100" alt="Screenshot 2026-08-18 at 1 48 46 PM" src="https://github.com/user-attachments/assets/e4d86a1a-8c64-4cd4-8d8c-59926e08de42" /> | <img width="171" height="79" alt="Screenshot 2026-08-18 at 1 49 35 PM" src="https://github.com/user-attachments/assets/52898004-1caf-487f-8b97-2d1ed18ba3e9" /> |

Note that `title` is still present on `Autocomplete`'s clear button.
<img width="201" height="99" alt="Screenshot 2026-08-18 at 1 50 58 PM" src="https://github.com/user-attachments/assets/f916756b-af3b-4c53-ac18-b10d244696f9" />

