### PR TITLE
Deprecate InitColorSchemeScript

### DIFF
--- a/.changeset/red-lemons-hug.md
+++ b/.changeset/red-lemons-hug.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `InitColorSchemeScript`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -23,6 +23,7 @@ import type { FormLabelProps } from "@mui/material/FormLabel";
 import type {} from "@mui/material/Grow";
 import type { IconProps } from "@mui/material/Icon";
 import type { IconButtonProps } from "@mui/material/IconButton";
+import type {} from "@mui/material/InitColorSchemeScript";
 import type { InputProps } from "@mui/material/Input";
 import type { InputBaseProps } from "@mui/material/InputBase";
 import type { ListSubheaderOwnProps as MuiListSubheaderOwnProps } from "@mui/material/ListSubheader";
@@ -526,6 +527,13 @@ declare module "@mui/material/CssBaseline" {
 	/** @deprecated StrataKit does not support this component.  Use `Root` from `@stratakit/mui` instead */
 	export default function CssBaseline(
 		props: CssBaselineProps,
+	): React.JSX.Element;
+}
+
+declare module "@mui/material/InitColorSchemeScript" {
+	/** @deprecated StrataKit does not support this component. */
+	export default function InitColorSchemeScript(
+		props: Record<string, unknown>,
 	): React.JSX.Element;
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Deprecated `InitColorSchemeScript`.  This does not have any StrataKit documentation. See https://github.com/iTwin/stratakit/discussions/1577#discussioncomment-18002666

<img width="582" height="113" alt="image" src="https://github.com/user-attachments/assets/fed7a92c-f5ec-47c1-9dfe-60419d97c6e3" />


### Testing

<!--
How did you test your changes?

Include relevant details such as manual testing, unit tests, accessibility checks, or visual verification.
If testing is not applicable, briefly explain why.
-->
