### PR TITLE
Deprecate Toolbar

### DIFF
--- a/.changeset/plenty-rabbits-hammer.md
+++ b/.changeset/plenty-rabbits-hammer.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Deprecated `Toolbar` to avoid confusion with `Toolbar` from `@stratakit/structures`. This is replaced by a styled `div` in `AppBar`.

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -50,6 +50,7 @@ import type { TabScrollButtonProps } from "@mui/material/TabScrollButton";
 import type { TabsProps } from "@mui/material/Tabs";
 import type { TextFieldProps } from "@mui/material/TextField";
 import type { ToggleButtonProps } from "@mui/material/ToggleButton";
+import type { ToolbarProps } from "@mui/material/Toolbar";
 import type { TooltipProps } from "@mui/material/Tooltip";
 import type {
 	TypographyProps,
@@ -1257,6 +1258,14 @@ declare module "@mui/material/ToggleButton" {
 		 */
 		labelPlacement?: TooltipProps["placement"];
 	}
+}
+
+declare module "@mui/material/Toolbar" {
+	/** @deprecated StrataKit does not support this component. */
+	// @ts-expect-error -- Default exports cannot be augmented, but the `@deprecated` above still takes effect.
+	export default function Toolbar(
+		props: ToolbarProps,
+	): React.JSX.Element | null;
 }
 
 declare module "@mui/material/ToggleButtonGroup" {


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

- Deprecate `Toolbar`  https://github.com/iTwin/stratakit/pull/1782 updates the examples

<img width="634" height="130" alt="image" src="https://github.com/user-attachments/assets/e426d501-e6b5-4f88-b802-5e830295a2a4" />


### Testing
