### PR TITLE
Update AppBar documentation to not use Toolbar

### DIFF
--- a/.changeset/lazy-toys-cross.md
+++ b/.changeset/lazy-toys-cross.md
@@ -1,5 +1,0 @@
----
-"examples": patch
----
-
-Update `AppBar` example to use a styled `div` instead of `Toolbar`.

--- a/.changeset/lazy-toys-cross.md
+++ b/.changeset/lazy-toys-cross.md
@@ -1,0 +1,5 @@
+---
+"examples": patch
+---
+
+Update `AppBar` example to use a styled `div` instead of `Toolbar`.

--- a/apps/website/src/content/docs/components/mui/AppBar.md
+++ b/apps/website/src/content/docs/components/mui/AppBar.md
@@ -7,3 +7,7 @@ links:
 ---
 
 ::example{src="mui/AppBar.default" min-width="450px"}
+
+## StrataKit MUI modifications
+
+- Use a styled `div` instead of MUI's `Toolbar` to avoid confusion with the [`Toolbar` from `@stratakit/structures`](https://stratakit.bentley.com/docs/components/toolbar/).

--- a/apps/website/src/content/docs/components/mui/AppBar.md
+++ b/apps/website/src/content/docs/components/mui/AppBar.md
@@ -10,4 +10,4 @@ links:
 
 ## StrataKit MUI modifications
 
-- Use a styled `div` instead of MUI's `Toolbar` to avoid confusion with the [`Toolbar` from `@stratakit/structures`](https://stratakit.bentley.com/docs/components/toolbar/).
+- The use of MUI's `Toolbar` has been replaced with a styled `<div>` to avoid confusion with the [StrataKit `Toolbar`](/components/toolbar/).

--- a/examples/mui/AppBar.default.module.css
+++ b/examples/mui/AppBar.default.module.css
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** Duplicates the behavior of MUI's Toolbar component */
+.flexContainer {
+	position: relative;
+	display: flex;
+	align-items: center;
+	padding-inline: var(--stratakit-space-x4);
+	min-height: 56px;
+
+	@media (orientation: landscape) {
+		min-height: 48px;
+	}
+
+	@media (min-width: 600px) {
+		min-height: 64px;
+	}
+}

--- a/examples/mui/AppBar.default.module.css
+++ b/examples/mui/AppBar.default.module.css
@@ -2,8 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/** Duplicates the behavior of MUI's Toolbar component */
-.flexContainer {
+.appBarContent {
 	position: relative;
 	display: flex;
 	align-items: center;

--- a/examples/mui/AppBar.default.tsx
+++ b/examples/mui/AppBar.default.tsx
@@ -15,7 +15,7 @@ import styles from "./AppBar.default.module.css";
 export default () => {
 	return (
 		<AppBar position="static">
-			<div className={styles.flexContainer}>
+			<div className={styles.appBarContent}>
 				<IconButton size="large" edge="start" aria-label="menu">
 					<Icon href={`${svgMenu}#icon-large`} size="large" />
 				</IconButton>

--- a/examples/mui/AppBar.default.tsx
+++ b/examples/mui/AppBar.default.tsx
@@ -6,16 +6,16 @@
 import AppBar from "@mui/material/AppBar";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
-import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import { Icon } from "@stratakit/mui";
 
 import svgMenu from "@stratakit/icons/menu.svg";
+import styles from "./AppBar.default.module.css";
 
 export default () => {
 	return (
 		<AppBar position="static">
-			<Toolbar>
+			<div className={styles.flexContainer}>
 				<IconButton size="large" edge="start" aria-label="menu">
 					<Icon href={`${svgMenu}#icon-large`} size="large" />
 				</IconButton>
@@ -23,7 +23,7 @@ export default () => {
 					News
 				</Typography>
 				<Button variant="text">Login</Button>
-			</Toolbar>
+			</div>
 		</AppBar>
 	);
 };


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Prepare for deprecation of `Toolbar` in https://github.com/iTwin/stratakit/pull/1780

### Testing

Compare [AppBar on main](https://stratakit.bentley.com/docs/examples/mui/AppBar.default/) to [AppBar on this branch](https://stratakit.bentley.com/1782/docs/examples/mui/AppBar.default/)

Check at < 600px width with landscape aspect ratio: height =48px
Check at < 600px with portrait aspect ratio: height = 56px
Check at >600px: height = 64px
