### PR TITLE
use `position: fixed` in `Tooltip`

### DIFF
--- a/.changeset/fancy-boxes-start.md
+++ b/.changeset/fancy-boxes-start.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated `Tooltip` to use `fixed` positioning strategy.

--- a/packages/mui/src/~createTheme.tsx
+++ b/packages/mui/src/~createTheme.tsx
@@ -663,6 +663,7 @@ function createTheme(args: CreateThemeArgs) {
 						},
 						popper: {
 							component: MuiTooltipPopper,
+							popperOptions: { strategy: "fixed" },
 							modifiers: [
 								{
 									name: "offset",


### PR DESCRIPTION
_Fixes #1778_

### Changes

This PR changes the [positioning strategy](https://github.com/floating-ui/popper.js.org/blob/master/src/pages/docs/v2/constructors.mdx#strategy) of `Tooltip`'s underlying popper from `absolute` to `fixed`.

After #1665, the `Tooltip` is rendered in the [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer), which completely changes how [containing blocks](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Display/Containing_block) work. When in top layer, elements that have `position: absolute` will always be positioned relative to the _initial_ containing block ([per CSS spec](https://www.w3.org/TR/css-position-4/#top-layer:~:text=If%20its%20position%20property%20computes%20to%20fixed%2C%20its%20containing%20block%20is%20the%20viewport%3B%20otherwise%2C%20it%E2%80%99s%20the%20initial%20containing%20block)). The problem is that the underlying popper is not aware that `Tooltip` is rendered in top layer, so its calculations continue to look for the normal [absolute positioning containing block](https://www.w3.org/TR/css-position-3/#def-cb).

Using `position: fixed` avoids this problem because it will always be positioned relative to the viewport. The calculations remain the same, regardless of whether it's in top layer.

**Note:** There could still be cases where popper could incorrectly calculate the coordinates if there is an intermediate [fixed positioning containing block](https://www.w3.org/TR/css-position-3/#fixed-cb) created in between the `<body>` and the Tooltip element. Worth keeping this in mind with the portaling changes in #1762.

### Testing

Observed that the Tooltip is now using `position: fixed`.

<img width="268" height="99" alt="screenshot of devtools" src="https://github.com/user-attachments/assets/4e11d149-2975-40ee-b8b8-abbd98426079" />

Confirmed that using `fixed` strategy _fixed_ the issue in the minimal reproduction from #1778.