### PR TITLE
Prepare `@stratakit/internal-utils` for publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"privatePackages": { "version": true, "tag": false }
+	"privatePackages": false
 }

--- a/packages/internal-utils/CHANGELOG.md
+++ b/packages/internal-utils/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Changelog
+
+## 0.1.0
+
+Initial release 🥳

--- a/packages/internal-utils/package.json
+++ b/packages/internal-utils/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@stratakit/internal-utils",
-	"private": true,
 	"type": "module",
 	"version": "0.1.0",
 	"license": "MIT",


### PR DESCRIPTION
### Changes

- Removed `"private": true,` which will result in this package being published as soon as this PR merges to `main`.
- Updated `CHANGELOG.md`
- Removed temporary `privatePackages` workaround https://github.com/iTwin/stratakit/pull/1565#discussion_r3631769125

### Testing

N/A
