### PR TITLE
change default `caption-side`

### DIFF
--- a/.changeset/fast-socks-roll.md
+++ b/.changeset/fast-socks-roll.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Changed default `caption-side` for `Table`.

--- a/apps/website/src/content/docs/components/mui/Table.md
+++ b/apps/website/src/content/docs/components/mui/Table.md
@@ -14,6 +14,7 @@ links:
 - Enabled `TableRow`'s [`hover`](https://mui.com/material-ui/api/table-row/#table-row-prop-hover) prop by default, except when used inside `TableHead`.
 - Deprecated `hideSortIcon` and `IconComponent` property of `TableSortLabel`. The icon is not customizable.
 - Deprecated `size` prop of `TableCell`
+- The default `caption-side` is `top`.
 
 ## Examples
 

--- a/examples/mui/Table.footer.module.css
+++ b/examples/mui/Table.footer.module.css
@@ -6,7 +6,3 @@
 .table {
 	min-inline-size: 650px;
 }
-
-.caption {
-	caption-side: top;
-}

--- a/examples/mui/Table.footer.tsx
+++ b/examples/mui/Table.footer.tsx
@@ -40,7 +40,7 @@ export default () => {
 	return (
 		<TableContainer render={<Paper />}>
 			<Table className={styles.table}>
-				<caption className={styles.caption}>Dessert nutrition</caption>
+				<caption>Dessert nutrition</caption>
 				<TableHead>
 					<TableRow>
 						<TableCell>Dessert (100g serving)</TableCell>

--- a/packages/mui/src/~components/MuiTable.css
+++ b/packages/mui/src/~components/MuiTable.css
@@ -8,6 +8,8 @@
 	padding-block-end: var(--stratakit-space-x4);
 	padding-inline-start: var(--stratakit-space-x4);
 	padding-inline-end: var(--stratakit-space-x3);
+
+	caption-side: top;
 }
 
 .MuiTableRow-root {


### PR DESCRIPTION
### Changes

This PR changes the [`caption-side`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/caption-side) for `<caption>` elements inside `Table`. (For some reason, MUI was setting this to `bottom`. The browser default is **`top`**, which is now explicitly set by this PR.)

This could be considered a breaking layout change, so ideally should go into 1.0.

### Testing

Verify all Table examples look correct.

[Deploy preview](https://stratakit.bentley.com/1793/docs/components/table/)