### PR TITLE
replace remaining usage of `faded` tokens

### DIFF
--- a/.changeset/wicked-deer-decide.md
+++ b/.changeset/wicked-deer-decide.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated border color for `Badge`.

--- a/apps/test-app/app/tokens.module.css
+++ b/apps/test-app/app/tokens.module.css
@@ -35,19 +35,19 @@
 	background-image:
 		repeating-linear-gradient(
 			45deg,
-			var(--stratakit-color-bg-neutral-base) 25%,
+			var(--stratakit-color-bg-mono-base) 25%,
 			transparent 25%,
 			transparent 75%,
-			var(--stratakit-color-bg-neutral-base) 75%,
-			var(--stratakit-color-bg-neutral-base)
+			var(--stratakit-color-bg-mono-base) 75%,
+			var(--stratakit-color-bg-mono-base)
 		),
 		repeating-linear-gradient(
 			45deg,
-			var(--stratakit-color-bg-neutral-base) 25%,
-			var(--stratakit-color-bg-neutral-faded) 25%,
-			var(--stratakit-color-bg-neutral-faded) 75%,
-			var(--stratakit-color-bg-neutral-base) 75%,
-			var(--stratakit-color-bg-neutral-base)
+			var(--stratakit-color-bg-mono-base) 25%,
+			var(--stratakit-color-bg-mono-muted) 25%,
+			var(--stratakit-color-bg-mono-muted) 75%,
+			var(--stratakit-color-bg-mono-base) 75%,
+			var(--stratakit-color-bg-mono-base)
 		);
 	forced-color-adjust: none;
 

--- a/apps/website/src/styles/overrides.css
+++ b/apps/website/src/styles/overrides.css
@@ -241,7 +241,7 @@ aside.starlight-aside {
 		border-inline-end: 1px solid var(--stratakit-color-border-neutral-base);
 
 		&::after {
-			border-block-start-color: var(--stratakit-color-border-neutral-faded);
+			border-block-start-color: var(--stratakit-color-border-neutral-inverse);
 		}
 	}
 }
@@ -273,7 +273,7 @@ starlight-menu-button button {
 
 .sl-heading-wrapper:has(:target) {
 	:target {
-		outline: 2px solid var(--stratakit-color-border-neutral-faded);
+		outline: 2px solid var(--stratakit-color-border-neutral-inverse);
 		outline-offset: 4px;
 	}
 

--- a/packages/mui/src/~components/MuiAccordion.css
+++ b/packages/mui/src/~components/MuiAccordion.css
@@ -85,7 +85,7 @@
 	@media (any-hover: hover) {
 		&:where(:hover:not(.Mui-disabled)) {
 			background-color: var(--stratakit-color-bg-glow-on-surface-neutral-hover);
-			--_MuiAccordion-expand-icon-color: var(--stratakit-color-icon-neutral-hover);
+			--_MuiAccordion-expand-icon-color: var(--stratakit-color-icon-neutral-primary);
 		}
 	}
 

--- a/packages/mui/src/~components/MuiBadge.css
+++ b/packages/mui/src/~components/MuiBadge.css
@@ -111,7 +111,7 @@
 
 		&:where(.MuiBadge-colorSecondary) {
 			--_MuiBadge-color: var(--stratakit-color-text-mono-base);
-			--_MuiBadge-border-color: var(--stratakit-color-border-neutral-faded);
+			--_MuiBadge-border-color: var(--stratakit-color-border-mono-base);
 		}
 
 		&:where(.MuiBadge-colorSuccess) {


### PR DESCRIPTION
### Changes

This PR replaces all instances of `-faded` tokens that were remaining after #1759 and #1773.

Extracted out of #1758, where these tokens are being removed.

### Testing

Confirm visuals in affected areas.

`Badge` is the only affected _component_ in the library.

Spot the difference:
| Before | After |
| --- | --- |
| <img width="174" height="78" alt="image" src="https://github.com/user-attachments/assets/3d1ba04d-b575-4829-b629-253599f9bdb4" /> | <img width="170" height="79" alt="image" src="https://github.com/user-attachments/assets/0a3f3bd5-05e8-4b7f-8d33-25a1318479c4" /> |