### PR TITLE
replace `text-glow` and `icon-glow` tokens

### DIFF
--- a/.changeset/empty-shirts-smash.md
+++ b/.changeset/empty-shirts-smash.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/bricks": patch
+---
+
+Updated colors for `Button` and `Anchor`.

--- a/packages/bricks/src/Anchor.css
+++ b/packages/bricks/src/Anchor.css
@@ -5,16 +5,6 @@
 .🥝Anchor {
 	--✨color--default: var(--stratakit-color-text-neutral-primary);
 	--✨color--accent: var(--stratakit-color-text-accent-strong);
-	--✨color--accent-hover: color-mix(
-		in oklch,
-		var(--✨color--accent) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-text-glow-strong-hover-\%)
-	);
-	--✨color--accent-pressed: color-mix(
-		in oklch,
-		var(--✨color--accent) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-text-glow-strong-pressed-\%)
-	);
 	--✨color--disabled: var(--stratakit-color-text-neutral-disabled);
 
 	@layer base {
@@ -42,9 +32,7 @@
 
 	@layer modifiers {
 		&:where([data-_sk-tone="accent"]) {
-			--🥝Anchor-color: var(--🌀Anchor-state--default, var(--✨color--accent))
-				var(--🌀Anchor-state--hover, var(--✨color--accent-hover))
-				var(--🌀Anchor-state--pressed, var(--✨color--accent-pressed));
+			--🥝Anchor-color: var(--✨color--accent);
 			-webkit-tap-highlight-color: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 		}
 	}

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -86,29 +86,8 @@
 	--✨bg--outline-accent-pressed: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 	--✨bg--outline-accent-disabled: transparent;
 
-	--✨color--outline-accent-default: var(--stratakit-color-text-accent-strong);
-	--✨color--outline-accent-hover: color-mix(
-		in oklch,
-		var(--✨color--outline-accent-default) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-text-glow-strong-hover-\%)
-	);
-	--✨color--outline-accent-pressed: color-mix(
-		in oklch,
-		var(--✨color--outline-accent-default) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-text-glow-strong-pressed-\%)
-	);
-
-	--✨icon--outline-accent-default: var(--stratakit-color-icon-accent-strong);
-	--✨icon--outline-accent-hover: color-mix(
-		in oklch,
-		var(--✨icon--outline-accent-default) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-icon-glow-strong-hover-\%)
-	);
-	--✨icon--outline-accent-pressed: color-mix(
-		in oklch,
-		var(--✨icon--outline-accent-default) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-icon-glow-strong-pressed-\%)
-	);
+	--✨color--outline-accent: var(--stratakit-color-text-accent-strong);
+	--✨icon--outline-accent: var(--stratakit-color-icon-accent-strong);
 
 	--✨border--outline-accent-default: var(--stratakit-color-border-accent-base);
 	--✨border--outline-accent-hover: color-mix(
@@ -135,28 +114,8 @@
 	--✨bg--ghost-accent-pressed: var(--stratakit-color-bg-glow-on-surface-accent-pressed);
 	--✨bg--ghost-accent-disabled: transparent;
 
-	--✨color--ghost-accent-default: var(--stratakit-color-text-accent-strong);
-	--✨color--ghost-accent-hover: color-mix(
-		in oklch,
-		var(--✨color--ghost-accent-default) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-text-glow-strong-hover-\%)
-	);
-	--✨color--ghost-accent-pressed: color-mix(
-		in oklch,
-		var(--✨color--ghost-accent-default) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-text-glow-strong-pressed-\%)
-	);
-	--✨icon--ghost-accent-default: var(--stratakit-color-icon-accent-strong);
-	--✨icon--ghost-accent-hover: color-mix(
-		in oklch,
-		var(--✨icon--ghost-accent-default) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-icon-glow-strong-hover-\%)
-	);
-	--✨icon--ghost-accent-pressed: color-mix(
-		in oklch,
-		var(--✨icon--ghost-accent-default) 100%,
-		var(--stratakit-color-glow-hue) var(--stratakit-color-icon-glow-strong-pressed-\%)
-	);
+	--✨color--ghost-accent: var(--stratakit-color-text-accent-strong);
+	--✨icon--ghost-accent: var(--stratakit-color-icon-accent-strong);
 	/* #endregion */
 
 	@layer base {
@@ -267,12 +226,8 @@
 					var(--🌀Button-state--pressed, var(--✨border--outline-accent-pressed))
 					var(--🌀Button-state--active, var(--✨border--active))
 					var(--🌀Button-state--disabled, var(--✨border--outline-accent-disabled));
-				--🥝Button-color: var(--🌀Button-state--default, var(--✨color--outline-accent-default))
-					var(--🌀Button-state--hover, var(--✨color--outline-accent-hover))
-					var(--🌀Button-state--pressed, var(--✨color--outline-accent-pressed));
-				--🥝Icon-color: var(--🌀Button-state--default, var(--✨icon--outline-accent-default))
-					var(--🌀Button-state--hover, var(--✨icon--outline-accent-hover))
-					var(--🌀Button-state--pressed, var(--✨icon--outline-accent-pressed));
+				--🥝Button-color: var(--✨color--outline-accent);
+				--🥝Icon-color: var(--✨icon--outline-accent);
 			}
 		}
 
@@ -299,12 +254,8 @@
 					var(--🌀Button-state--pressed, var(--✨bg--ghost-accent-pressed))
 					var(--🌀Button-state--active, var(--✨bg--active))
 					var(--🌀Button-state--disabled, var(--✨bg--ghost-accent-disabled));
-				--🥝Button-color: var(--🌀Button-state--default, var(--✨color--ghost-accent-default))
-					var(--🌀Button-state--hover, var(--✨color--ghost-accent-hover))
-					var(--🌀Button-state--pressed, var(--✨color--ghost-accent-pressed));
-				--🥝Icon-color: var(--🌀Button-state--default, var(--✨icon--ghost-accent-default))
-					var(--🌀Button-state--hover, var(--✨icon--ghost-accent-hover))
-					var(--🌀Button-state--pressed, var(--✨icon--ghost-accent-pressed));
+				--🥝Button-color: var(--✨color--ghost-accent);
+				--🥝Icon-color: var(--✨icon--ghost-accent);
 			}
 		}
 	}


### PR DESCRIPTION
### Changes

This replaces all instances of `text-glow-*` and `icon-glow-*` tokens, which are being removed in #1758.

They were only used for hover/pressed states in `Button` and `Anchor`. 

### Testing

See [deploy preview](https://stratakit.bentley.com/1795/tests/anchor?visual).

Not changing the text/icon color during hover/pressed states makes almost zero perceptible difference.