### PR TITLE
chore: bump nanoid to 3.3.18 in lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4729,10 +4729,10 @@ packages:
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
       }
 
-  nanoid@3.3.16:
+  nanoid@3.3.18:
     resolution:
       {
-        integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==,
+        integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -8865,7 +8865,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   neotraverse@0.6.18: {}
 
@@ -9008,7 +9008,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
### Changes
`nanoid` resolves to 3.3.16, via `postcss@8.5.25`.
We update the lockfile so that postcss uses 3.3.18 which removes GHSA-2v37-7h3g-55p8.

### Testing

Checks run:

- ✅ `corepack pnpm install --frozen-lockfile`
- ✅ `corepack pnpm exec biome ci --error-on-warnings .`
- ✅ `corepack pnpm lint:copyright`
- ✅ `corepack pnpm prettier`
- ✅ `corepack pnpm --filter=@stratakit/test-app run typecheck`
- ✅ `WIREIT_LOGGER=metrics corepack pnpm --filter="./apps/**" build`
- ✅ `corepack pnpm --filter=internal test`
- ✅ `corepack pnpm why -r nanoid` (now resolves `nanoid@3.3.18`)
- ⚠️ `corepack pnpm audit --json` still reports unrelated existing advisories (`esbuild`, `sharp`, `astro`), but no longer reports nanoid `GHSA-2v37-7h3g-55p8`
