### PR TITLE
Enter pre-release mode

### DIFF
--- a/.changeset/cute-papers-jump.md
+++ b/.changeset/cute-papers-jump.md
@@ -1,0 +1,6 @@
+---
+"@stratakit/foundations": major
+"@stratakit/mui": major
+---
+
+**Placeholder to force 1.0 release** - edit the changelog to remove this and move all of the _Minor changes_ up to the _Major changes_ section.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,16 @@
+{
+	"mode": "pre",
+	"tag": "rc",
+	"initialVersions": {
+		"@stratakit/website": "0.0.1",
+		"examples": "0.0.1",
+		"internal": "0.0.1",
+		"@stratakit/bricks": "0.5.6",
+		"@stratakit/foundations": "0.5.0",
+		"@stratakit/icons": "0.4.3",
+		"@stratakit/internal-utils": "0.1.0",
+		"@stratakit/mui": "0.5.4",
+		"@stratakit/structures": "0.5.10"
+	},
+	"changesets": []
+}


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Enter [pre-release mode](https://changesets.dev/guide/prereleases) to prepare to make a `1.0.0-rc.0` release.


Because we haven't marked any of our existing changesets as major releases, it would default to making a `0.5.6-rc.0` version next.  I  added a new dummy changeset with a major change to get to version as `1.0.0-rc.0` for `foundations` and `mui`

### Testing

2. `pnpm version`
3. Verify the version in `packages/mui/package.json` is `1.0.0-rc.0` and `packages/foudations/package.json` is `1.0.0-rc.0`.  All other packages should be bumped by a minor version and also include the `-rc.0` suffix
4. Run `pnpm changeset pre exit`
5. Run `pnpm changeset version`
6. Verify that the packages no longer have the `-rc.0` suffix