### PR TITLE
Update `react` and `react-dom` version range

### DIFF
--- a/.changeset/strict-bags-begin.md
+++ b/.changeset/strict-bags-begin.md
@@ -1,0 +1,9 @@
+---
+"@stratakit/internal-utils": minor
+"@stratakit/foundations": minor
+"@stratakit/structures": minor
+"@stratakit/bricks": minor
+"@stratakit/mui": minor
+---
+
+Updated the supported version of `react` and `react-dom` to `^19.0.0`. Short term the packages will continue to work with `^18.0.0`, but it is recommended to upgrade to React v19 to ensure future compatibility.

--- a/packages/bricks/package.json
+++ b/packages/bricks/package.json
@@ -199,8 +199,8 @@
 	},
 	"peerDependencies": {
 		"@stratakit/foundations": "^0.5.0",
-		"react": ">=18.0.0",
-		"react-dom": ">=18.0.0"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"wireit": {
 		"build": {

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -68,8 +68,8 @@
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {
-		"react": ">=18.0.0",
-		"react-dom": ">=18.0.0"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"peerDependenciesMeta": {
 		"react": {

--- a/packages/internal-utils/package.json
+++ b/packages/internal-utils/package.json
@@ -67,8 +67,8 @@
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {
-		"react": ">=18.0.0",
-		"react-dom": ">=18.0.0"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"wireit": {
 		"build": {

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -70,8 +70,8 @@
 	"peerDependencies": {
 		"@mui/material": "^9.0.0",
 		"@stratakit/foundations": "^0.5.0",
-		"react": ">=18.0.0",
-		"react-dom": ">=18.0.0"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"wireit": {
 		"build": {

--- a/packages/structures/package.json
+++ b/packages/structures/package.json
@@ -141,8 +141,8 @@
 	},
 	"peerDependencies": {
 		"@stratakit/foundations": "^0.5.0",
-		"react": ">=18.0.0",
-		"react-dom": ">=18.0.0"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"wireit": {
 		"build": {


### PR DESCRIPTION
### Changes

[React v19](https://react.dev/blog/2024/12/05/react-19) was released almost 2 years ago.

This PR narrows-down the `react` and `react-dom` version range from both ends:

- Dropped support for v18
- Dropped support for (currently unreleased) v20 and newer

There are no code changes - this means that StrataKit packages will continue to work with React v18 in the short term.
Consumers should start migration to React v19 to ensure future compatibility.

### Testing

N/A
