### PR TITLE
replace `border-shadow-strong`

### DIFF
--- a/.changeset/brown-squids-learn.md
+++ b/.changeset/brown-squids-learn.md
@@ -1,0 +1,6 @@
+---
+"@stratakit/bricks": patch
+"@stratakit/mui": patch
+---
+
+Updated borders for `Button` and `Checkbox`.

--- a/packages/bricks/src/Button.css
+++ b/packages/bricks/src/Button.css
@@ -49,7 +49,7 @@
 	);
 	--✨border--solid-neutral-disabled: transparent;
 
-	--✨border--solid-accent-default: var(--stratakit-color-border-shadow-strong);
+	--✨border--solid-accent-default: var(--stratakit-color-border-glow-strong-default);
 	--✨border--solid-accent-hover: color-mix(
 		in oklch,
 		var(--✨border--solid-accent-default) 100%,

--- a/packages/bricks/src/Checkbox.css
+++ b/packages/bricks/src/Checkbox.css
@@ -27,7 +27,7 @@
 		var(--✨border--default) 100%,
 		var(--stratakit-color-glow-hue) var(--stratakit-color-border-glow-base-hover-\%)
 	);
-	--✨border--checked: var(--stratakit-color-border-shadow-strong);
+	--✨border--checked: var(--stratakit-color-border-glow-strong-default);
 	--✨border--checked-hover: color-mix(
 		in oklch,
 		var(--✨border--checked) 100%,

--- a/packages/mui/src/~components/MuiCheckbox.css
+++ b/packages/mui/src/~components/MuiCheckbox.css
@@ -14,7 +14,7 @@
 	--✨bg--disabled: var(--stratakit-color-bg-glow-on-surface-disabled);
 
 	--✨border--default: var(--stratakit-color-border-neutral-base);
-	--✨border--checked: var(--stratakit-color-border-shadow-strong);
+	--✨border--checked: var(--stratakit-color-border-glow-strong-default);
 	--✨border--error: var(--stratakit-color-border-critical-base);
 	--✨border--disabled: var(--stratakit-color-border-glow-on-surface-disabled);
 


### PR DESCRIPTION
### Changes

Replaces all instances of `--stratakit-color-border-shadow-strong` with `--stratakit-color-border-glow-strong-default`, which has the exact same value.

Similar to #1774.

In a future PR, both `border-shadow-*` tokens will be removed.

### Testing

Confirmed visuals look ok.