### PR TITLE
Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,6 +40,19 @@ body:
         Fork [this StackBlitz template](https://stackblitz.com/github/iTwin/stratakit/tree/main/internal/minimal-template?file=src%2FApp.tsx) and reproduce the issue.
     validations:
       required: true
+  - type: dropdown
+    attributes:
+      label: Affected package
+      description: Which package is affected by this bug?
+      multiple: true
+      options:
+        - "@stratakit/bricks"
+        - "@stratakit/foundations"
+        - "@stratakit/icons"
+        - "@stratakit/mui"
+        - "@stratakit/structures"
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Environment and versions

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
   - type: textarea
     attributes:
       label: Steps to reproduce
-      description: Detailed steps to reproduce the behavior
+      description: Detailed steps to reproduce the behavior.
       placeholder: |
         1. …
         2. …
@@ -29,7 +29,7 @@ body:
   - type: textarea
     attributes:
       label: Expected behavior
-      description: A clear description of what you expected to happen
+      description: A clear description of what you expected to happen.
     validations:
       required: true
   - type: input
@@ -47,10 +47,10 @@ body:
         Please provide version information and environment details.
         This helps us reproduce the issue.
       placeholder: |
-        - @stratakit/mui 0.2.1
+        - @stratakit/mui 1.0.0
         - @mui/material 9.0.0
-        - react 19.2.0
-        - Browsers: Chrome 147, Safari 26.2
+        - react 18.0.0
+        - Browsers: Chrome 154, Safari 27
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,7 @@
 contact_links:
   - name: Questions 🤔
     url: https://github.com/iTwin/stratakit/discussions/categories/q-a
-    about: Ask questions and get help from contributors through GitHub Discussions.
+    about: Ask questions and get help from contributors
+  - name: Examples 👀
+    url: https://github.com/iTwin/stratakit/discussions/categories/examples
+    about: Request or share a self-contained example for building something using existing StrataKit features


### PR DESCRIPTION
### Changes

- Refine issue templates.
- Add [**Examples 👀**](https://github.com/iTwin/stratakit/discussions/categories/examples). Was removed from iTwinUI in https://github.com/iTwin/iTwinUI/pull/2698.