### PR TITLE
Add local SVG documentation

### DIFF
--- a/apps/website/src/content/docs/components/stratakit/Icon.md
+++ b/apps/website/src/content/docs/components/stratakit/Icon.md
@@ -43,9 +43,17 @@ By default, the **Icon** component inherits the ancestor's color. Use the [`colo
 
 ::example{src="mui/Icon.color"}
 
-### Custom
+### Custom SVG
 
 The `href` prop can point to any valid `<symbol>` or `<svg>` that has an `id`. This is the recommended way to use custom icons.
+
+::example{src="mui/Icon.localSvg"}
+
+:::note
+If your SVG file is missing an `id`, it is recommended to set `id="icon"` on the root `<svg>` element in the file. The `Icon` component will append a `#icon` hash to any `href` that is missing a hash.
+:::
+
+### Inline SVG
 
 Alternatively, the `render` prop can be used to display an inlined SVG, as in the example below. This can be useful when you need to target the individual elements inside the SVG (e.g. for styling or animation purposes).
 

--- a/apps/website/src/content/docs/components/stratakit/Icon.md
+++ b/apps/website/src/content/docs/components/stratakit/Icon.md
@@ -43,7 +43,7 @@ By default, the **Icon** component inherits the ancestor's color. Use the [`colo
 
 ::example{src="mui/Icon.color"}
 
-### Custom SVG
+### Custom
 
 The `href` prop can point to any valid `<symbol>` or `<svg>` that has an `id`. This is the recommended way to use custom icons.
 
@@ -53,9 +53,9 @@ The `href` prop can point to any valid `<symbol>` or `<svg>` that has an `id`. T
 If your SVG file is missing an `id`, it is recommended to set `id="icon"` on the root `<svg>` element in the file. The `Icon` component will append a `#icon` hash to any `href` that is missing a hash.
 :::
 
-### Inline SVG
+### Inline
 
-Alternatively, the `render` prop can be used to display an inlined SVG, as in the example below. This can be useful when you need to target the individual elements inside the SVG (e.g. for styling or animation purposes).
+The `render` prop can be used to display an inlined SVG, as in the example below. This can be useful when you need to target the individual elements inside the SVG (e.g. for styling or animation purposes).
 
 ::example{src="mui/Icon.custom"}
 

--- a/examples/mui/Icon.localSvg.svg
+++ b/examples/mui/Icon.localSvg.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" id="icon">
+  <circle 
+    cx="8"
+    cy="8"
+    r="7"
+    fill="currentColor"
+  />
+</svg>

--- a/examples/mui/Icon.localSvg.tsx
+++ b/examples/mui/Icon.localSvg.tsx
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Icon } from "@stratakit/mui";
+
+import localSvg from "./Icon.localSvg.svg";
+
+export default () => {
+	return <Icon href={localSvg} alt="Filled Circle" />;
+};


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Adds guidance on using a local SVG.

### Testing

Review [preview documentation](https://stratakit.bentley.com/1829/docs/components/icon/#custom-svg)
