### PR TITLE
Fix issue with @mixin css not getting transformed in build.

### DIFF
--- a/apps/test-app/vite.config.ts
+++ b/apps/test-app/vite.config.ts
@@ -95,17 +95,10 @@ export default defineConfig({
 
 /** Vite plugin that bundles "*.css?inline" files using lightningcss. Only used during dev. */
 function bundleCssPlugin() {
-	let isDev = false;
-
 	return {
 		name: "bundle-css",
 
-		configResolved({ command }) {
-			isDev = command === "serve";
-		},
-
 		async transform(_, id) {
-			if (!isDev) return;
 			if (!id.endsWith(".css?inline")) return;
 
 			const filename = id.replace(/\?inline$/, "");


### PR DESCRIPTION
### Changes

Remove some conditional code for running CSS transforms that was letting `@mixin` slip through to the built output.  Now the code should always run.  Found this issue when the CSS minifier changed in https://github.com/iTwin/stratakit/pull/1814 and started complaining about: `Unknown at rule: @apply`

**`command` is not reliable**

During `pnpm build` resolveConfig gets called multiple times with both `build` and `serve` to support sever side rendering.

<img width="409" height="357" alt="image" src="https://github.com/user-attachments/assets/04f1fd17-96c4-4d7b-9ee7-08b650970d58" />


**unbuilt sources from other packages are injested**

Tried removing `@stratakit/source` custom condition from both `apps/test-app/vite.config.ts` and `apps/test-app/tsconfig.json` but  `@mixin` was still present .  Not sure where this was slipping in. 


### Testing

1. Checkout main  
1. Run `pnpm  --filter @stratakit/test-app build`
1. Search for `@mixin` in the `apps/test-apps` folder (be sure to turn off ignore excludes).  You should see a result in the build folder Both in config and in an index-{hash}.js file. <img width="1683" height="820" alt="image" src="https://github.com/user-attachments/assets/699ec0a0-7a37-4ffe-a499-25885bd3fa80" />
1. Checkout this branch
1. Run `pnpm  --filter @stratakit/test-app build`
1. Re-run the search.  Verify that there is no `@mixin`  in the index-{hash}.js file.
