### PR TITLE
Add `Accordion` `size` prop

### DIFF
--- a/.changeset/great-plums-count.md
+++ b/.changeset/great-plums-count.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": minor
+---
+
+Added `size` prop to `Accordion`.

--- a/apps/test-app/app/mui/Accordion.showcase.tsx
+++ b/apps/test-app/app/mui/Accordion.showcase.tsx
@@ -11,6 +11,7 @@ import AccordionExpanded from "examples/mui/Accordion.expanded.tsx";
 import AccordionMarkerPlacement from "examples/mui/Accordion.marker-placement.tsx";
 import AccordionMultiple from "examples/mui/Accordion.multiple.tsx";
 import AccordionResponsive from "examples/mui/Accordion.responsive.tsx";
+import AccordionSizes from "examples/mui/Accordion.sizes.tsx";
 import AccordionVariants from "examples/mui/Accordion.variants.tsx";
 import { createKnob, isProduction } from "~/~utils.tsx";
 
@@ -36,6 +37,7 @@ export default function AccordionExamples() {
 			<AccordionMultiple />
 			{!isProduction && <AccordionMultipleOutlined_ />}
 			<AccordionVariants />
+			<AccordionSizes />
 		</Stack>
 	);
 }

--- a/apps/website/src/content/docs/components/mui/Accordion.md
+++ b/apps/website/src/content/docs/components/mui/Accordion.md
@@ -29,6 +29,7 @@ Make sure the **Accordion** is suitable for your use case. There may be other, m
 
 - Restyled using StrataKit's visual language.
 - The overall size has been decreased.
+- Added [`size`](#sizes) prop.
 - Added [responsive design](#responsive-design) that reorients the marker placement based on container width.
 - Added [`markerPlacement`](#marker-placement) prop to `AccordionSummary` to override responsive design.
 - Added details indentation when the `markerPlacement` is set to `"start"`.
@@ -58,6 +59,13 @@ Disclose any **Accordion's** content by default using the `defaultExpanded` prop
 | ------------- | --------- | -------- |
 | Settings page | ❌        | ✅       |
 | Widget        | ✅        | ❌       |
+
+### Sizes
+
+- **Small:** Use in compact interfaces where space is limited.
+- **Medium:** Default size, suitable for most use cases.
+
+::example{src="mui/Accordion.sizes"}
 
 ### Responsive design
 

--- a/examples/mui/Accordion.sizes.tsx
+++ b/examples/mui/Accordion.sizes.tsx
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+
+export default () => {
+	return (
+		<Accordion size="small">
+			<AccordionSummary>
+				<code>small</code> size
+			</AccordionSummary>
+			<AccordionDetails>
+				A more compact accordion for dense layouts.
+			</AccordionDetails>
+		</Accordion>
+	);
+};

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -93,6 +93,13 @@ declare module "@mui/material/Accordion" {
 	interface AccordionHeadingSlotPropsOverrides extends TypographyProps {}
 
 	interface AccordionOwnProps {
+		/**
+		 * The size of the accordion.
+		 *
+		 * @default 'medium'
+		 */
+		size?: "small" | "medium";
+
 		/** @deprecated StrataKit does not support this prop. */
 		disableGutters?: boolean | undefined;
 	}

--- a/packages/mui/src/~components/MuiAccordion.css
+++ b/packages/mui/src/~components/MuiAccordion.css
@@ -19,6 +19,11 @@
 	border-end-end-radius: var(--_MuiAccordion-border-radius-bottom);
 	overflow-anchor: none; /* Prevent scroll jump with exclusive accordions */
 
+	&:where([data-_sk-size="small"]) {
+		--_MuiAccordion-padding: var(--stratakit-space-200);
+		--_MuiAccordion-column-gap: var(--stratakit-space-200);
+	}
+
 	@container (inline-size < 500px) {
 		&:where(:has(.MuiAccordionSummary-root:not([data-_sk-marker-placement="start"]))) {
 			--_MuiAccordion-details-indent: var(--_MuiAccordion-padding);
@@ -70,6 +75,10 @@
 	padding-inline-start: var(--_MuiAccordion-padding);
 	padding-inline-end: var(--_MuiAccordion-padding);
 
+	:where(.MuiAccordion-root[data-_sk-size="small"]) & {
+		min-block-size: var(--stratakit-size-control-listitem-height-small);
+	}
+
 	:where(.MuiAccordion-root.MuiPaper-elevation) & {
 		--🥝focus-outline-offset: -2px;
 	}
@@ -102,6 +111,10 @@
 	font-weight: 500;
 	margin-block-start: var(--stratakit-space-100);
 	margin-block-end: var(--stratakit-space-100);
+
+	:where(.MuiAccordion-root[data-_sk-size="small"]) & {
+		@apply --typography("body-sm");
+	}
 }
 
 .MuiAccordionSummary-expandIconWrapper {

--- a/packages/mui/src/~components/MuiAccordion.tsx
+++ b/packages/mui/src/~components/MuiAccordion.tsx
@@ -20,12 +20,13 @@ interface MuiAccordionRootSlotProps extends BaseProps {
 
 const MuiAccordionRootSlot = forwardRef<"div", MuiAccordionRootSlotProps>(
 	(props, forwardedRef) => {
-		const { square, variant } = props.ownerState || {};
+		const { size = "medium", square, variant } = props.ownerState || {};
 
 		return (
 			<Paper
 				{...props}
 				square={square ?? variant !== "outlined"} // Disable rounded corners on non-outlined variants
+				data-_sk-size={size !== "medium" ? size : undefined}
 				ref={forwardedRef}
 			/>
 		);


### PR DESCRIPTION
### Changes

Added `size` prop to `Accordion` which accepts `"medium"` (default) & `"small"`.  This was the only MUI component that was missing a `size` option to meet iTwinUI parity.

[**Deploy preview**](https://stratakit.bentley.com/1852/mui/#accordion) 👀
[**Documentation**](https://stratakit.bentley.com/1852/docs/components/accordion/#sizes) 📚

### Testing

_Coming soon…_