### PR TITLE
update `Card` spacing

### DIFF
--- a/.changeset/tough-poets-return.md
+++ b/.changeset/tough-poets-return.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Updated spacing for `Card`.

--- a/examples/mui/Card.default.tsx
+++ b/examples/mui/Card.default.tsx
@@ -34,7 +34,7 @@ export default () => {
 				}
 			/>
 			<CardContent>
-				<Typography>
+				<Typography gutterBottom>
 					Stadium is a place for outdoor sports, concerts, or other events and
 					activities.
 				</Typography>

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -55,7 +55,6 @@
 .MuiCardContent-root {
 	color: var(--stratakit-color-text-neutral-secondary);
 	padding: var(--stratakit-space-400);
-	padding-block-end: var(--stratakit-space-500);
 
 	&:where(:has(+ .MuiCardActions-root)) {
 		padding-block-end: 0;

--- a/packages/mui/src/~components/MuiCard.css
+++ b/packages/mui/src/~components/MuiCard.css
@@ -28,6 +28,8 @@
 }
 
 .MuiCardHeader-root {
+	padding: var(--stratakit-space-400);
+
 	&:where(:has(+ .MuiCardContent-root, + .MuiCardActions-root)) {
 		padding-block-end: 0;
 	}
@@ -52,6 +54,8 @@
 
 .MuiCardContent-root {
 	color: var(--stratakit-color-text-neutral-secondary);
+	padding: var(--stratakit-space-400);
+	padding-block-end: var(--stratakit-space-500);
 
 	&:where(:has(+ .MuiCardActions-root)) {
 		padding-block-end: 0;


### PR DESCRIPTION
### Changes

This updates the `Card` to use custom `padding` values instead of the default MUI values. The main difference is that the bottom padding is reduced (previously it was using a large 24px value, which was oddly noticeable when using the `Card` in #1853).

The `gutterBottom` prop of `Typography` can be used to prevent it from getting too close to the bottom edge of the `Card`.

### Testing

| Before | After |
| --- | --- |
| <img width="327" height="248" alt="image" src="https://github.com/user-attachments/assets/22161143-0711-4a91-9d08-1ddfebdf0f7c" /> | <img width="328" height="244" alt="image" src="https://github.com/user-attachments/assets/640c2cc1-756e-4f5b-8bbe-5a6d9bf63080" /> |