### PR TITLE
fix `Drawer` borders

### DIFF
--- a/.changeset/crisp-places-crash.md
+++ b/.changeset/crisp-places-crash.md
@@ -1,0 +1,5 @@
+---
+"@stratakit/mui": patch
+---
+
+Fixed redundant borders in `Drawer`.

--- a/packages/mui/src/~components/MuiDrawer.css
+++ b/packages/mui/src/~components/MuiDrawer.css
@@ -10,3 +10,23 @@
 :is(html, body):where(:has(.MuiDrawer-root:not(.MuiModal-root.MuiModal-hidden))) {
 	overflow: clip;
 }
+
+.MuiDrawer-paper {
+	border: none;
+
+	:where(.MuiDrawer-root.MuiDrawer-anchorLeft) & {
+		border-inline-end: 1px solid var(--stratakit-color-border-page-base);
+	}
+
+	:where(.MuiDrawer-root.MuiDrawer-anchorRight) & {
+		border-inline-start: 1px solid var(--stratakit-color-border-page-base);
+	}
+
+	:where(.MuiDrawer-root.MuiDrawer-anchorTop) & {
+		border-block-end: 1px solid var(--stratakit-color-border-page-base);
+	}
+
+	:where(.MuiDrawer-root.MuiDrawer-anchorBottom) & {
+		border-block-start: 1px solid var(--stratakit-color-border-page-base);
+	}
+}

--- a/packages/mui/src/~forced-colors.css
+++ b/packages/mui/src/~forced-colors.css
@@ -114,24 +114,6 @@
 	--_MuiCircularProgress-color: CanvasText;
 }
 
-.MuiDrawer-paper {
-	:where(.MuiDrawer-anchorTop) > & {
-		border-block-end: 1px solid;
-	}
-
-	:where(.MuiDrawer-anchorRight) > & {
-		border-inline-start: 1px solid;
-	}
-
-	:where(.MuiDrawer-anchorBottom) > & {
-		border-block-start: 1px solid;
-	}
-
-	:where(.MuiDrawer-anchorLeft) > & {
-		border-inline-end: 1px solid;
-	}
-}
-
 .MuiFormControlLabel-label:where(.Mui-disabled) {
 	color: GrayText;
 }


### PR DESCRIPTION
### Changes

This updates `Drawer` to remove the redundant borders that touch the viewport edges. (Caused by #1785)

### Testing

| Before | After |
| --- | --- |
| <img width="255" height="293" alt="image" src="https://github.com/user-attachments/assets/3eb71773-4ecb-4ce5-bd88-7e92ed0d95bc" /> | <img width="283" height="288" alt="image" src="https://github.com/user-attachments/assets/75810f75-d57c-445a-b37d-b1498812c137" /> |