### PR TITLE
Fix bug with icon button losing focus when label is added

### DIFF
--- a/packages/mui/src/~components/MuiIconButton.tsx
+++ b/packages/mui/src/~components/MuiIconButton.tsx
@@ -20,15 +20,15 @@ const MuiIconButton = forwardRef<"button", MuiIconButtonProps>(
 	(props, forwardedRef) => {
 		const { title, label = title, labelPlacement, ...rest } = props;
 
-		if (label) {
-			return (
-				<Tooltip title={label} describeChild={false} placement={labelPlacement}>
-					<MuiButtonBase {...rest} ref={forwardedRef} />
-				</Tooltip>
-			);
-		}
-
-		return <MuiButtonBase {...rest} ref={forwardedRef} />;
+		return (
+			<Tooltip
+				title={label ?? ""}
+				describeChild={false}
+				placement={labelPlacement}
+			>
+				<MuiButtonBase {...rest} ref={forwardedRef} />
+			</Tooltip>
+		);
 	},
 );
 DEV: MuiIconButton.displayName = "MuiIconButton";


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Prevent `IconButton` from re-creating `MuiButtonBase` element and losing focus if the title changes.  This can happen when an `IconButton` is wrapped in a `Tooltip`  (for example by a 3rd party component that is wrapping an `IconButton` it a `ToolTip`).

Found this while working on https://github.com/iTwin/stratakit/pull/1851. 


### Cause

Consider
```tsx
<ToolTip>
  <IconButton />
</ToolTip>

```
When `describeChild` is `true` (which is the [default  from createTheme](https://github.com/iTwin/stratakit/blob/24311a1abefce47970c8eec20c8610b654dee610/packages/mui/src/~createTheme.tsx#L674))  the `title` passed the the child varies between a string and null. See [Tooltip implementation](https://github.com/mui/material-ui/blob/809a7717b4c050ba3f69b75300689f07c050a16e/packages/mui-material/src/Tooltip/Tooltip.js#L518-L519).

This means the `title` prop getting passed to `IconButton` will vary depending on if the parent tooltip is open.  Each time it changes from `null` to a string, it ends up recreating the actual HTML button element (since it has a different parent) and that recreation (instead of an update) causes the button to lose focus.

### Testing

Run this code as one of the examples on `main`. 

1. Tab to the button
2. Press `Enter`
    - Note that there is no click logged.  This is because the button was recreated and lost focus.
 
Check out this branch and repeat the test.
Note that it should now log a click.

<details>
<summary>Test Code</summary>


```tsx
import React from "react";
import { Tooltip } from "@mui/material";
import Container from "@mui/material/Container";
import IconButton from "@mui/material/IconButton";
import { Icon } from "@stratakit/mui";

import svgPlaceholder from "@stratakit/icons/placeholder.svg";

export default function App() {
	const [log, setLog] = React.useState<string[]>([]);
	const click = (event: any) => {
		setLog((log) => [...log, "Clicked"]);
	};

	return (
		<Container maxWidth="md" sx={{ padding: 4 }}>
			<Tooltip title="Test">
				<IconButton id="iconButton" onClick={click}>
					<Icon href={svgPlaceholder} id="icon" />
				</IconButton>
			</Tooltip>
			<div>
				{log.map((value, i) => (
					// biome-ignore lint/suspicious/noArrayIndexKey: debugging
					<p key={i}>{value}</p>
				))}
			</div>
		</Container>
	);
}

```
</details>