### PR TITLE
Add <IconButton  variant="outlined"/>

### DIFF
--- a/apps/test-app/app/mui/IconButton.showcase.tsx
+++ b/apps/test-app/app/mui/IconButton.showcase.tsx
@@ -7,6 +7,7 @@ import IconButtonColors_ from "examples/mui/IconButton._colors.tsx";
 import IconButtonPlacements_ from "examples/mui/IconButton._placements.tsx";
 import IconButtonDefault from "examples/mui/IconButton.default.tsx";
 import IconButtonSizes from "examples/mui/IconButton.sizes.tsx";
+import IconButtonVariants from "examples/mui/IconButton.variants.tsx";
 import { createKnob, isProduction } from "~/~utils.tsx";
 
 export default function IconButtonExamples() {
@@ -14,6 +15,7 @@ export default function IconButtonExamples() {
 		<>
 			<IconButtonDefault />
 			<IconButtonSizes />
+			<IconButtonVariants />
 			{!isProduction && (
 				<Stack spacing={2} direction="row" sx={{ flexWrap: "wrap" }}>
 					<IconButtonColors_ />

--- a/apps/website/src/content/docs/components/mui/IconButton.md
+++ b/apps/website/src/content/docs/components/mui/IconButton.md
@@ -49,6 +49,13 @@ Make sure to provide an accessible description in the form of a visually hidden 
 
 ::example{src="mui/IconButton.sizes"}
 
+### Variant
+
+- **Ghost:** Default variant, suitable for most cases.
+- **Outlined:** Adds a border for greater emphasis. Use when a standalone icon button needs more visual weight to clearly convey that it's interactive.
+
+::example{src="mui/IconButton.variants"}
+
 ## ✅ Do
 
 - Use the `label` prop to provide an accessible name and tooltip for the **IconButton**.

--- a/examples/mui/IconButton.variants.tsx
+++ b/examples/mui/IconButton.variants.tsx
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import { Icon } from "@stratakit/mui";
+
+import svgPlaceholder from "@stratakit/icons/placeholder.svg";
+
+export default () => {
+	return (
+		<Stack
+			spacing={2}
+			direction="row"
+			sx={{ alignItems: "center", flexWrap: "wrap" }}
+		>
+			<IconButton variant="ghost" label="Ghost">
+				<Icon href={svgPlaceholder} />
+			</IconButton>
+
+			<IconButton variant="outlined" label="Outlined">
+				<Icon href={svgPlaceholder} />
+			</IconButton>
+		</Stack>
+	);
+};

--- a/packages/mui/src/types.ts
+++ b/packages/mui/src/types.ts
@@ -759,6 +759,13 @@ declare module "@mui/material/IconButton" {
 		 * @default 'top'
 		 */
 		labelPlacement?: TooltipProps["placement"];
+
+		/**
+		 * The variant to use.
+		 *
+		 * @default 'ghost'
+		 */
+		variant?: "ghost" | "outlined";
 	}
 }
 

--- a/packages/mui/src/~components/MuiIconButton.css
+++ b/packages/mui/src/~components/MuiIconButton.css
@@ -5,12 +5,19 @@
 
 .MuiIconButton-root {
 	--_MuiIconButton-icon-color: var(--stratakit-color-icon-neutral-base);
+	--_MuiIconButton-border-color: transparent;
 
 	border-radius: var(--stratakit-radius-sm);
 	color: var(--_MuiIconButton-icon-color);
 	min-block-size: var(--_MuiIconButton-size);
 	min-inline-size: var(--_MuiIconButton-size);
 	padding: var(--_MuiIconButton-padding);
+
+	&:where([data-_sk-iconbutton-variant="outlined"]) {
+		--_MuiIconButton-border-color: var(--stratakit-color-border-neutral-base);
+		border: 1px solid;
+		border-color: var(--_MuiIconButton-border-color);
+	}
 
 	&:where(.MuiIconButton-edgeStart) {
 		margin-inline-start: calc(var(--_MuiIconButton-margin-negative) * -1);
@@ -23,6 +30,11 @@
 	@media (any-hover: hover) {
 		&:where(:hover) {
 			--_MuiIconButton-icon-color: var(--stratakit-color-icon-neutral-primary);
+			--_MuiIconButton-border-color: red;
+
+			&:where([data-_sk-iconbutton-variant="outlined"]) {
+				background: none;
+			}
 		}
 	}
 
@@ -54,5 +66,6 @@
 
 	&:where(.Mui-disabled) {
 		--_MuiIconButton-icon-color: var(--stratakit-color-icon-neutral-disabled);
+		--_MuiIconButton-border-color: var(--stratakit-color-border-neutral-disabled);
 	}
 }

--- a/packages/mui/src/~components/MuiIconButton.css
+++ b/packages/mui/src/~components/MuiIconButton.css
@@ -5,7 +5,7 @@
 
 .MuiIconButton-root {
 	--_MuiIconButton-icon-color: var(--stratakit-color-icon-neutral-base);
-	--_MuiIconButton-border-color: transparent;
+	--_MuiIconButton-outlined-border-color: var(--stratakit-color-border-neutral-base);
 
 	border-radius: var(--stratakit-radius-sm);
 	color: var(--_MuiIconButton-icon-color);
@@ -14,9 +14,8 @@
 	padding: var(--_MuiIconButton-padding);
 
 	&:where([data-_sk-iconbutton-variant="outlined"]) {
-		--_MuiIconButton-border-color: var(--stratakit-color-border-neutral-base);
 		border: 1px solid;
-		border-color: var(--_MuiIconButton-border-color);
+		border-color: var(--_MuiIconButton-outlined-border-color);
 	}
 
 	&:where(.MuiIconButton-edgeStart) {
@@ -30,7 +29,11 @@
 	@media (any-hover: hover) {
 		&:where(:hover) {
 			--_MuiIconButton-icon-color: var(--stratakit-color-icon-neutral-primary);
-			--_MuiIconButton-border-color: red;
+			--_MuiIconButton-outlined-border-color: color-mix(
+				in oklch,
+				var(--stratakit-color-border-neutral-base) 100%,
+				var(--stratakit-color-glow-hue) var(--stratakit-color-border-glow-base-hover-\%)
+			);
 
 			&:where([data-_sk-iconbutton-variant="outlined"]) {
 				background: none;
@@ -64,8 +67,16 @@
 		--_MuiIconButton-icon-color: var(--stratakit-color-icon-critical-base);
 	}
 
+	&:where(:active) {
+		--_MuiIconButton-outlined-border-color: color-mix(
+			in oklch,
+			var(--stratakit-color-border-neutral-base) 100%,
+			var(--stratakit-color-glow-hue) var(--stratakit-color-border-glow-pressed-hover-\%)
+		);
+	}
+
 	&:where(.Mui-disabled) {
 		--_MuiIconButton-icon-color: var(--stratakit-color-icon-neutral-disabled);
-		--_MuiIconButton-border-color: var(--stratakit-color-border-neutral-disabled);
+		--_MuiIconButton-outlined-border-color: var(--stratakit-color-border-neutral-disabled);
 	}
 }

--- a/packages/mui/src/~components/MuiIconButton.tsx
+++ b/packages/mui/src/~components/MuiIconButton.tsx
@@ -14,16 +14,26 @@ import type { BaseProps } from "@stratakit/internal-utils/props";
 
 interface MuiIconButtonProps
 	extends BaseProps<"button">,
-		Pick<IconButtonOwnProps, "label" | "labelPlacement"> {}
+		Pick<IconButtonOwnProps, "label" | "labelPlacement" | "variant"> {}
 
 const MuiIconButton = forwardRef<"button", MuiIconButtonProps>(
 	(props, forwardedRef) => {
-		const { title, label = title, labelPlacement, ...rest } = props;
+		const {
+			title,
+			label = title,
+			labelPlacement,
+			variant = "ghost",
+			...rest
+		} = props;
 
 		if (label) {
 			return (
 				<Tooltip title={label} describeChild={false} placement={labelPlacement}>
-					<MuiButtonBase {...rest} ref={forwardedRef} />
+					<MuiButtonBase
+						{...rest}
+						data-_sk-IconButton-variant={variant}
+						ref={forwardedRef}
+					/>
 				</Tooltip>
 			);
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to StrataKit.

Before submitting, please review our contributing guidelines:
https://github.com/iTwin/stratakit/blob/main/CONTRIBUTING.md#pull-requests

If you are only making changes to the documentation site using the "Edit page" link, you can ignore most of this template.
-->

### Changes

Add `<IconButton  variant="outlined"/>`.  Fixes https://github.com/iTwin/stratakit/discussions/1809.

In forced colors the `icon` variant is also outlined and the `outlined` variant matches that.


|  | Light| Dark | Forced| 
| --- | ---|  --- | ---|
| normal | <img width="47" height="46" alt="image" src="https://github.com/user-attachments/assets/535dd37c-74c8-4f30-8a30-e7ce6ed8d4cb" />| <img width="44" height="44" alt="image" src="https://github.com/user-attachments/assets/90d0ca7a-0d89-4ba3-b372-aed02fa36b1e" /> | <img width="42" height="42" alt="image" src="https://github.com/user-attachments/assets/464e0572-9836-4e35-9c69-336dc8e73078" />
| hover | <img width="56" height="41" alt="image" src="https://github.com/user-attachments/assets/3abf5dd1-42d7-4d5f-b11a-70b166bf9745" /> | <img width="47" height="43" alt="image" src="https://github.com/user-attachments/assets/05d1c47e-9146-404f-976d-38afda8e1d67" />| <img width="49" height="46" alt="image" src="https://github.com/user-attachments/assets/bfb628c4-f8f4-4197-8a6e-2b5b604178e7" />
| disabled | <img width="51" height="47" alt="image" src="https://github.com/user-attachments/assets/99f54a14-cd0b-49ab-aa8d-6733ae8f97c2" /> | <img width="52" height="46" alt="image" src="https://github.com/user-attachments/assets/be12029e-bcdd-4e02-9be2-64faaf6a2974" />| <img width="54" height="49" alt="image" src="https://github.com/user-attachments/assets/055c4ac5-957d-41ce-8bc7-78a25eac5cfa" />
| active | <img width="43" height="36" alt="image" src="https://github.com/user-attachments/assets/f36a7fbc-08ae-4ea2-8296-116dfe742def" /> |  <img width="49" height="50" alt="image" src="https://github.com/user-attachments/assets/2a0caae2-2a97-4487-bbf0-f89630369d6e" />|  <img width="49" height="43" alt="image" src="https://github.com/user-attachments/assets/6bef49e0-6ca4-49d3-92d4-1df20a971246" />
| focused | <img width="51" height="41" alt="image" src="https://github.com/user-attachments/assets/928a8d46-a690-4369-8747-c98885927ffd" /> | <img width="57" height="51" alt="image" src="https://github.com/user-attachments/assets/3195accf-3517-4205-9ce7-9de3c42a7e0e" /> | <img width="53" height="49" alt="image" src="https://github.com/user-attachments/assets/4206f3f6-be14-4ee4-a2ae-dcd438e5a9b1" />




### Testing

[Deploy preview](https://stratakit.bentley.com/1861/docs/components/iconbutton/#variant)
